### PR TITLE
feat: start the local herdr server when it isn't running

### DIFF
--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -5,14 +5,28 @@ public actor HerdrService {
     public let device: Device
     private var tunnel: SSHTunnel?
     private var rpc: SocketRPC?
+    /// nil for remote devices and when auto-start is off; remotes are the user's to run.
+    private let localServer: LocalHerdrServer?
+    /// Auto-start is for a server that was never there, not for one that went away: see
+    /// `ping(_:socketPath:)`.
+    private var everConnected = false
 
     public static let minimumProtocolVersion = 17
 
-    public init(device: Device) {
+    public init(device: Device, autoStartLocalServer: Bool = true) {
+        self.init(
+            device: device,
+            localServer: device.isLocal && autoStartLocalServer ? LocalHerdrServer() : nil
+        )
+    }
+
+    /// Seam for tests: injects the auto-start collaborator, nil turning it off.
+    init(device: Device, localServer: LocalHerdrServer?) {
         self.device = device
         if let target = device.sshTarget {
             self.tunnel = SSHTunnel(target: target, credentialID: device.id)
         }
+        self.localServer = localServer
     }
 
     // MARK: - Connection
@@ -28,12 +42,53 @@ public actor HerdrService {
             socketPath = try await tunnel.ensureUp()
         }
         let client = SocketRPC(socketPath: socketPath)
-        let pong = try await client.request(method: "ping", params: .object([:]), as: PingResult.self)
+        let pong = try await ping(client, socketPath: socketPath)
         guard pong.protocolVersion >= Self.minimumProtocolVersion else {
             throw HerdrError.incompatibleProtocol(pong.protocolVersion)
         }
         rpc = client
+        everConnected = true
         return pong
+    }
+
+    /// Test seam: whether this service would start a local server at all.
+    var autoStartsLocalServer: Bool { localServer != nil }
+
+    /// Pings; when the local server was never reachable in this session, starts it and pings
+    /// again, so the app boots without the user opening a terminal to run `herdr`.
+    ///
+    /// A server that already answered here and is gone now was stopped deliberately — by
+    /// `herdr server stop`, or by the restart in the middle of `herdr update` — and bringing
+    /// it back would both undo the user's decision and let herdrm win the bind race that
+    /// `herdr update` needs. The guard is per service instance rather than per process on
+    /// purpose: Reconnect and the backoff loop must still be able to start a server for
+    /// someone who installed or repaired herdr after opening the app.
+    private func ping(_ client: SocketRPC, socketPath: String) async throws -> PingResult {
+        do {
+            return try await client.request(method: "ping", params: .object([:]), as: PingResult.self)
+        } catch let error as HerdrError where Self.isServerDown(error) {
+            guard let localServer, !everConnected else { throw error }
+            try await localServer.ensureRunning(socketPath: socketPath)
+            return try await client.request(method: "ping", params: .object([:]), as: PingResult.self)
+        }
+    }
+
+    /// The two shapes a missing server takes: no socket file at all, or a file whose
+    /// `connect()` is refused because nobody is listening.
+    ///
+    /// Nothing else qualifies, and the strictness is the point: `SocketRPC` reports a failed
+    /// `read()` (the 15 s timeout — a hung but live server), `write()` or `socket()` through
+    /// the same `connectionFailed` case, and every one of those proves somebody was on the
+    /// other end. Treating them as "no server" would start a second daemon on top of a live
+    /// one. Matched on the text `SocketRPC.connect` builds — `"connect(): \(strerror)"` — the
+    /// way `AppModel.isSSHAuthenticationFailure` already matches OpenSSH's wording.
+    static func isServerDown(_ error: HerdrError) -> Bool {
+        switch error {
+        case .socketUnavailable: return true
+        case .connectionFailed(let reason):
+            return reason.contains("connect():") && reason.contains("Connection refused")
+        default: return false
+        }
     }
 
     public func disconnect() async {

--- a/Packages/HerdrKit/Sources/HerdrKit/LocalServer.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/LocalServer.swift
@@ -1,0 +1,239 @@
+import Foundation
+
+/// Starts the local herdr server on demand, so a cold boot connects instead of telling the
+/// user to go run `herdr` in a terminal first.
+///
+/// Every collaborator is injected: `binaryPath` finds the CLI, `launcher` spawns it, and
+/// `ensureRunning` takes the socket path and the timeout. Nothing is global, so the whole
+/// flow is exercisable on a machine where herdr isn't installed.
+public struct LocalHerdrServer: Sendable {
+    /// A spawned `herdr server`: watched, never owned. See `spawn(binary:)`.
+    public struct Launched: Sendable {
+        /// Whether the spawned process is still alive.
+        public let isRunning: @Sendable () -> Bool
+        /// What the process printed. Meaningful once it has exited.
+        public let output: @Sendable () -> String
+
+        public init(
+            isRunning: @escaping @Sendable () -> Bool,
+            output: @escaping @Sendable () -> String
+        ) {
+            self.isRunning = isRunning
+            self.output = output
+        }
+    }
+
+    /// PATH used to find the herdr CLI. GUI apps launched from Finder don't inherit a
+    /// login-shell PATH, hence the same export the SSH side uses, plus mise's shim
+    /// directory: `mise use -g herdr` is one of herdr's install methods and its shims sit
+    /// in none of the other directories. `SSHTunnel.remotePathExport` stays untouched on
+    /// purpose — it is shared with the tunnel and the terminal attach, where the extra
+    /// directory would belong to the remote user, not to this Mac.
+    public static let localPathExport =
+        "\(SSHTunnel.remotePathExport); export PATH=\"$HOME/.local/share/mise/shims:$PATH\""
+
+    /// Grace given to the socket after the spawned process exits. `herdr server` also exits
+    /// non-zero when another process won the race to bind the socket — that server is
+    /// serving, so an exit on its own is not a failure.
+    private static let exitGracePeriod: TimeInterval = 0.5
+
+    /// How long an existing-but-refusing socket is re-probed before it counts as stale.
+    /// Sized for a momentarily full accept queue (milliseconds), not for a slow start.
+    private static let ambiguousSocketGrace: TimeInterval = 1
+
+    private let binaryPath: @Sendable () -> String?
+    private let launcher: @Sendable (String) throws -> Launched
+    private let pollInterval: TimeInterval
+
+    public init(
+        binaryPath: @escaping @Sendable () -> String? = { LocalHerdrServer.resolveBinary() },
+        launcher: @escaping @Sendable (String) throws -> Launched = { try LocalHerdrServer.spawn(binary: $0) },
+        pollInterval: TimeInterval = 0.05
+    ) {
+        self.binaryPath = binaryPath
+        self.launcher = launcher
+        self.pollInterval = pollInterval
+    }
+
+    // MARK: - Lifecycle
+
+    /// Returns once `socketPath` accepts connections, starting `herdr server` if it doesn't.
+    /// Cheap and safe to call on every connect: a live socket short-circuits.
+    public func ensureRunning(socketPath: String, timeout: TimeInterval = 10) async throws {
+        guard try await serverIsGone(socketPath: socketPath) else { return }
+        guard let binary = binaryPath() else { throw HerdrError.herdrNotInstalled }
+        let launched = try launcher(binary)
+
+        let timeoutDeadline = Date().addingTimeInterval(timeout)
+        var deadline = timeoutDeadline
+        var exited = false
+        while true {
+            // Only a real connection proves the server is up: herdr creates the socket file
+            // tens of milliseconds before it accepts, and a dead server leaves it behind.
+            if Self.socketAcceptsConnections(socketPath) { return }
+            if !exited, !launched.isRunning() {
+                exited = true
+                deadline = min(Date().addingTimeInterval(Self.exitGracePeriod), timeoutDeadline)
+            }
+            guard Date() < deadline else { break }
+            try await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+        }
+        if exited {
+            throw HerdrError.connectionFailed(
+                "herdr server exited without serving \(socketPath): \(launched.output())"
+            )
+        }
+        throw HerdrError.connectionFailed("timed out waiting for the herdr server at \(socketPath)")
+    }
+
+    /// Whether nobody is serving `socketPath`, and starting a server is therefore safe.
+    ///
+    /// An existing socket file is the ambiguous case, and getting it wrong is expensive: when
+    /// a healthy server's accept queue is momentarily full macOS answers `ECONNREFUSED`, and
+    /// `herdr server` reacts to a refused socket by unlinking it and binding its own — which
+    /// would strand the running server holding all of the user's panes, unreachable and
+    /// invisible to `herdr server stop`. A full backlog drains in milliseconds while a stale
+    /// socket stays dead forever, so the ambiguous case is re-probed before concluding
+    /// anything. No file means no ambiguity: nothing to strand, and no latency added to the
+    /// case that matters.
+    private func serverIsGone(socketPath: String) async throws -> Bool {
+        if Self.socketAcceptsConnections(socketPath) { return false }
+        guard FileManager.default.fileExists(atPath: socketPath) else { return true }
+        let deadline = Date().addingTimeInterval(Self.ambiguousSocketGrace)
+        while Date() < deadline {
+            try await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+            if Self.socketAcceptsConnections(socketPath) { return false }
+        }
+        return true
+    }
+
+    // MARK: - Collaborators
+
+    /// Locates the herdr CLI (`command -v` under `localPathExport`); nil when not found.
+    /// `environment` overrides what the lookup inherits, which is how a launchd-style PATH
+    /// (or a different `$HOME`) can be exercised without touching this process.
+    public static func resolveBinary(environment: [String: String]? = nil) -> String? {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/sh")
+        proc.arguments = ["-c", "\(localPathExport); command -v herdr"]
+        if let environment { proc.environment = environment }
+        let out = Pipe()
+        proc.standardOutput = out
+        proc.standardError = FileHandle.nullDevice
+        do {
+            try proc.run()
+        } catch {
+            return nil
+        }
+        let data = out.fileHandleForReading.readDataToEndOfFile()
+        proc.waitUntilExit()
+        let path = (String(data: data, encoding: .utf8) ?? "")
+            .split(separator: "\n").first
+            .map { $0.trimmingCharacters(in: .whitespaces) } ?? ""
+        guard !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) else { return nil }
+        return path
+    }
+
+    /// Spawns `herdr server` and hands back a handle for watching it.
+    ///
+    /// The process is deliberately **not** owned: nothing here terminates it, and there is no
+    /// counterpart to `SSHTunnel.tearDown()`. herdr's server is a shared daemon holding every
+    /// agent's PTY, so killing it when herdrm quits would take the user's running agents down
+    /// with it. It is meant to outlive us (launchd reparents it) and a second `herdr server`
+    /// is a harmless no-op, so leaving it running is the correct end state.
+    ///
+    /// Its output goes to a file for the same reason: an undrained pipe stalls the daemon once
+    /// the buffer fills, and closing our end of it would break the daemon's stdout — while a
+    /// file still carries the real error text when the start fails.
+    public static func spawn(binary: String) throws -> Launched {
+        // Unique per spawn: a fixed name would let a second herdrm (or a second start)
+        // truncate a log file the live daemon still holds open at a non-zero offset.
+        let logURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdrm-herdr-server-\(getpid())-\(UUID().uuidString.prefix(8)).log")
+        FileManager.default.createFile(atPath: logURL.path, contents: nil)
+        guard let log = try? FileHandle(forWritingTo: logURL) else {
+            throw HerdrError.connectionFailed("could not open \(logURL.path)")
+        }
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: binary)
+        proc.arguments = ["server"]
+        proc.environment = serverEnvironment()
+        proc.standardInput = FileHandle.nullDevice
+        proc.standardOutput = log
+        proc.standardError = log
+        do {
+            try proc.run()
+        } catch {
+            throw HerdrError.connectionFailed("herdr server spawn: \(error.localizedDescription)")
+        }
+        let watched = ProcessBox(proc)
+        return Launched(
+            isRunning: { watched.process.isRunning },
+            output: {
+                let text = (try? String(contentsOf: logURL, encoding: .utf8)) ?? ""
+                return String(text.trimmingCharacters(in: .whitespacesAndNewlines).suffix(2_000))
+            }
+        )
+    }
+
+    /// The environment handed to the server, which is `base` plus a `SHELL` when it has none.
+    ///
+    /// herdr picks the shell of every pane from `$SHELL`, and launchd does not export it: a GUI
+    /// app started from Finder has no `SHELL` in its environment (`launchctl getenv SHELL` is
+    /// empty), so a server spawned from herdrm would give the user `sh` panes instead of their
+    /// login shell — no `.zshrc`, and none of the agents installed under `~/.local/bin` (claude
+    /// among them) on PATH. The panes are interactive shells that rebuild their own PATH from
+    /// the rc files, so `SHELL` is the only variable that has to be right here.
+    ///
+    /// An explicit `SHELL` is never overwritten: running a shell other than the account's is a
+    /// deliberate choice. When the login shell cannot be resolved, nothing is set and herdr
+    /// keeps whatever default it has.
+    /// Process identity of the GUI app, which must not reach the daemon: the server outlives
+    /// herdrm and every pane inherits its environment, so `__CFBundleIdentifier` would make a
+    /// pane's `defaults`/NSUserDefaults hit herdrm's domain and TCC prompts get attributed to
+    /// the app (revoking herdrm's permissions would then break agents). `DYLD_*` and friends
+    /// come from an Xcode debug launch and would be baked into a daemon outliving Xcode.
+    /// Everything else the user's environment carries is wanted and stays.
+    private static let strippedEnvironmentKeys: Set<String> = [
+        "__CFBundleIdentifier", "XPC_SERVICE_NAME", "XPC_FLAGS",
+        "OSLogRateLimit", "MallocNanoZone", "OS_ACTIVITY_DT_MODE",
+    ]
+
+    private static let strippedEnvironmentPrefix = "DYLD_"
+
+    static func serverEnvironment(base: [String: String] = ProcessInfo.processInfo.environment) -> [String: String] {
+        var environment = base.filter {
+            !strippedEnvironmentKeys.contains($0.key) && !$0.key.hasPrefix(strippedEnvironmentPrefix)
+        }
+        let declared = base["SHELL"]?.trimmingCharacters(in: .whitespaces) ?? ""
+        guard declared.isEmpty, let shell = loginShell() else { return environment }
+        environment["SHELL"] = shell
+        return environment
+    }
+
+    /// The account's login shell straight from the password database (`getpwuid`), which is
+    /// where it lives when the environment doesn't carry it. nil when it can't be read.
+    static func loginShell() -> String? {
+        guard let entry = getpwuid(getuid())?.pointee.pw_shell else { return nil }
+        let shell = String(cString: entry).trimmingCharacters(in: .whitespaces)
+        return shell.isEmpty ? nil : shell
+    }
+
+    /// True when something is listening on `path` right now, using the very same connect the
+    /// RPC client does — a `fileExists` check would accept a stale socket file.
+    static func socketAcceptsConnections(_ path: String) -> Bool {
+        guard let fd = try? SocketRPC.connect(path: path) else { return false }
+        close(fd)
+        return true
+    }
+}
+
+/// Lets the observation closures be `@Sendable` around a `Process`, which isn't.
+/// Safe because the wrapped process is only ever read (`isRunning`), never mutated.
+private final class ProcessBox: @unchecked Sendable {
+    let process: Process
+
+    init(_ process: Process) {
+        self.process = process
+    }
+}

