### PR TITLE
Enhanced Remote SSH Support (e.g. tailscale)

### DIFF
--- a/Packages/HerdrKit/Package.swift
+++ b/Packages/HerdrKit/Package.swift
@@ -8,7 +8,10 @@ let package = Package(
         .library(name: "HerdrKit", targets: ["HerdrKit"])
     ],
     targets: [
-        .target(name: "HerdrKit"),
+        .target(
+            name: "HerdrKit",
+            linkerSettings: [.linkedFramework("Security")]
+        ),
         .testTarget(name: "HerdrKitTests", dependencies: ["HerdrKit"])
     ]
 )

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -187,9 +187,12 @@ public actor HerdrService {
         args: [String] = [],
         waitForShell: Bool = false
     ) async throws {
-        let pinnedTerminalID = waitForShell ? try await paneTerminalID(paneID) : nil
+        var pinnedTerminalID: String?
+        if waitForShell {
+            pinnedTerminalID = try? await paneTerminalID(paneID)
+        }
         let clock = ContinuousClock()
-        let retryDeadline = clock.now.advanced(by: .seconds(2))
+        let retryDeadline = clock.now.advanced(by: Self.paneShellReadinessTimeout)
 
         while true {
             do {
@@ -204,17 +207,31 @@ public actor HerdrService {
                 )
                 return
             } catch let error as HerdrError {
+                // Probe failures must not replace the server's original error.
                 guard waitForShell,
-                      case .rpc(let code, _) = error,
-                      code == "agent_pane_busy",
+                      Self.isPaneBusy(error),
                       clock.now < retryDeadline,
                       let pinnedTerminalID,
-                      try await paneTerminalID(paneID) == pinnedTerminalID,
-                      try await paneShellIsInitializing(paneID)
+                      await paneShellStillInitializing(paneID, pinnedTerminalID: pinnedTerminalID)
                 else { throw error }
                 try await Task.sleep(for: .milliseconds(100))
             }
         }
+    }
+
+    static let paneShellReadinessTimeout: Duration = .seconds(2)
+
+    static func isPaneBusy(_ error: HerdrError) -> Bool {
+        guard case .rpc(let code, _) = error else { return false }
+        return code == "agent_pane_busy"
+    }
+
+    private func paneShellStillInitializing(_ paneID: String, pinnedTerminalID: String) async -> Bool {
+        guard let terminalID = try? await paneTerminalID(paneID),
+              terminalID == pinnedTerminalID,
+              let initializing = try? await paneShellIsInitializing(paneID)
+        else { return false }
+        return initializing
     }
 
     private func paneTerminalID(_ paneID: String) async throws -> String? {
@@ -327,27 +344,33 @@ public actor HerdrService {
     // MARK: - Terminal attach
 
     /// The command the embedded terminal should spawn to attach to a pane.
-    public nonisolated func attachCommand(
-        paneID: String
-    ) -> (executable: String, args: [String], environment: [String: String], authorizationID: UUID?) {
+    public nonisolated func attachCommand(paneID: String) -> AttachCommand {
         switch device.kind {
         case .local:
             // GUI apps launched from Finder don't inherit a login-shell PATH.
             let local = "\(SSHTunnel.remotePathExport); exec herdr agent attach '\(paneID)' --takeover"
-            return ("/bin/sh", ["-c", local], [:], nil)
+            return AttachCommand(executable: "/bin/sh", args: ["-c", local], environment: [:], authorizationID: nil)
         case .ssh(let target):
             let remote = "\(SSHTunnel.remotePathExport); exec herdr agent attach '\(paneID)' --takeover"
             let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
-            return (
-                "/usr/bin/ssh",
-                ["-tt"] + authentication.arguments + [
+            return AttachCommand(
+                executable: "/usr/bin/ssh",
+                args: ["-tt"] + authentication.arguments + [
                     "-o", "StrictHostKeyChecking=accept-new",
                     "-o", "ConnectTimeout=10",
                     target, remote,
                 ],
-                authentication.environment,
-                authentication.authorizationID
+                environment: authentication.environment,
+                authorizationID: authentication.authorizationID
             )
         }
     }
+}
+
+public struct AttachCommand: Sendable {
+    public let executable: String
+    public let args: [String]
+    public let environment: [String: String]
+    /// Single-use askpass grant; the caller must discard it once the process exits.
+    public let authorizationID: UUID?
 }

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -11,7 +11,7 @@ public actor HerdrService {
     public init(device: Device) {
         self.device = device
         if let target = device.sshTarget {
-            self.tunnel = SSHTunnel(target: target)
+            self.tunnel = SSHTunnel(target: target, credentialID: device.id)
         }
     }
 
@@ -102,7 +102,12 @@ public actor HerdrService {
         case .local:
             output = try await Self.runLocalShell(script)
         case .ssh(let target):
-            output = try await SSHTunnel.runSSH(target: target, command: script, timeout: 15)
+            output = try await SSHTunnel.runSSH(
+                target: target,
+                command: script,
+                timeout: 15,
+                credentialID: device.id
+            )
         }
         let found = Set(output.split(separator: "\n").map(String.init))
         return kinds.filter { found.contains(Self.binaryName(for: $0)) }
@@ -175,16 +180,90 @@ public actor HerdrService {
         return paneID
     }
 
-    public func startAgent(name: String, kind: String, paneID: String, args: [String] = []) async throws {
-        _ = try await client().request(
-            method: "agent.start",
-            params: .object([
-                "name": .string(name),
-                "kind": .string(kind),
-                "pane_id": .string(paneID),
-                "args": .array(args.map { .string($0) }),
-            ])
+    public func startAgent(
+        name: String,
+        kind: String,
+        paneID: String,
+        args: [String] = [],
+        waitForShell: Bool = false
+    ) async throws {
+        let pinnedTerminalID = waitForShell ? try await paneTerminalID(paneID) : nil
+        let clock = ContinuousClock()
+        let retryDeadline = clock.now.advanced(by: .seconds(2))
+
+        while true {
+            do {
+                _ = try await client().request(
+                    method: "agent.start",
+                    params: .object([
+                        "name": .string(name),
+                        "kind": .string(kind),
+                        "pane_id": .string(paneID),
+                        "args": .array(args.map { .string($0) }),
+                    ])
+                )
+                return
+            } catch let error as HerdrError {
+                guard waitForShell,
+                      case .rpc(let code, _) = error,
+                      code == "agent_pane_busy",
+                      clock.now < retryDeadline,
+                      let pinnedTerminalID,
+                      try await paneTerminalID(paneID) == pinnedTerminalID,
+                      try await paneShellIsInitializing(paneID)
+                else { throw error }
+                try await Task.sleep(for: .milliseconds(100))
+            }
+        }
+    }
+
+    private func paneTerminalID(_ paneID: String) async throws -> String? {
+        let result = try await client().request(
+            method: "pane.get",
+            params: .object(["pane_id": .string(paneID)])
         )
+        return result["pane"]?["terminal_id"]?.stringValue
+    }
+
+    private func paneShellIsInitializing(_ paneID: String) async throws -> Bool {
+        let result = try await client().request(
+            method: "pane.process_info",
+            params: .object(["pane_id": .string(paneID)])
+        )
+        guard let processInfo = result["process_info"] else { return false }
+        return Self.processInfoShowsShellInitialization(processInfo)
+    }
+
+    static func processInfoShowsShellInitialization(_ processInfo: JSONValue) -> Bool {
+        guard let shellPID = integer(processInfo["shell_pid"]),
+              integer(processInfo["foreground_process_group_id"]) == shellPID
+        else { return false }
+        return processInfo["foreground_processes"]?.arrayValue?.contains { process in
+            guard integer(process["pid"]) == shellPID else { return false }
+            let name = process["name"]?.stringValue
+            let argv0 = process["argv"]?.arrayValue?.first?.stringValue
+            return name.map(isPaneShellProcessName) == true
+                || argv0.map(isPaneShellProcessName) == true
+        } == true
+    }
+
+    private static func integer(_ value: JSONValue?) -> UInt64? {
+        guard case .number(let number)? = value else { return nil }
+        return UInt64(exactly: number)
+    }
+
+    private static func isPaneShellProcessName(_ value: String) -> Bool {
+        var name = value
+            .split(whereSeparator: { $0 == "/" || $0 == "\\" })
+            .last
+            .map(String.init) ?? value
+        while name.hasPrefix("-") { name.removeFirst() }
+        name = name.lowercased()
+        if name.hasSuffix(".exe") { name.removeLast(4) }
+        return [
+            "sh", "bash", "dash", "zsh", "fish", "ksh", "mksh", "csh", "tcsh",
+            "elvish", "xonsh", "nu", "pwsh", "powershell", "cmd",
+        ].contains(name)
     }
 
     /// Reads the pane's visible screen with ANSI intact. Returns nil text when unchanged
@@ -248,20 +327,27 @@ public actor HerdrService {
     // MARK: - Terminal attach
 
     /// The command the embedded terminal should spawn to attach to a pane.
-    public nonisolated func attachCommand(paneID: String) -> (executable: String, args: [String]) {
+    public nonisolated func attachCommand(
+        paneID: String
+    ) -> (executable: String, args: [String], environment: [String: String], authorizationID: UUID?) {
         switch device.kind {
         case .local:
             // GUI apps launched from Finder don't inherit a login-shell PATH.
             let local = "\(SSHTunnel.remotePathExport); exec herdr agent attach '\(paneID)' --takeover"
-            return ("/bin/sh", ["-c", local])
+            return ("/bin/sh", ["-c", local], [:], nil)
         case .ssh(let target):
             let remote = "\(SSHTunnel.remotePathExport); exec herdr agent attach '\(paneID)' --takeover"
-            return ("/usr/bin/ssh", [
-                "-tt",
-                "-o", "BatchMode=yes",
-                "-o", "StrictHostKeyChecking=accept-new",
-                target, remote,
-            ])
+            let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
+            return (
+                "/usr/bin/ssh",
+                ["-tt"] + authentication.arguments + [
+                    "-o", "StrictHostKeyChecking=accept-new",
+                    "-o", "ConnectTimeout=10",
+                    target, remote,
+                ],
+                authentication.environment,
+                authentication.authorizationID
+            )
         }
     }
 }

--- a/Packages/HerdrKit/Sources/HerdrKit/SSHCredentialStore.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SSHCredentialStore.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Security
+
+public enum SSHCredentialStore {
+    public static let askPassModeEnvironmentKey = "HERDRM_SSH_ASKPASS"
+    public static let authorizationIDEnvironmentKey = "HERDRM_SSH_AUTHORIZATION_ID"
+    public static let persistenceDescription = "Saved in your macOS login Keychain"
+
+    private static let passwordService = "dev.bybee.herdrm.ssh-password"
+    private static let authorizationService = "dev.bybee.herdrm.ssh-authorization"
+
+    public static func password(for deviceID: UUID) throws -> String? {
+        if let password = try keychainPassword(for: deviceID) {
+            try? removeLegacyLocalData(directory: "passwords", id: deviceID)
+            return password
+        }
+
+        // Migrate credentials written by the short-lived Debug file-store implementation.
+        guard let legacyData = try legacyLocalData(directory: "passwords", id: deviceID) else {
+            return nil
+        }
+        let password = try decodePassword(legacyData)
+        try setKeychainPassword(password, for: deviceID)
+        try removeLegacyLocalData(directory: "passwords", id: deviceID)
+        return password
+    }
+
+    public static func hasPassword(for deviceID: UUID) -> Bool {
+        (try? password(for: deviceID)) != nil
+    }
+
+    public static func setPassword(_ password: String, for deviceID: UUID) throws {
+        guard !password.isEmpty else {
+            try removePassword(for: deviceID)
+            return
+        }
+
+        try setKeychainPassword(password, for: deviceID)
+    }
+
+    public static func removePassword(for deviceID: UUID) throws {
+        try removeKeychainPassword(for: deviceID)
+        try? removeLegacyLocalData(directory: "passwords", id: deviceID)
+    }
+
+    static func createAuthorization(for deviceID: UUID) throws -> UUID? {
+        guard try password(for: deviceID) != nil else { return nil }
+        let authorizationID = UUID()
+        var item = keychainQuery(service: authorizationService, account: authorizationID.uuidString)
+        item[kSecValueData as String] = Data(deviceID.uuidString.utf8)
+        item[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
+        let status = SecItemAdd(item as CFDictionary, nil)
+        guard status == errSecSuccess else { throw SSHCredentialStoreError(status: status) }
+        return authorizationID
+    }
+
+    public static func consumePassword(authorizationID: UUID) throws -> String? {
+        guard let authorization = try keychainData(
+            service: authorizationService,
+            account: authorizationID.uuidString
+        ) else { return nil }
+        defer { try? removeAuthorization(authorizationID) }
+        guard let rawDeviceID = String(data: authorization, encoding: .utf8),
+              let deviceID = UUID(uuidString: rawDeviceID)
+        else { throw SSHCredentialStoreError(status: errSecDecode) }
+        return try password(for: deviceID)
+    }
+
+    public static func removeAuthorization(_ authorizationID: UUID) throws {
+        let status = SecItemDelete(
+            keychainQuery(service: authorizationService, account: authorizationID.uuidString) as CFDictionary
+        )
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw SSHCredentialStoreError(status: status)
+        }
+        try? removeLegacyLocalData(directory: "authorizations", id: authorizationID)
+    }
+
+    private static func decodePassword(_ data: Data) throws -> String {
+        guard let password = String(data: data, encoding: .utf8) else {
+            throw SSHCredentialStoreError(status: errSecDecode)
+        }
+        return password
+    }
+
+    private static func keychainPassword(for deviceID: UUID) throws -> String? {
+        guard let data = try keychainData(
+            service: passwordService,
+            account: deviceID.uuidString
+        ) else { return nil }
+        return try decodePassword(data)
+    }
+
+    private static func setKeychainPassword(_ password: String, for deviceID: UUID) throws {
+
+        let passwordData = Data(password.utf8)
+        let query = keychainQuery(service: passwordService, account: deviceID.uuidString)
+        let attributes: [String: Any] = [
+            kSecValueData as String: passwordData,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+        ]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess { return }
+        guard updateStatus == errSecItemNotFound else {
+            throw SSHCredentialStoreError(status: updateStatus)
+        }
+
+        var newItem = query
+        newItem[kSecValueData as String] = passwordData
+        newItem[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
+        let addStatus = SecItemAdd(newItem as CFDictionary, nil)
+        guard addStatus == errSecSuccess else { throw SSHCredentialStoreError(status: addStatus) }
+    }
+
+    private static func removeKeychainPassword(for deviceID: UUID) throws {
+        let status = SecItemDelete(
+            keychainQuery(service: passwordService, account: deviceID.uuidString) as CFDictionary
+        )
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw SSHCredentialStoreError(status: status)
+        }
+    }
+
+    private static func keychainData(service: String, account: String) throws -> Data? {
+        var query = keychainQuery(service: service, account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess else { throw SSHCredentialStoreError(status: status) }
+        guard let data = result as? Data else { throw SSHCredentialStoreError(status: errSecDecode) }
+        return data
+    }
+
+    private static func keychainQuery(service: String, account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    private static func legacyLocalData(directory: String, id: UUID) throws -> Data? {
+        let url = legacyLocalURL(directory: directory, id: id)
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try Data(contentsOf: url)
+    }
+
+    private static func removeLegacyLocalData(directory: String, id: UUID) throws {
+        let url = legacyLocalURL(directory: directory, id: id)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+
+        let root = url.deletingLastPathComponent().deletingLastPathComponent()
+        let children = ["passwords", "authorizations"].map {
+            root.appendingPathComponent($0, isDirectory: true)
+        }
+        for directory in children + [root] {
+            guard (try? FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty) == true
+            else { continue }
+            try? FileManager.default.removeItem(at: directory)
+        }
+    }
+
+    private static func legacyLocalURL(directory: String, id: UUID) -> URL {
+        let applicationSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let root = applicationSupport
+            .appendingPathComponent("HerdrM", isDirectory: true)
+            .appendingPathComponent("SSHCredentials", isDirectory: true)
+        return root
+            .appendingPathComponent(directory, isDirectory: true)
+            .appendingPathComponent(id.uuidString, isDirectory: false)
+    }
+}
+
+public struct SSHCredentialStoreError: LocalizedError, Sendable {
+    public let status: OSStatus
+
+    public var errorDescription: String? {
+        let detail = SecCopyErrorMessageString(status, nil) as String? ?? "OSStatus \(status)"
+        return "could not access SSH password in Keychain: \(detail)"
+    }
+}

--- a/Packages/HerdrKit/Sources/HerdrKit/SSHCredentialStore.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SSHCredentialStore.swift
@@ -10,10 +10,7 @@ public enum SSHCredentialStore {
     private static let authorizationService = "dev.bybee.herdrm.ssh-authorization"
 
     public static func password(for deviceID: UUID) throws -> String? {
-        if let password = try keychainPassword(for: deviceID) {
-            try? removeLegacyLocalData(directory: "passwords", id: deviceID)
-            return password
-        }
+        if let password = try keychainPassword(for: deviceID) { return password }
 
         // Migrate credentials written by the short-lived Debug file-store implementation.
         guard let legacyData = try legacyLocalData(directory: "passwords", id: deviceID) else {
@@ -23,10 +20,6 @@ public enum SSHCredentialStore {
         try setKeychainPassword(password, for: deviceID)
         try removeLegacyLocalData(directory: "passwords", id: deviceID)
         return password
-    }
-
-    public static func hasPassword(for deviceID: UUID) -> Bool {
-        (try? password(for: deviceID)) != nil
     }
 
     public static func setPassword(_ password: String, for deviceID: UUID) throws {
@@ -48,10 +41,19 @@ public enum SSHCredentialStore {
         let authorizationID = UUID()
         var item = keychainQuery(service: authorizationService, account: authorizationID.uuidString)
         item[kSecValueData as String] = Data(deviceID.uuidString.utf8)
-        item[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
+        item[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         let status = SecItemAdd(item as CFDictionary, nil)
         guard status == errSecSuccess else { throw SSHCredentialStoreError(status: status) }
         return authorizationID
+    }
+
+    /// Drops grants stranded by a crash between creation and askpass consumption.
+    public static func purgeAuthorizations() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: authorizationService,
+        ]
+        SecItemDelete(query as CFDictionary)
     }
 
     public static func consumePassword(authorizationID: UUID) throws -> String? {
@@ -92,12 +94,11 @@ public enum SSHCredentialStore {
     }
 
     private static func setKeychainPassword(_ password: String, for deviceID: UUID) throws {
-
         let passwordData = Data(password.utf8)
         let query = keychainQuery(service: passwordService, account: deviceID.uuidString)
         let attributes: [String: Any] = [
             kSecValueData as String: passwordData,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlocked,
+            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
         ]
         let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
         if updateStatus == errSecSuccess { return }
@@ -107,7 +108,7 @@ public enum SSHCredentialStore {
 
         var newItem = query
         newItem[kSecValueData as String] = passwordData
-        newItem[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlocked
+        newItem[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
         let addStatus = SecItemAdd(newItem as CFDictionary, nil)
         guard addStatus == errSecSuccess else { throw SSHCredentialStoreError(status: addStatus) }
     }

--- a/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
@@ -1,11 +1,23 @@
 import Foundation
 
+struct SSHAuthenticationConfiguration {
+    let arguments: [String]
+    let environment: [String: String]
+    let authorizationID: UUID?
+
+    func discardAuthorization() {
+        guard let authorizationID else { return }
+        try? SSHCredentialStore.removeAuthorization(authorizationID)
+    }
+}
+
 /// Forwards a remote herdr Unix socket to a local one using the system OpenSSH client
 /// (`ssh -N -L local.sock:remote.sock target`), so remote devices reuse SocketRPC as-is.
-/// Auth relies on the user's local SSH keys/agent (BatchMode; no password prompts).
+/// Auth uses OpenSSH config/agent/Tailscale SSH, with Keychain-backed askpass as a fallback.
 public actor SSHTunnel {
     public let target: String
     public private(set) var localSocketPath: String?
+    private let credentialID: UUID?
     private var process: Process?
     private var remoteHome: String?
 
@@ -13,8 +25,9 @@ public actor SSHTunnel {
     public static let remotePathExport =
         "export PATH=\"$HOME/.local/bin:$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\""
 
-    public init(target: String) {
+    public init(target: String, credentialID: UUID? = nil) {
         self.target = target
+        self.credentialID = credentialID
     }
 
     deinit {
@@ -26,7 +39,12 @@ public actor SSHTunnel {
     /// Resolves the remote $HOME once; also proves SSH reachability.
     public func probeRemoteHome() async throws -> String {
         if let remoteHome { return remoteHome }
-        let output = try await Self.runSSH(target: target, command: "echo \"$HOME\"", timeout: 12)
+        let output = try await Self.runSSH(
+            target: target,
+            command: "echo \"$HOME\"",
+            timeout: 12,
+            credentialID: credentialID
+        )
         let home = output.trimmingCharacters(in: .whitespacesAndNewlines)
         guard home.hasPrefix("/") else {
             throw HerdrError.tunnelFailed("could not resolve remote home (got: \(output))")
@@ -60,9 +78,9 @@ public actor SSHTunnel {
 
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
-        proc.arguments = [
-            "-N",
-            "-o", "BatchMode=yes",
+        let authentication = Self.authenticationConfiguration(for: credentialID)
+        defer { authentication.discardAuthorization() }
+        proc.arguments = ["-N"] + authentication.arguments + [
             "-o", "StrictHostKeyChecking=accept-new",
             "-o", "ConnectTimeout=10",
             "-o", "ExitOnForwardFailure=yes",
@@ -71,8 +89,10 @@ public actor SSHTunnel {
             "-L", "\(localSock):\(remoteSock)",
             target,
         ]
+        proc.environment = ProcessInfo.processInfo.environment.merging(authentication.environment) { _, new in new }
+        let errorOutput = Pipe()
         proc.standardOutput = FileHandle.nullDevice
-        proc.standardError = FileHandle.nullDevice
+        proc.standardError = errorOutput
         try proc.run()
         process = proc
 
@@ -83,7 +103,8 @@ public actor SSHTunnel {
                 return localSock
             }
             if !proc.isRunning {
-                throw HerdrError.tunnelFailed("ssh exited with status \(proc.terminationStatus)")
+                let errorData = errorOutput.fileHandleForReading.readDataToEndOfFile()
+                throw HerdrError.tunnelFailed(Self.failureReason(status: proc.terminationStatus, stderr: errorData))
             }
             try await Task.sleep(nanoseconds: 250_000_000)
         }
@@ -101,11 +122,16 @@ public actor SSHTunnel {
     }
 
     /// Sniffs the remote OS: "macos", an os-release ID like "ubuntu"/"debian", or a uname fallback.
-    public static func probeOS(target: String) async throws -> String {
+    public static func probeOS(target: String, credentialID: UUID? = nil) async throws -> String {
         let command = """
         case "$(uname -s)" in Darwin) echo macos;; Linux) . /etc/os-release 2>/dev/null; echo "${ID:-linux}";; *) uname -s | tr '[:upper:]' '[:lower:]';; esac
         """
-        let output = try await runSSH(target: target, command: command, timeout: 10)
+        let output = try await runSSH(
+            target: target,
+            command: command,
+            timeout: 10,
+            credentialID: credentialID
+        )
         let os = output.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !os.isEmpty else { throw HerdrError.tunnelFailed("empty OS probe result") }
         return os
@@ -114,20 +140,29 @@ public actor SSHTunnel {
     // MARK: - One-shot exec
 
     /// Runs a command on the remote host and returns stdout. Used for probes.
-    public static func runSSH(target: String, command: String, timeout: TimeInterval) async throws -> String {
+    public static func runSSH(
+        target: String,
+        command: String,
+        timeout: TimeInterval,
+        credentialID: UUID? = nil
+    ) async throws -> String {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 let proc = Process()
                 proc.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
-                proc.arguments = [
-                    "-o", "BatchMode=yes",
+                let authentication = authenticationConfiguration(for: credentialID)
+                defer { authentication.discardAuthorization() }
+                proc.arguments = authentication.arguments + [
                     "-o", "StrictHostKeyChecking=accept-new",
                     "-o", "ConnectTimeout=8",
-                    target, command,
+                    target,
+                    command,
                 ]
+                proc.environment = ProcessInfo.processInfo.environment.merging(authentication.environment) { _, new in new }
                 let out = Pipe()
+                let errorOutput = Pipe()
                 proc.standardOutput = out
-                proc.standardError = FileHandle.nullDevice
+                proc.standardError = errorOutput
                 do {
                     try proc.run()
                 } catch {
@@ -141,11 +176,46 @@ public actor SSHTunnel {
                 proc.waitUntilExit()
                 let data = out.fileHandleForReading.readDataToEndOfFile()
                 guard proc.terminationStatus == 0 else {
-                    continuation.resume(throwing: HerdrError.tunnelFailed("ssh exited \(proc.terminationStatus)"))
+                    let errorData = errorOutput.fileHandleForReading.readDataToEndOfFile()
+                    continuation.resume(throwing: HerdrError.tunnelFailed(
+                        failureReason(status: proc.terminationStatus, stderr: errorData)
+                    ))
                     return
                 }
                 continuation.resume(returning: String(data: data, encoding: .utf8) ?? "")
             }
         }
+    }
+
+    static func authenticationConfiguration(
+        for credentialID: UUID?
+    ) -> SSHAuthenticationConfiguration {
+        guard let credentialID, let executablePath = Bundle.main.executablePath,
+              let authorizationID = try? SSHCredentialStore.createAuthorization(for: credentialID)
+        else {
+            return SSHAuthenticationConfiguration(
+                arguments: ["-o", "BatchMode=yes"],
+                environment: [:],
+                authorizationID: nil
+            )
+        }
+        return SSHAuthenticationConfiguration(
+            arguments: ["-o", "BatchMode=no", "-o", "NumberOfPasswordPrompts=1"],
+            environment: [
+                "SSH_ASKPASS": executablePath,
+                "SSH_ASKPASS_REQUIRE": "force",
+                "DISPLAY": "herdrm:0",
+                SSHCredentialStore.askPassModeEnvironmentKey: "1",
+                SSHCredentialStore.authorizationIDEnvironmentKey: authorizationID.uuidString,
+            ],
+            authorizationID: authorizationID
+        )
+    }
+
+    private static func failureReason(status: Int32, stderr: Data) -> String {
+        let detail = String(data: stderr, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let detail, !detail.isEmpty else { return "ssh exited \(status)" }
+        return String(detail.suffix(2_000))
     }
 }

--- a/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
@@ -204,7 +204,6 @@ public actor SSHTunnel {
             environment: [
                 "SSH_ASKPASS": executablePath,
                 "SSH_ASKPASS_REQUIRE": "force",
-                "DISPLAY": "herdrm:0",
                 SSHCredentialStore.askPassModeEnvironmentKey: "1",
                 SSHCredentialStore.authorizationIDEnvironmentKey: authorizationID.uuidString,
             ],

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
@@ -61,6 +61,13 @@ final class LocalSocketTests: XCTestCase {
         XCTAssertEqual(AgentStatus(wire: nil), .unknown)
     }
 
+    func testOnlyPaneBusyErrorsAreRetryable() {
+        XCTAssertTrue(HerdrService.isPaneBusy(.rpc(code: "agent_pane_busy", message: "busy")))
+        XCTAssertFalse(HerdrService.isPaneBusy(.rpc(code: "agent_name_taken", message: "taken")))
+        XCTAssertFalse(HerdrService.isPaneBusy(.rpc(code: "agent_pane_unavailable", message: "gone")))
+        XCTAssertFalse(HerdrService.isPaneBusy(.connectionFailed("dropped")))
+    }
+
     func testShellInitializationProcessInfoRequiresThePaneShellInForeground() {
         let initializing: JSONValue = .object([
             "shell_pid": .number(42),

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
@@ -61,6 +61,39 @@ final class LocalSocketTests: XCTestCase {
         XCTAssertEqual(AgentStatus(wire: nil), .unknown)
     }
 
+    func testShellInitializationProcessInfoRequiresThePaneShellInForeground() {
+        let initializing: JSONValue = .object([
+            "shell_pid": .number(42),
+            "foreground_process_group_id": .number(42),
+            "foreground_processes": .array([
+                .object([
+                    "pid": .number(42),
+                    "name": .string("-zsh"),
+                    "argv": .array([.string("/bin/zsh")]),
+                ]),
+            ]),
+        ])
+        XCTAssertTrue(HerdrService.processInfoShowsShellInitialization(initializing))
+
+        let busy: JSONValue = .object([
+            "shell_pid": .number(42),
+            "foreground_process_group_id": .number(99),
+            "foreground_processes": .array([
+                .object(["pid": .number(99), "name": .string("vim")]),
+            ]),
+        ])
+        XCTAssertFalse(HerdrService.processInfoShowsShellInitialization(busy))
+
+        let replacedShell: JSONValue = .object([
+            "shell_pid": .number(42),
+            "foreground_process_group_id": .number(42),
+            "foreground_processes": .array([
+                .object(["pid": .number(42), "name": .string("opencode")]),
+            ]),
+        ])
+        XCTAssertFalse(HerdrService.processInfoShowsShellInitialization(replacedShell))
+    }
+
     func testEventStreamDeliversTabLifecycle() async throws {
         try requireLocalHerdr()
         let service = HerdrService(device: .local)

--- a/Packages/HerdrKit/Tests/HerdrKitTests/RemoteSSHTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/RemoteSSHTests.swift
@@ -49,4 +49,43 @@ final class RemoteSSHTests: XCTestCase {
         }
         await service.disconnect()
     }
+
+    func testForwardedSocketStartsAgentInNewPane() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let socketPath = environment["HERDRM_E2E_SOCKET_PATH"] else {
+            throw XCTSkip("HERDRM_E2E_SOCKET_PATH not set")
+        }
+        let kind = environment["HERDRM_E2E_AGENT_KIND"] ?? "claude"
+        let device = Device(
+            name: "e2e-forwarded",
+            kind: .local,
+            socketPath: socketPath
+        )
+        let service = HerdrService(device: device)
+        _ = try await service.connect()
+
+        var paneID: String?
+        do {
+            let pane = try await service.createTab(workspaceID: nil, cwd: nil, label: "herdrm-e2e")
+            paneID = pane
+            let name = "herdrm-e2e-\(UUID().uuidString.prefix(6).lowercased())"
+            try await service.startAgent(
+                name: name,
+                kind: kind,
+                paneID: pane,
+                waitForShell: true
+            )
+            let agents = try await service.agents()
+            XCTAssertTrue(
+                agents.contains { $0.paneID == pane },
+                "started agent did not appear in agent.list"
+            )
+            try await service.closePane(paneID: pane)
+            paneID = nil
+        } catch {
+            if let paneID { try? await service.closePane(paneID: paneID) }
+            throw error
+        }
+        await service.disconnect()
+    }
 }

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+import Security
+@testable import HerdrKit
+
+final class SSHAuthenticationTests: XCTestCase {
+    func testKeychainCredentialConfiguresAskPassAuthentication() throws {
+        let deviceID = UUID()
+        defer { try? SSHCredentialStore.removePassword(for: deviceID) }
+
+        XCTAssertNil(try SSHCredentialStore.password(for: deviceID))
+        try SSHCredentialStore.setPassword("test-password", for: deviceID)
+        XCTAssertEqual(try SSHCredentialStore.password(for: deviceID), "test-password")
+
+        let authentication = SSHTunnel.authenticationConfiguration(for: deviceID)
+        XCTAssertEqual(
+            authentication.arguments,
+            ["-o", "BatchMode=no", "-o", "NumberOfPasswordPrompts=1"]
+        )
+        XCTAssertEqual(
+            authentication.environment[SSHCredentialStore.askPassModeEnvironmentKey],
+            "1"
+        )
+        let rawAuthorizationID = try XCTUnwrap(
+            authentication.environment[SSHCredentialStore.authorizationIDEnvironmentKey]
+        )
+        let authorizationID = try XCTUnwrap(UUID(uuidString: rawAuthorizationID))
+        XCTAssertEqual(
+            try SSHCredentialStore.consumePassword(authorizationID: authorizationID),
+            "test-password"
+        )
+        XCTAssertNil(try SSHCredentialStore.consumePassword(authorizationID: authorizationID))
+        XCTAssertFalse(authentication.environment["SSH_ASKPASS", default: ""].isEmpty)
+
+        try SSHCredentialStore.removePassword(for: deviceID)
+        XCTAssertNil(try SSHCredentialStore.password(for: deviceID))
+    }
+
+    func testLegacyLocalCredentialMigratesToKeychain() throws {
+        let deviceID = UUID()
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: "dev.bybee.herdrm.ssh-password",
+            kSecAttrAccount as String: deviceID.uuidString,
+        ]
+        defer {
+            try? SSHCredentialStore.removePassword(for: deviceID)
+            SecItemDelete(query as CFDictionary)
+        }
+
+        let applicationSupport = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+        let passwordDirectory = applicationSupport
+            .appendingPathComponent("HerdrM/SSHCredentials/passwords", isDirectory: true)
+        let passwordFile = passwordDirectory.appendingPathComponent(deviceID.uuidString)
+        try FileManager.default.createDirectory(
+            at: passwordDirectory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try Data("legacy-password".utf8).write(to: passwordFile)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: passwordFile.path
+        )
+
+        XCTAssertEqual(try SSHCredentialStore.password(for: deviceID), "legacy-password")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: passwordFile.path))
+        XCTAssertEqual(SecItemCopyMatching(query as CFDictionary, nil), errSecSuccess)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ working, blocked, or done. **herdrm** puts a native macOS window on top of it:
 
 - macOS 14+
 - [herdr](https://herdr.dev) running locally and/or on your remote machines
-- For remote devices: SSH key access (herdrm uses your local keys/agent)
+- For remote devices: OpenSSH access through your SSH config/agent, Tailscale
+  SSH, or a password stored in the macOS login Keychain
 
 ## Install
 

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -303,6 +303,30 @@ final class AppModel: ObservableObject {
         }
     }
 
+    /// Leaves the device disconnected but recoverable; the reconnect loop stopped at the prompt.
+    func cancelSSHAuthentication(for request: SSHAuthenticationRequest) {
+        sshAuthenticationRequest = nil
+        sessions[request.deviceID]?.connection =
+            .failed("Authentication cancelled — choose Reconnect to try again")
+    }
+
+    var hasReconnectableDevice: Bool {
+        devicesInScope.contains { isFailed($0.id) }
+    }
+
+    func reconnectFailedDevices() {
+        for device in devicesInScope where isFailed(device.id) {
+            stopSession(device.id)
+            startSession(device)
+            probeOSIfNeeded(device)
+        }
+    }
+
+    private func isFailed(_ deviceID: UUID) -> Bool {
+        if case .failed = session(deviceID).connection { return true }
+        return false
+    }
+
     /// Renames a device and/or updates its SSH target (e.g. after an IP change).
     func updateDevice(_ id: UUID, name: String, sshTarget: String) {
         guard let index = devices.firstIndex(where: { $0.id == id }), !devices[index].isLocal else { return }
@@ -415,8 +439,12 @@ final class AppModel: ObservableObject {
         guard let herdrError = error as? HerdrError,
               case .tunnelFailed(let reason) = herdrError
         else { return false }
-        return reason.localizedCaseInsensitiveContains("permission denied")
-            || reason.localizedCaseInsensitiveContains("authentication failed")
+        return [
+            "permission denied",
+            "authentication failed",
+            "too many authentication failures",
+            "no supported authentication methods",
+        ].contains { reason.localizedCaseInsensitiveContains($0) }
     }
 
     private func removeSSHPassword(for deviceID: UUID) {

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -30,6 +30,13 @@ struct DeviceSessionState {
     var installedAgentKinds: [String] = []
 }
 
+struct SSHAuthenticationRequest: Identifiable {
+    let deviceID: UUID
+    let target: String
+
+    var id: UUID { deviceID }
+}
+
 @MainActor
 final class AppModel: ObservableObject {
     @Published var devices: [Device]
@@ -46,6 +53,7 @@ final class AppModel: ObservableObject {
     /// In-window device panel (NSPopover crashes in ViewBridge on macOS 26+ betas).
     @Published var showDevicePanel = false
     @Published var deviceToEdit: Device?
+    @Published var sshAuthenticationRequest: SSHAuthenticationRequest?
     /// Transient action failures: shown as an alert, never by tearing down sessions.
     @Published var actionError: String?
 
@@ -243,6 +251,13 @@ final class AppModel: ObservableObject {
                     }
                 } catch {
                     self.sessions[device.id]?.connection = .failed(error.localizedDescription)
+                    if let target = device.sshTarget, Self.isSSHAuthenticationFailure(error) {
+                        self.sshAuthenticationRequest = SSHAuthenticationRequest(
+                            deviceID: device.id,
+                            target: target
+                        )
+                        return
+                    }
                 }
                 guard !Task.isCancelled else { return }
                 try? await Task.sleep(nanoseconds: UInt64(backoff * 1_000_000_000))
@@ -272,12 +287,29 @@ final class AppModel: ObservableObject {
         setDeviceFilter(device.id)
     }
 
+    func saveSSHPassword(_ password: String, for request: SSHAuthenticationRequest) {
+        guard !password.isEmpty,
+              let device = device(request.deviceID),
+              device.sshTarget == request.target
+        else { return }
+        do {
+            try SSHCredentialStore.setPassword(password, for: device.id)
+            sshAuthenticationRequest = nil
+            stopSession(device.id)
+            startSession(device)
+            probeOSIfNeeded(device)
+        } catch {
+            actionError = error.localizedDescription
+        }
+    }
+
     /// Renames a device and/or updates its SSH target (e.g. after an IP change).
     func updateDevice(_ id: UUID, name: String, sshTarget: String) {
         guard let index = devices.firstIndex(where: { $0.id == id }), !devices[index].isLocal else { return }
         let targetChanged = devices[index].sshTarget != sshTarget
         devices[index].name = name
         if targetChanged {
+            removeSSHPassword(for: id)
             devices[index].kind = .ssh(target: sshTarget)
             devices[index].osID = nil
             stopSession(id)
@@ -289,6 +321,8 @@ final class AppModel: ObservableObject {
 
     func removeDevice(_ device: Device) {
         guard !device.isLocal else { return }
+        removeSSHPassword(for: device.id)
+        if sshAuthenticationRequest?.deviceID == device.id { sshAuthenticationRequest = nil }
         stopSession(device.id)
         devices.removeAll { $0.id == device.id }
         store.save(devices)
@@ -366,11 +400,30 @@ final class AppModel: ObservableObject {
     private func probeOSIfNeeded(_ device: Device) {
         guard device.osID == nil, let target = device.sshTarget else { return }
         Task {
-            guard let os = try? await SSHTunnel.probeOS(target: target) else { return }
+            guard let os = try? await SSHTunnel.probeOS(
+                target: target,
+                credentialID: device.id
+            ) else { return }
             if let index = self.devices.firstIndex(where: { $0.id == device.id }) {
                 self.devices[index].osID = os
                 self.store.save(self.devices)
             }
+        }
+    }
+
+    private static func isSSHAuthenticationFailure(_ error: Error) -> Bool {
+        guard let herdrError = error as? HerdrError,
+              case .tunnelFailed(let reason) = herdrError
+        else { return false }
+        return reason.localizedCaseInsensitiveContains("permission denied")
+            || reason.localizedCaseInsensitiveContains("authentication failed")
+    }
+
+    private func removeSSHPassword(for deviceID: UUID) {
+        do {
+            try SSHCredentialStore.removePassword(for: deviceID)
+        } catch {
+            actionError = error.localizedDescription
         }
     }
 
@@ -454,10 +507,22 @@ final class AppModel: ObservableObject {
                 let pane = try await service.createTab(workspaceID: workspaceID, cwd: nil, label: kind)
                 createdPane = pane
                 do {
-                    try await service.startAgent(name: kind, kind: kind, paneID: pane, args: args)
+                    try await service.startAgent(
+                        name: kind,
+                        kind: kind,
+                        paneID: pane,
+                        args: args,
+                        waitForShell: true
+                    )
                 } catch HerdrError.rpc(let code, _) where code == "agent_name_taken" {
                     let suffix = String(UUID().uuidString.prefix(4)).lowercased()
-                    try await service.startAgent(name: "\(kind)-\(suffix)", kind: kind, paneID: pane, args: args)
+                    try await service.startAgent(
+                        name: "\(kind)-\(suffix)",
+                        kind: kind,
+                        paneID: pane,
+                        args: args,
+                        waitForShell: true
+                    )
                 }
                 await refresh(device.id)
                 selectedPane = PaneRef(deviceID: device.id, paneID: pane)

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -55,6 +55,9 @@ struct RootView: View {
         .sheet(isPresented: $model.showNewAgent) { NewAgentSheet(model: model) }
         .sheet(isPresented: $model.showNewSpace) { NewSpaceSheet(model: model) }
         .sheet(item: $model.deviceToEdit) { device in EditDeviceSheet(model: model, device: device) }
+        .sheet(item: $model.sshAuthenticationRequest) { request in
+            SSHAuthenticationSheet(model: model, request: request)
+        }
         .alert(
             "Something went wrong",
             isPresented: Binding(
@@ -258,7 +261,7 @@ struct AddDeviceSheet: View {
             SheetHeader(
                 systemImage: "desktopcomputer",
                 title: "Add Device",
-                subtitle: "Must run herdr and be reachable over SSH with your local keys"
+                subtitle: "Uses OpenSSH config, agent, Tailscale SSH, or password"
             )
             Rectangle().fill(Theme.hairline).frame(height: 1)
 
@@ -297,6 +300,56 @@ struct AddDeviceSheet: View {
             .padding(.vertical, 12)
         }
         .frame(width: 400)
+    }
+}
+
+struct SSHAuthenticationSheet: View {
+    @ObservedObject var model: AppModel
+    let request: SSHAuthenticationRequest
+    @State private var password = ""
+    @FocusState private var passwordFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SheetHeader(
+                systemImage: "key.fill",
+                title: "SSH Authentication",
+                subtitle: request.target
+            )
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            VStack(alignment: .leading, spacing: 8) {
+                SheetSectionLabel("PASSWORD")
+                SecureField("SSH password", text: $password)
+                    .textFieldStyle(.roundedBorder)
+                    .focused($passwordFocused)
+                Label(SSHCredentialStore.persistenceDescription, systemImage: "lock.fill")
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            .padding(16)
+
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    model.sshAuthenticationRequest = nil
+                }
+                .keyboardShortcut(.cancelAction)
+                Button("Connect") {
+                    model.saveSSHPassword(password, for: request)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(password.isEmpty)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .frame(width: 400)
+        .onAppear { passwordFocused = true }
     }
 }
 

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -224,6 +224,11 @@ struct DetailView: View {
                         model.showNewAgent = true
                     }
                     .controlSize(.small)
+                } else if model.hasReconnectableDevice {
+                    Button("Reconnect") {
+                        model.reconnectFailedDevices()
+                    }
+                    .controlSize(.small)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -334,7 +339,7 @@ struct SSHAuthenticationSheet: View {
             HStack {
                 Spacer()
                 Button("Cancel") {
-                    model.sshAuthenticationRequest = nil
+                    model.cancelSSHAuthentication(for: request)
                 }
                 .keyboardShortcut(.cancelAction)
                 Button("Connect") {

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -14,6 +14,7 @@ struct HerdrMApp: App {
         if ProcessInfo.processInfo.environment[SSHCredentialStore.askPassModeEnvironmentKey] == "1" {
             Self.runSSHAskPass()
         }
+        SSHCredentialStore.purgeAuthorizations()
         updaterController = SPUStandardUpdaterController(
             startingUpdater: true,
             updaterDelegate: nil,
@@ -54,7 +55,7 @@ struct HerdrMApp: App {
 
     private static func runSSHAskPass() -> Never {
         let environment = ProcessInfo.processInfo.environment
-          guard let rawID = environment[SSHCredentialStore.authorizationIDEnvironmentKey],
+        guard let rawID = environment[SSHCredentialStore.authorizationIDEnvironmentKey],
               let authorizationID = UUID(uuidString: rawID),
               let password = try? SSHCredentialStore.consumePassword(authorizationID: authorizationID)
         else {

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -1,4 +1,6 @@
 import AppKit
+import Darwin
+import HerdrKit
 import Sparkle
 import SwiftUI
 
@@ -6,11 +8,18 @@ import SwiftUI
 struct HerdrMApp: App {
     @AppStorage("app.theme") private var themePreference = "system"
 
-    private let updaterController = SPUStandardUpdaterController(
-        startingUpdater: true,
-        updaterDelegate: nil,
-        userDriverDelegate: nil
-    )
+    private let updaterController: SPUStandardUpdaterController
+
+    init() {
+        if ProcessInfo.processInfo.environment[SSHCredentialStore.askPassModeEnvironmentKey] == "1" {
+            Self.runSSHAskPass()
+        }
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: nil,
+            userDriverDelegate: nil
+        )
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -41,6 +50,18 @@ struct HerdrMApp: App {
         case "dark": NSApp.appearance = NSAppearance(named: .darkAqua)
         default: NSApp.appearance = nil
         }
+    }
+
+    private static func runSSHAskPass() -> Never {
+        let environment = ProcessInfo.processInfo.environment
+          guard let rawID = environment[SSHCredentialStore.authorizationIDEnvironmentKey],
+              let authorizationID = UUID(uuidString: rawID),
+              let password = try? SSHCredentialStore.consumePassword(authorizationID: authorizationID)
+        else {
+            Darwin.exit(EXIT_FAILURE)
+        }
+        FileHandle.standardOutput.write(Data("\(password)\n".utf8))
+        Darwin.exit(EXIT_SUCCESS)
     }
 }
 

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -43,6 +43,12 @@ struct AttachTerminalView: NSViewRepresentable {
         let command = service.attachCommand(paneID: paneID)
         var environment = Terminal.getEnvironmentVariables(termName: "xterm-256color")
         environment.append("LANG=en_US.UTF-8")
+        for (key, value) in command.environment {
+            environment.removeAll { $0.hasPrefix("\(key)=") }
+            environment.append("\(key)=\(value)")
+        }
+        context.coordinator.authorizationID = command.authorizationID
+        context.coordinator.scheduleAuthorizationCleanup()
         view.startProcess(
             executable: command.executable,
             args: command.args,
@@ -71,9 +77,29 @@ struct AttachTerminalView: NSViewRepresentable {
     }
 
     final class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
+        var authorizationID: UUID?
+
+        deinit {
+            discardAuthorization()
+        }
+
+        func scheduleAuthorizationCleanup() {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 30) { [weak self] in
+                self?.discardAuthorization()
+            }
+        }
+
+        private func discardAuthorization() {
+            guard let authorizationID else { return }
+            try? SSHCredentialStore.removeAuthorization(authorizationID)
+            self.authorizationID = nil
+        }
+
         func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
         func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}
         func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
-        func processTerminated(source: TerminalView, exitCode: Int32?) {}
+        func processTerminated(source: TerminalView, exitCode: Int32?) {
+            discardAuthorization()
+        }
     }
 }


### PR DESCRIPTION
### Enhanced Remote SSH Support

This update makes remote HerdrM sessions behave consistently with local sessions while keeping authentication within macOS and OpenSSH security boundaries.

#### What changed

- Added support for SSH config, keys/agent, Tailscale SSH, and password authentication.
- Added an in-app password prompt when OpenSSH reports an authentication failure.
- Stored remembered passwords in macOS Keychain rather than `devices.json` or process arguments.
- Used single-use Keychain authorization IDs when invoking `SSH_ASKPASS`, so the password itself never enters the SSH process environment.
- Preserved OpenSSH host verification with `StrictHostKeyChecking=accept-new`.
- Surfaced OpenSSH stderr instead of reducing every failure to `ssh exited 255`.
- Applied the same authentication configuration to probes, socket forwarding, agent discovery, and terminal attachment.

#### Security review

I reviewed the implementation against Apple Keychain guidance, OpenSSH’s `SSH_ASKPASS` contract, VS Code Remote SSH, and Tailscale SSH.

An intermediate Debug implementation stored the password in a private `0600` Application Support file. That was rolled back because file permissions do not protect the credential from other processes running as the same macOS user. Existing temporary credentials are migrated into Keychain and the local file is removed.

Keys, SSH agent, or Tailscale SSH remain the preferred authentication methods. The Keychain password is only a fallback. Unsigned Debug rebuilds may trigger another Keychain permission prompt because their signing identity changes; signed production builds have a stable identity.

#### Remote agent startup

Fixed `agent_pane_busy: agent target pane ... is not an available shell`.

`tab.create` can return before the new shell finishes initializing. HerdrM now mirrors the official herdr CLI behavior:

- Pins the new pane’s `terminal_id`.
- Checks `pane.process_info`.
- Retries only while the actual pane shell remains in the foreground.
- Polls every 100 ms for up to two seconds.
- Preserves `agent_pane_busy` immediately when the pane is genuinely occupied.

#### Validation

- Keychain storage, one-time authorization, and legacy migration tests pass.
- Shell-readiness guard tests pass.
- Live remote E2E created a pane, started Claude, observed it in `agent.list`, and cleaned up the pane.
- Full suite: 8 tests passed; 4 opt-in remote tests skipped in the generic run.
- Debug Xcode build and optimized HerdrKit build both pass.
- Verified that only the configured device credential remains in Keychain, with no plaintext credential files or orphaned authorization items.