### PR TITLE
feat: add space renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ the Sparkle update description — a release without a section here fails CI.
 - Terminal settings: "Mouse reporting" toggle — turn it off to always select
   text with the mouse even in TUIs that capture the mouse (Shift-drag selects
   either way). (#2, #5)
+- Spaces can now be renamed from the sidebar context menu.
 
 ### Fixed
 - The terminal now re-renders immediately when the app theme changes. (#4)

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -163,6 +163,16 @@ public actor HerdrService {
         return (id, result["root_pane"]?["pane_id"]?.stringValue)
     }
 
+    public func renameWorkspace(workspaceID: String, label: String) async throws {
+        _ = try await client().request(
+            method: "workspace.rename",
+            params: .object([
+                "workspace_id": .string(workspaceID),
+                "label": .string(label),
+            ])
+        )
+    }
+
     /// Creates a tab (optionally in a workspace/cwd) and returns the new pane id.
     public func createTab(workspaceID: String?, cwd: String?, label: String?) async throws -> String {
         var params: [String: JSONValue] = ["focus": .bool(false)]

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -46,6 +46,7 @@ final class AppModel: ObservableObject {
     /// In-window device panel (NSPopover crashes in ViewBridge on macOS 26+ betas).
     @Published var showDevicePanel = false
     @Published var deviceToEdit: Device?
+    @Published var spaceToRename: SpaceEntry?
     /// Transient action failures: shown as an alert, never by tearing down sessions.
     @Published var actionError: String?
 
@@ -415,6 +416,22 @@ final class AppModel: ObservableObject {
     }
 
     // MARK: - Actions
+
+    func renameSpace(_ entry: SpaceEntry, label: String) {
+        let label = label.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !label.isEmpty, label != entry.workspace.label else { return }
+        Task {
+            do {
+                try await service(for: entry.device).renameWorkspace(
+                    workspaceID: entry.workspace.workspaceID,
+                    label: label
+                )
+                await refresh(entry.device.id)
+            } catch {
+                actionError = error.localizedDescription
+            }
+        }
+    }
 
     /// Creates a workspace rooted at the given directory ("~" expands to the device's
     /// home, local or remote), then goes straight into the New Agent sheet for it.

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -54,6 +54,7 @@ struct RootView: View {
         .sheet(isPresented: $model.showAddDevice) { AddDeviceSheet(model: model) }
         .sheet(isPresented: $model.showNewAgent) { NewAgentSheet(model: model) }
         .sheet(isPresented: $model.showNewSpace) { NewSpaceSheet(model: model) }
+        .sheet(item: $model.spaceToRename) { entry in RenameSpaceSheet(model: model, entry: entry) }
         .sheet(item: $model.deviceToEdit) { device in EditDeviceSheet(model: model, device: device) }
         .alert(
             "Something went wrong",
@@ -610,6 +611,55 @@ struct NewAgentSheet: View {
     }
 }
 
+struct RenameSpaceSheet: View {
+    @ObservedObject var model: AppModel
+    let entry: AppModel.SpaceEntry
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SheetHeader(
+                systemImage: "pencil",
+                title: "Rename Space",
+                subtitle: "Rename \(entry.workspace.label) on \(entry.device.name)"
+            )
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            VStack(alignment: .leading, spacing: 8) {
+                SheetSectionLabel("NAME")
+                TextField("Space name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+            }
+            .padding(16)
+
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Rename") {
+                    model.renameSpace(entry, label: name)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(trimmedName.isEmpty || trimmedName == entry.workspace.label)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .frame(width: 400)
+        .onAppear { name = entry.workspace.label }
+    }
+}
+
 struct EditDeviceSheet: View {
     @ObservedObject var model: AppModel
     let device: Device
@@ -668,4 +718,3 @@ struct EditDeviceSheet: View {
         }
     }
 }
-

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -76,6 +76,10 @@ struct SidebarView: View {
                     ForEach(model.visibleSpaces) { entry in
                         spaceRow(entry)
                             .contextMenu {
+                                Button("Rename Space…") {
+                                    model.spaceToRename = entry
+                                }
+                                Divider()
                                 Button("Close Space \"\(entry.workspace.label)\"…", role: .destructive) {
                                     model.requestCloseSpace(entry)
                                 }


### PR DESCRIPTION
## Summary

- add a Rename Space action to the sidebar context menu
- call herdr's existing `workspace.rename` API
- validate names, refresh the affected device, and surface errors through the existing alert

## Testing

- `make kit-test`
- unsigned Debug build with `xcodebuild`
- launched the Debug app locally