--- a/Packages/HerdrKit/Sources/HerdrKit/Models.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/Models.swift
@@ -165,6 +165,7 @@ public struct HerdrEvent: Sendable {
 public enum HerdrError: Error, LocalizedError, Sendable {
     case socketUnavailable(String)
     case connectionFailed(String)
+    case herdrNotInstalled
     case rpc(code: String, message: String)
     case malformedResponse(String)
     case incompatibleProtocol(Int)
@@ -174,6 +175,7 @@ public enum HerdrError: Error, LocalizedError, Sendable {
         switch self {
         case .socketUnavailable(let path): return "herdr socket not found at \(path)"
         case .connectionFailed(let reason): return "connection failed: \(reason)"
+        case .herdrNotInstalled: return "herdr not found on herdrm's PATH — install it with \"brew install herdr\""
         case .rpc(let code, let message): return "herdr error \(code): \(message)"
         case .malformedResponse(let reason): return "malformed response: \(reason)"
         case .incompatibleProtocol(let version): return "herdr protocol \(version) is too old (need >= 17)"

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalServerTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalServerTests.swift
@@ -1,0 +1,603 @@
+import XCTest
+@testable import HerdrKit
+
+/// Hermetic tests for the local herdr auto-start: the launcher is injected and every socket
+/// lives in a per-test temp directory, so nothing here touches the real herdr server or
+/// `~/.config/herdr`. Names stay short because sockaddr_un caps paths at 104 bytes.
+final class LocalServerTests: XCTestCase {
+    private var directory: URL!
+    private var socketPath: String!
+    private var listeners: [FakeListener] = []
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hk-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        socketPath = directory.appendingPathComponent("s.sock").path
+    }
+
+    override func tearDownWithError() throws {
+        listeners.forEach { $0.stop() }
+        listeners = []
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    // MARK: - Starting
+
+    func testServerThatOpensTheSocketIsAwaited() async throws {
+        let path = socketPath!
+        let listener = makeListener()
+        let launches = Recorder()
+        let server = LocalHerdrServer(
+            binaryPath: { "/fake/herdr" },
+            launcher: { binary in
+                launches.record(binary)
+                // Same shape as the real thing: the socket lands well after the spawn returns.
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.15) { try? listener.start(at: path) }
+                return .alive()
+            }
+        )
+
+        try await server.ensureRunning(socketPath: path, timeout: 3)
+
+        XCTAssertEqual(launches.values, ["/fake/herdr"])
+        XCTAssertTrue(LocalHerdrServer.socketAcceptsConnections(path))
+    }
+
+    func testLiveSocketLaunchesNothing() async throws {
+        let path = socketPath!
+        try makeListener().start(at: path)
+        let launches = Recorder()
+        // A poll interval far larger than a connect(): every connect herdrm makes goes through
+        // here, so answering must cost one probe, not one poll.
+        let server = LocalHerdrServer(
+            binaryPath: { "/fake/herdr" },
+            launcher: { binary in
+                launches.record(binary)
+                return .alive()
+            },
+            pollInterval: 0.5
+        )
+
+        let started = Date()
+        try await server.ensureRunning(socketPath: path, timeout: 3)
+
+        XCTAssertEqual(launches.values, [], "a server already serving must not be started again")
+        XCTAssertLessThan(Date().timeIntervalSince(started), 0.25, "the happy path waited for a poll")
+    }
+
+    func testStaleSocketFileStillStartsTheServer() async throws {
+        let path = socketPath!
+        let stale = makeListener()
+        try stale.start(at: path)
+        stale.stop()
+        XCTAssertTrue(FileManager.default.fileExists(atPath: path), "expected an orphaned socket file")
+        XCTAssertFalse(LocalHerdrServer.socketAcceptsConnections(path))
+
+        let listener = makeListener()
+        let launches = Recorder()
+        let server = LocalHerdrServer(
+            binaryPath: { "/fake/herdr" },
+            launcher: { binary in
+                launches.record(binary)
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) { try? listener.start(at: path) }
+                return .alive()
+            }
+        )
+
+        try await server.ensureRunning(socketPath: path, timeout: 3)
+
+        XCTAssertEqual(launches.values.count, 1, "an orphaned socket file is not a running server")
+    }
+
+    /// `herdr server` exits non-zero when another process wins the race to bind the socket.
+    /// The socket, not the exit status, decides.
+    func testExitedProcessWithAUsableSocketSucceeds() async throws {
+        let path = socketPath!
+        let listener = makeListener()
+        let exited = Flag()
+        let server = LocalHerdrServer(
+            binaryPath: { "/fake/herdr" },
+            launcher: { _ in
+                // Death first, socket 50 ms later, both on one thread: the gap is a real sleep
+                // instead of two independent timers, so the post-exit grace is what is being
+                // measured and not the scheduler.
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.02) {
+                    exited.set()
+                    Thread.sleep(forTimeInterval: 0.05)
+                    try? listener.start(at: path)
+                }
+                return LocalHerdrServer.Launched(
+                    isRunning: { !exited.value },
+                    output: { "error: herdr server is already running" }
+                )
+            }
+        )
+
+        try await server.ensureRunning(socketPath: path, timeout: 3)
+
+        XCTAssertTrue(LocalHerdrServer.socketAcceptsConnections(path))
+    }
+
+    // MARK: - Failing
+
+    func testMissingBinaryReportsHowToInstallIt() async throws {
+        let launches = Recorder()
+        let server = LocalHerdrServer(
+            binaryPath: { nil },
+            launcher: { binary in
+                launches.record(binary)
+                return .alive()
+            }
+        )
+
+        let error = await captureError { try await server.ensureRunning(socketPath: socketPath, timeout: 1) }
+
+        guard case .herdrNotInstalled? = error as? HerdrError else {
+            return XCTFail("expected herdrNotInstalled, got \(String(describing: error))")
+        }
+        let description = try XCTUnwrap((error as? HerdrError)?.errorDescription)
+        XCTAssertTrue(description.contains("brew install herdr"), description)
+        XCTAssertTrue(description.contains("not found"), "the CLI may just be off herdrm's PATH: \(description)")
+        XCTAssertEqual(launches.values, [])
+    }
+
+    func testFailedStartReportsTheProcessOutput() async throws {
+        let server = LocalHerdrServer(
+            binaryPath: { "/fake/herdr" },
+            launcher: { _ in
+                LocalHerdrServer.Launched(
+                    isRunning: { false },
+                    output: { "error: failed to read config at line 7" }
+                )
+            }
+        )
+
+        let error = await captureError { try await server.ensureRunning(socketPath: socketPath, timeout: 5) }
+
+        let description = try XCTUnwrap((error as? HerdrError)?.errorDescription)
+        XCTAssertTrue(description.contains("failed to read config at line 7"), description)
+    }
+
+    func testServerThatNeverOpensTheSocketTimesOut() async throws {
+        let server = LocalHerdrServer(binaryPath: { "/fake/herdr" }, launcher: { _ in .alive() })
+
+        let started = Date()
+        let error = await captureError { try await server.ensureRunning(socketPath: socketPath, timeout: 1) }
+        let elapsed = Date().timeIntervalSince(started)
+
+        let description = try XCTUnwrap((error as? HerdrError)?.errorDescription)
+        XCTAssertTrue(description.contains("timed out"), description)
+        XCTAssertGreaterThanOrEqual(elapsed, 0.9, "gave up before the timeout")
+        XCTAssertLessThan(elapsed, 3, "waited past the requested timeout")
+    }
+
+    // MARK: - Spawning and resolving
+    /// A healthy server whose accept queue is momentarily full refuses connections on macOS.
+    /// Spawning then would make `herdr server` unlink its socket and strand it.
+    func testExistingSocketThatStartsAcceptingIsNeverRespawned() async throws {
+        let path = socketPath!
+        let stale = makeListener()
+        try stale.start(at: path)
+        stale.stop()  // the file stays: the ambiguous case, refusing for now
+
+        let listener = makeListener()
+        DispatchQueue.global().asyncAfter(deadline: .now() + 0.2) { try? listener.start(at: path) }
+        let launches = Recorder()
+        let server = LocalHerdrServer(
+            binaryPath: { "/fake/herdr" },
+            launcher: { binary in
+                launches.record(binary)
+                return .alive()
+            }
+        )
+
+        let started = Date()
+        try await server.ensureRunning(socketPath: path, timeout: 5)
+
+        XCTAssertEqual(launches.values, [], "herdrm spawned a second server over a live one")
+        XCTAssertLessThan(Date().timeIntervalSince(started), 1.5, "did not return as soon as it was served")
+    }
+
+
+    func testSpawnRunsTheServerSubcommandAndKeepsItsOutput() async throws {
+        let script = directory.appendingPathComponent("fake-herdr")
+        try """
+        #!/bin/sh
+        echo "argv: $*"
+        echo "boom" >&2
+        exit 1
+        """.write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)
+
+        let launched = try LocalHerdrServer.spawn(binary: script.path)
+        for _ in 0..<100 where launched.isRunning() {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        XCTAssertFalse(launched.isRunning())
+        let output = launched.output()
+        XCTAssertTrue(output.contains("argv: server"), output)
+        XCTAssertTrue(output.contains("boom"), output)
+    }
+
+    /// The bug this guards: a GUI app has no `SHELL`, herdr then hands out `sh` panes and the
+    /// user loses their rc files and everything under `~/.local/bin`.
+    func testSpawnGivesTheServerAShellEvenWhenTheAppHasNone() async throws {
+        let inherited = ProcessInfo.processInfo.environment["SHELL"]
+        unsetenv("SHELL")
+        setenv("HERDRM_TEST_MARKER", "kept", 1)
+        defer {
+            if let inherited { setenv("SHELL", inherited, 1) }
+            unsetenv("HERDRM_TEST_MARKER")
+        }
+
+        let script = directory.appendingPathComponent("fake-herdr-env")
+        try """
+        #!/bin/sh
+        echo "shell: $(printenv SHELL)"
+        echo "marker: $(printenv HERDRM_TEST_MARKER)"
+        """.write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: script.path)
+
+        let launched = try LocalHerdrServer.spawn(binary: script.path)
+        for _ in 0..<100 where launched.isRunning() {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        let output = launched.output()
+        let shell = try XCTUnwrap(LocalHerdrServer.loginShell())
+        XCTAssertTrue(output.contains("shell: \(shell)"), output)
+        XCTAssertTrue(output.contains("marker: kept"), "the server lost the app's environment: \(output)")
+    }
+
+    func testTwoSpawnsDoNotShareALogFile() async throws {
+        func script(named name: String, saying text: String) throws -> String {
+            let url = directory.appendingPathComponent(name)
+            try "#!/bin/sh\necho \"\(text)\"\n".write(to: url, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+            return url.path
+        }
+
+        let first = try LocalHerdrServer.spawn(binary: try script(named: "fake-a", saying: "first-server"))
+        let second = try LocalHerdrServer.spawn(binary: try script(named: "fake-b", saying: "second-server"))
+        for _ in 0..<100 where first.isRunning() || second.isRunning() {
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+
+        XCTAssertTrue(first.output().contains("first-server"), first.output())
+        XCTAssertFalse(first.output().contains("second-server"), "one spawn truncated the other's log")
+        XCTAssertTrue(second.output().contains("second-server"), second.output())
+    }
+
+    func testServerEnvironmentDropsTheAppsProcessIdentity() {
+        let base = [
+            "__CFBundleIdentifier": "dev.bybee.herdrm",
+            "XPC_SERVICE_NAME": "application.dev.bybee.herdrm.1.2",
+            "XPC_FLAGS": "0x0",
+            "OSLogRateLimit": "1",
+            "MallocNanoZone": "0",
+            "OS_ACTIVITY_DT_MODE": "YES",
+            "DYLD_INSERT_LIBRARIES": "/usr/lib/libLogRedirect.dylib",
+            "DYLD_FRAMEWORK_PATH": "/tmp/frameworks",
+            "PATH": "/usr/bin:/bin",
+            "HOME": "/Users/nobody",
+            "LANG": "en_US.UTF-8",
+        ]
+
+        let environment = LocalHerdrServer.serverEnvironment(base: base)
+
+        for key in ["__CFBundleIdentifier", "XPC_SERVICE_NAME", "XPC_FLAGS", "OSLogRateLimit",
+                    "MallocNanoZone", "OS_ACTIVITY_DT_MODE", "DYLD_INSERT_LIBRARIES", "DYLD_FRAMEWORK_PATH"] {
+            XCTAssertNil(environment[key], "\(key) reached the daemon and every pane under it")
+        }
+        for key in ["PATH", "HOME", "LANG"] {
+            XCTAssertEqual(environment[key], base[key], "the user's \(key) was thrown away")
+        }
+    }
+
+    func testServerEnvironmentFillsInTheLoginShellWhenMissing() throws {
+        let environment = LocalHerdrServer.serverEnvironment(base: ["PATH": "/usr/bin"])
+
+        let shell = try XCTUnwrap(environment["SHELL"], "the server would hand out sh panes")
+        XCTAssertFalse(shell.isEmpty)
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: shell), shell)
+    }
+
+    func testServerEnvironmentKeepsAnExplicitShell() {
+        let environment = LocalHerdrServer.serverEnvironment(base: ["SHELL": "/opt/homebrew/bin/fish"])
+
+        XCTAssertEqual(environment["SHELL"], "/opt/homebrew/bin/fish", "a deliberate SHELL was overwritten")
+    }
+
+    func testServerEnvironmentTreatsAnEmptyShellAsMissing() throws {
+        let environment = LocalHerdrServer.serverEnvironment(base: ["SHELL": ""])
+
+        let shell = try XCTUnwrap(environment["SHELL"])
+        XCTAssertFalse(shell.isEmpty, "an empty SHELL leaves herdr with no shell to pick")
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: shell), shell)
+    }
+
+    func testServerEnvironmentPreservesTheRestOfTheEnvironment() {
+        let base = ["PATH": "/usr/bin:/bin", "HOME": "/Users/nobody", "HERDRM_MARKER": "keep-me"]
+
+        let environment = LocalHerdrServer.serverEnvironment(base: base)
+
+        for (key, value) in base {
+            XCTAssertEqual(environment[key], value, "the server lost \(key) from its environment")
+        }
+    }
+
+    func testLoginShellIsAnExecutableFile() throws {
+        let shell = try XCTUnwrap(LocalHerdrServer.loginShell())
+
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: shell, isDirectory: &isDirectory), shell)
+        XCTAssertFalse(isDirectory.boolValue, "\(shell) is a directory, not a shell")
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: shell), shell)
+    }
+
+    /// The condition the PATH export exists for: an app launched from Finder gets launchd's
+    /// PATH, which has none of the places herdr installs into.
+    func testResolverFindsHerdrUnderLaunchdsPath() throws {
+        let sessionSocket = (NSHomeDirectory() as NSString)
+            .appendingPathComponent(".config/herdr/herdr.sock")
+        try XCTSkipUnless(FileManager.default.fileExists(atPath: sessionSocket), "herdr is not installed here")
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
+        let binary = try XCTUnwrap(
+            LocalHerdrServer.resolveBinary(environment: environment),
+            "herdr is installed but invisible to an app launched from Finder"
+        )
+
+        XCTAssertTrue(binary.hasSuffix("/herdr"), binary)
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: binary), binary)
+    }
+
+    /// `mise use -g herdr` puts the CLI in a shim directory no other install method uses.
+    func testResolverFindsAMiseShimmedHerdr() throws {
+        let shims = directory.appendingPathComponent(".local/share/mise/shims", isDirectory: true)
+        try FileManager.default.createDirectory(at: shims, withIntermediateDirectories: true)
+        let shim = shims.appendingPathComponent("herdr")
+        try "#!/bin/sh\nexit 0\n".write(to: shim, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: shim.path)
+
+        let binary = LocalHerdrServer.resolveBinary(
+            environment: ["PATH": "/usr/bin:/bin", "HOME": directory.path]
+        )
+
+        XCTAssertEqual(binary, shim.path, "a mise-installed herdr is invisible to herdrm")
+    }
+
+    // MARK: - Retry policy
+
+    func testConnectStartsTheLocalServerAndRetriesThePing() async throws {
+        let path = socketPath!
+        let listener = makeListener()
+        let launches = Recorder()
+        let localServer = LocalHerdrServer(
+            binaryPath: { "/fake/herdr" },
+            launcher: { binary in
+                launches.record(binary)
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.1) {
+                    try? listener.start(
+                        at: path,
+                        replyingWith: #"{"id":"1","result":{"version":"0.8.0","protocol":19}}"#
+                    )
+                }
+                return .alive()
+            }
+        )
+        let service = HerdrService(
+            device: Device(name: "Test", kind: .local, socketPath: path),
+            localServer: localServer
+        )
+
+        let pong = try await service.connect()
+
+        XCTAssertEqual(pong.version, "0.8.0")
+        XCTAssertEqual(pong.protocolVersion, 19)
+        XCTAssertEqual(launches.values, ["/fake/herdr"], "the dead socket did not trigger a start")
+    }
+
+    /// Asserted on the wiring rather than through `connect()`: a broken flag would otherwise
+    /// spawn a real `herdr server` against the machine's own socket, not the test's.
+    func testAutoStartIsWiredOnlyForLocalDevicesThatAskedForIt() async {
+        let local = Device(name: "Test", kind: .local, socketPath: socketPath)
+        let remote = Device(name: "Remote", kind: .ssh(target: "nobody@example.invalid"))
+
+        let byDefault = await HerdrService(device: local).autoStartsLocalServer
+        let turnedOff = await HerdrService(device: local, autoStartLocalServer: false).autoStartsLocalServer
+        let overSSH = await HerdrService(device: remote).autoStartsLocalServer
+
+        XCTAssertTrue(byDefault, "the app relies on the default being on")
+        XCTAssertFalse(turnedOff, "the flag did not turn auto-start off")
+        XCTAssertFalse(overSSH, "remote servers are the user's to run")
+    }
+
+    /// A server that answered once and is gone was stopped on purpose (`herdr server stop`,
+    /// or the restart inside `herdr update`). Reviving it would undo that decision.
+    func testNoAutoStartAfterTheServerHasAnsweredOnce() async throws {
+        let path = socketPath!
+        let listener = makeListener()
+        let launches = Recorder()
+        let localServer = LocalHerdrServer(
+            binaryPath: { "/fake/herdr" },
+            launcher: { binary in
+                launches.record(binary)
+                DispatchQueue.global().asyncAfter(deadline: .now() + 0.05) {
+                    try? listener.start(
+                        at: path,
+                        replyingWith: #"{"id":"1","result":{"version":"0.8.0","protocol":19}}"#
+                    )
+                }
+                return .alive()
+            }
+        )
+        let service = HerdrService(
+            device: Device(name: "Test", kind: .local, socketPath: path),
+            localServer: localServer
+        )
+        _ = try await service.connect()
+        XCTAssertEqual(launches.values.count, 1)
+
+        listener.stop()  // as `herdr server stop` does: the socket file outlives the server
+        let error = await captureError { _ = try await service.connect() }
+
+        XCTAssertNotNil(error, "the stopped server was silently restarted")
+        XCTAssertEqual(launches.values.count, 1, "herdrm revived a server the user stopped")
+    }
+
+    func testOnlyADeadServerTriggersAnAutoStart() {
+        XCTAssertTrue(HerdrService.isServerDown(.socketUnavailable("/tmp/herdr.sock")))
+        XCTAssertTrue(HerdrService.isServerDown(.connectionFailed("connect(): Connection refused")))
+        // Everything below proves somebody was on the other end: a second daemon on top of a
+        // live one is how the user's panes get stranded.
+        XCTAssertFalse(HerdrService.isServerDown(.connectionFailed("read(): Resource temporarily unavailable")))
+        XCTAssertFalse(HerdrService.isServerDown(.connectionFailed("write(): Broken pipe")))
+        XCTAssertFalse(HerdrService.isServerDown(.connectionFailed("socket(): Too many open files")))
+        XCTAssertFalse(HerdrService.isServerDown(.connectionFailed("connect(): Permission denied")))
+        XCTAssertFalse(HerdrService.isServerDown(.connectionFailed("not connected")))
+        XCTAssertFalse(HerdrService.isServerDown(.rpc(code: "unknown_method", message: "nope")))
+        XCTAssertFalse(HerdrService.isServerDown(.malformedResponse("empty reply")))
+        XCTAssertFalse(HerdrService.isServerDown(.incompatibleProtocol(3)))
+        XCTAssertFalse(HerdrService.isServerDown(.tunnelFailed("ssh exited 255")))
+        XCTAssertFalse(HerdrService.isServerDown(.herdrNotInstalled))
+    }
+
+    // MARK: - Helpers
+
+    private func makeListener() -> FakeListener {
+        let listener = FakeListener()
+        listeners.append(listener)
+        return listener
+    }
+
+    /// XCTAssertThrowsError has no async form; the failure tests need the error itself.
+    private func captureError(_ body: () async throws -> Void) async -> Error? {
+        do {
+            try await body()
+            return nil
+        } catch {
+            return error
+        }
+    }
+}
+
+private extension LocalHerdrServer.Launched {
+    /// A process that is still up and has said nothing — the normal state while starting.
+    static func alive() -> Self {
+        .init(isRunning: { true }, output: { "" })
+    }
+}
+
+/// A real listening Unix socket: the probe under test does a real `connect()`, so a stub
+/// would prove nothing. `replyingWith` additionally answers one NDJSON line per connection,
+/// which is all a `ping` needs. Started from background queues, hence the lock.
+private final class FakeListener: @unchecked Sendable {
+    private let lock = NSLock()
+    private var fd: Int32 = -1
+    private var reply: String?
+
+    /// Binds and listens, clearing any orphaned socket file first — as herdr itself does.
+    func start(at path: String, replyingWith reply: String? = nil) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        guard fd < 0 else { return }
+        self.reply = reply
+        try? FileManager.default.removeItem(atPath: path)
+        let sock = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard sock >= 0 else { throw HerdrError.connectionFailed("socket(): \(String(cString: strerror(errno)))") }
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let bytes = Array(path.utf8)
+        guard bytes.count < MemoryLayout.size(ofValue: addr.sun_path) else {
+            close(sock)
+            throw HerdrError.connectionFailed("socket path too long")
+        }
+        withUnsafeMutableBytes(of: &addr.sun_path) { $0.copyBytes(from: bytes) }
+        let len = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let bound = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { Darwin.bind(sock, $0, len) }
+        }
+        guard bound == 0, Darwin.listen(sock, 4) == 0 else {
+            let reason = String(cString: strerror(errno))
+            close(sock)
+            throw HerdrError.connectionFailed("listen(\(path)): \(reason)")
+        }
+        fd = sock
+        if reply != nil { serve(on: sock) }
+    }
+
+    /// Closes the listener but leaves the socket file behind — the stale-socket fixture.
+    func stop() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard fd >= 0 else { return }
+        close(fd)
+        fd = -1
+    }
+
+    /// One NDJSON reply per connection; the accept loop ends when `stop()` closes the socket.
+    private func serve(on sock: Int32) {
+        Thread.detachNewThread { [weak self] in
+            while true {
+                let connection = accept(sock, nil, nil)
+                guard connection >= 0 else { return }
+                // A peer may hang up before the reply (the liveness probe does exactly
+                // that); writing into a closed connection would SIGPIPE the test process.
+                var noSignal: Int32 = 1
+                setsockopt(connection, SOL_SOCKET, SO_NOSIGPIPE, &noSignal, socklen_t(MemoryLayout<Int32>.size))
+                var request = [UInt8](repeating: 0, count: 4_096)
+                let received = read(connection, &request, request.count)
+                if received > 0, var line = self?.replyLine.map({ Array(($0 + "\n").utf8) }) {
+                    _ = write(connection, &line, line.count)
+                }
+                close(connection)
+            }
+        }
+    }
+
+    private var replyLine: String? {
+        lock.lock()
+        defer { lock.unlock() }
+        return reply
+    }
+}
+
+/// A thread-safe one-way switch, for fakes that change state from a background queue.
+private final class Flag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var raised = false
+
+    func set() {
+        lock.lock()
+        defer { lock.unlock() }
+        raised = true
+    }
+
+    var value: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return raised
+    }
+}
+
+/// Records what the injected launcher was asked to run, from whichever thread calls it.
+private final class Recorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [String] = []
+
+    func record(_ value: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        recorded.append(value)
+    }
+
+    var values: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return recorded
+    }
+}

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
@@ -25,7 +25,7 @@ final class LocalSocketTests: XCTestCase {
 
     func testServiceConnectSnapshotAndLists() async throws {
         try requireLocalHerdr()
-        let service = HerdrService(device: .local)
+        let service = HerdrService(device: .local, autoStartLocalServer: false)
         _ = try await service.connect()
 
         let snapshot = try await service.snapshot()
@@ -103,7 +103,7 @@ final class LocalSocketTests: XCTestCase {
 
     func testEventStreamDeliversTabLifecycle() async throws {
         try requireLocalHerdr()
-        let service = HerdrService(device: .local)
+        let service = HerdrService(device: .local, autoStartLocalServer: false)
         _ = try await service.connect()
         let stream = try await service.events()
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ working, blocked, or done. **herdrm** puts a native macOS window on top of it:
 ## Requirements
 
 - macOS 14+
-- [herdr](https://herdr.dev) running locally and/or on your remote machines
+- [herdr](https://herdr.dev) installed locally (herdrm starts the local server
+  itself if it isn't running) and running on your remote machines
 - For remote devices: OpenSSH access through your SSH config/agent, Tailscale
   SSH, or a password stored in the macOS login Keychain
 


### PR DESCRIPTION
Opening herdrm before the herdr server is up shows `herdr socket not found at ~/.config/herdr/herdr.sock`, and the only way out is to switch to a terminal and run `herdr` once. This starts it for you: when a local ping finds nothing listening, `HerdrService` locates the CLI, spawns `herdr server`, and pings again.

Everything lives in `HerdrKit` — `Sources/HerdrM/` is untouched, and the existing `.connecting` state in `AppModel.startSession` covers the wait (0.16 s from cold on my machine).

### The three ways this could have gone wrong

The server is a shared daemon holding every agent's PTY, so most of the work here is about *not* doing damage:

**It is started, never owned.** Nothing terminates the process and there is no counterpart to `SSHTunnel.tearDown()` — quitting herdrm leaves the user's agents running. Verified: the spawned server reparents to launchd (PPID 1).

**It only fills a gap, it never undoes a decision.**
- A server that answered once in this session and is gone now was stopped on purpose — `herdr server stop`, or the restart inside `herdr update`, whose bind race herdrm must not win. The auto-start is skipped in that case. The guard is per `HerdrService` instance rather than per process so that Reconnect and the backoff loop can still start a server for someone who installed or repaired herdr *after* opening the app.
- Only a missing socket, or a `connect()` refused, counts as "no server". `SocketRPC` reports a failed `read()` (the 15 s timeout — a hung but *live* server), `write()` and `socket()` through the same `connectionFailed` case, and each of those proves somebody was on the other end.
- An existing socket file is re-probed for up to a second before concluding anything. A healthy server whose accept queue filled up momentarily also answers `ECONNREFUSED`, and `herdr server` reacts to a refused socket by unlinking it and binding its own. That would strand the running server with all of the user's panes, unreachable and invisible to `herdr server stop`. A full backlog drains in milliseconds; a stale socket stays dead forever. No socket file means no ambiguity, so the common case pays no extra latency.

**The environment it gets is the user's, not the app's.** This one bit me while testing and is easy to miss: launchd doesn't export `SHELL` (`launchctl getenv SHELL` is empty), and herdr picks each pane's shell from `$SHELL`. A server spawned from a GUI app therefore hands you `sh` panes instead of your login shell — no `.zshrc`, and none of the agents installed under `~/.local/bin` on `PATH`. Measured on the same machine, same herdr:

| server started from | pane shell | `command -v claude` |
|---|---|---|
| a terminal (status quo) | zsh | `~/.local/bin/claude` |
| a GUI-like environment | **sh** | **not found** |
| GUI-like + `SHELL` from `getpwuid` | zsh | `~/.local/bin/claude` |

So `SHELL` is filled in from the password database when the environment has none (an explicit one is never overwritten). In the other direction, the app's own process identity is dropped rather than inherited by every pane: `__CFBundleIdentifier`, `XPC_SERVICE_NAME`, `XPC_FLAGS`, `DYLD_*`, `MallocNanoZone`, `OS_ACTIVITY_DT_MODE`. Otherwise every pane runs under herdrm's bundle identity, which is what `defaults` and TCC grants key off — and a debug build would bake Xcode's `DYLD_INSERT_LIBRARIES` into a daemon that outlives Xcode.

Finding the CLI reuses `SSHTunnel.remotePathExport` (a Finder-launched app inherits no login-shell PATH) plus mise's shim directory, since `mise use -g herdr` is one of the documented install paths. `remotePathExport` itself is left alone — it's shared with the tunnel and the terminal attach, where that directory would belong to the remote user.

### Scope and opt-out

Local devices only; remotes are unchanged and still yours to run. `HerdrService.init` takes `autoStartLocalServer: Bool = true`, so it can be surfaced in Settings later, and the default keeps the app working with no changes on its side. The two `LocalSocketTests` that connect to the real socket now pass `false` — otherwise a stale socket file would let the suite start a real server on the developer's machine.

### Verification, and what I could not verify

`swift build` is clean with no warnings. The 23 new tests are hermetic (real Unix sockets in a temp dir, injected launcher) and none of them touches `~/.config/herdr` or starts a real herdr, not even in their failure mode. Each one was checked by mutation — 30 mutations, each compiling and reverted after, all killed by at least one test.

End to end against the real CLI, from a GUI-like environment (`env -i`, no `SHELL`, launchd's PATH): cold start connects in 0.16 s; the daemon survives as PPID 1; its panes come up as zsh with `claude` on PATH; after a deliberate `herdr server stop` the same service refuses to resurrect it; and the pruned variables are absent from the running daemon's environment while an unrelated marker variable survives.

**`make kit-test` and `make build` were not run**: this machine has Command Line Tools only, so there is no `XCTest` (`swift test` can't compile) and no `xcodebuild`. I verified the new tests by compiling the exact test file against an XCTest shim and running each case, but please run `make kit-test` on a machine with Xcode before merging.

No `CHANGELOG.md` entry, following #3 and #6 — happy to add one if you'd rather have it in the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
