### PR TITLE
feat(ui): ⌘N for new agent, ⇧⌘N for new space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Added
+- File menu commands with keyboard shortcuts: **New Agent** (⌘N) and **New
+  Space** (⇧⌘N), reachable while the focus is inside an agent's terminal.
+  ⌘N replaces *New Window* — herdrm is a single-window console, so a second
+  window would only duplicate the device tree.
+
 ## [0.3.0] - 2026-08-19
 
 ### Added

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -47,6 +47,7 @@ struct RootView: View {
                 .keyboardShortcut("k", modifiers: .command)
                 .hidden()
         )
+        .focusedSceneValue(\.appModel, model)
         .sheet(isPresented: $model.showSearch) { SearchSheet(model: model) }
         .ignoresSafeArea(.container, edges: .top)
         .frame(minWidth: 980, minHeight: 620)

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -5,9 +5,21 @@ import Sparkle
 import SwiftUI
 import UserNotifications
 
+private struct AppModelFocusedValueKey: FocusedValueKey {
+    typealias Value = AppModel
+}
+
+extension FocusedValues {
+    var appModel: AppModel? {
+        get { self[AppModelFocusedValueKey.self] }
+        set { self[AppModelFocusedValueKey.self] = newValue }
+    }
+}
+
 @main
 struct HerdrMApp: App {
     @AppStorage("app.theme") private var themePreference = "system"
+    @FocusedValue(\.appModel) private var focusedModel
 
     private let updaterController: SPUStandardUpdaterController
 
@@ -34,6 +46,17 @@ struct HerdrMApp: App {
         .windowStyle(.hiddenTitleBar)
         .windowToolbarStyle(.unified(showsTitle: false))
         .commands {
+            // herdrm is a single-window console: a second window would duplicate the
+            // whole device tree, so New Window gives up ⌘N to the action that matters.
+            CommandGroup(replacing: .newItem) {
+                Button("New Agent") { focusedModel?.showNewAgent = true }
+                    .keyboardShortcut("n", modifiers: .command)
+                    .disabled(focusedModel == nil)
+                Button("New Space") { focusedModel?.showNewSpace = true }
+                    .keyboardShortcut("n", modifiers: [.command, .shift])
+                    .disabled(focusedModel == nil)
+            }
+
             CommandGroup(after: .appInfo) {
                 Button("Check for Updates…") {
                     updaterController.checkForUpdates(nil)


### PR DESCRIPTION
Adds two File-menu commands so you can start work without leaving the keyboard:

- **New Agent** — ⌘N
- **New Space** — ⇧⌘N

Both work while the focus is inside an agent's terminal, which is the app's normal state.

## Why not the hidden-button pattern

`ContentView.swift` wires ⌘B and ⌘K as hidden `Button(…).keyboardShortcut(…)` in a `.background`.
Copying that for ⌘N does not work:

1. `WindowGroup` makes macOS inject *File ▸ New Window* with **⌘N already assigned**.
2. AppKit's main menu resolves its key equivalents **before** the view hierarchy's
   `performKeyEquivalent`, so the menu wins ⌘N over a hidden button.
3. SwiftTerm's `keyDown` sends every `.command` event to `interpretKeyEvents` and returns without
   propagating — and the terminal is this app's usual first responder. ⌘B/⌘K survive only because
   they resolve one step earlier; anything relying on the responder chain walks that edge.

Going through the menu avoids all three, and the shortcuts become discoverable — they show up in
the File menu with their key equivalents written out, which the hidden buttons never did.

## Heads-up: this replaces *New Window*

⌘N is taken from *File ▸ New Window* via `CommandGroup(replacing: .newItem)`. Flagging it up front
since it's the debatable part:

- herdrm is a single-window console. The sidebar already aggregates Spaces and Agents across *all*
  devices and the right pane is one attached terminal, so a second window shows nothing the first
  doesn't — it just duplicates the whole tree, and with it the connections and the `DeviceStore`.
- The `WindowGroup` is already configured as a single app window (`.hiddenTitleBar`,
  `.windowToolbarStyle(.unified(showsTitle: false))`), not as a document window.
- In an agent console, "New Agent" *is* the canonical new-thing action, and ⌘N is where a macOS
  user looks first.

I considered moving *New Window* to ⌥⌘N instead, but that trades a non-standard shortcut for a
window that duplicates the tree. Happy to do it that way if you'd rather keep New Window.

## Implementation

`RootView` owns the model as `@StateObject`, so a scene-level `CommandGroup` can't reach it. A
`FocusedValueKey` bridges the gap — using **`focusedSceneValue`**, not `focusedValue`: the latter
is only populated while *that view* holds focus, and in this app focus sits in the terminal, which
would break the main case.

`.disabled(focusedModel == nil)` greys the items out when no window is focused (Settings-only, or
the app in the background with the window closed) rather than leaving them a silent no-op.

## Verification

- `xcodegen generate` + Debug build: **BUILD SUCCEEDED**
- `cd Packages/HerdrKit && swift test`: **36 tests, 0 failures** (4 SSH E2E skipped, no target set)
- Manually: with an agent attached and the caret inside the terminal, ⌘N opens the New Agent sheet
  and ⇧⌘N opens New Space.

Three files, +30 lines. No changes to `project.yml`, signing, or the build. CHANGELOG entry added
under `## [Unreleased]` → `### Added`.