### PR TITLE
fix: tear down SSH tunnels when the app quits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Fixed
+- SSH tunnels are torn down when the app quits. Each launch used to leave its
+  `ssh` processes running (reparented to `launchd`) and their forwarded sockets
+  in place, so tunnels piled up across quit/relaunch cycles.
+
 ## [0.3.0] - 2026-08-19
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
@@ -93,6 +93,9 @@ public actor SSHTunnel {
         let errorOutput = Pipe()
         proc.standardOutput = FileHandle.nullDevice
         proc.standardError = errorOutput
+        // The probe above can suspend for seconds; if the session was cancelled meanwhile
+        // (app quitting), spawning here would leak an ssh nobody is left to tear down.
+        try Task.checkCancellation()
         try proc.run()
         process = proc
 

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -267,6 +267,18 @@ final class AppModel: ObservableObject {
         }
     }
 
+    /// Tears down every live tunnel. Awaited from the app's terminate hook — `stopSession`
+    /// fires its disconnect in a detached `Task`, which never runs when the process is exiting.
+    func shutdownAllSessions() async {
+        let live = services
+        services.removeAll()
+        sessionTasks.values.forEach { $0.cancel() }
+        sessionTasks.removeAll()
+        for service in live.values {
+            await service.disconnect()
+        }
+    }
+
     private func stopSession(_ id: UUID) {
         sessionTasks[id]?.cancel()
         sessionTasks[id] = nil

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -2,7 +2,8 @@ import HerdrKit
 import SwiftUI
 
 struct RootView: View {
-    @StateObject private var model = AppModel()
+    // Owned by AppDelegate so it outlives the window — see AppDelegate in HerdrMApp.swift.
+    @ObservedObject var model: AppModel
     // Deliberately not persisted: the app always launches with the sidebar visible.
     @State private var sidebarCollapsed = false
 

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -5,8 +5,29 @@ import Sparkle
 import SwiftUI
 import UserNotifications
 
+/// Holds app termination open long enough to tear the SSH tunnels down: without
+/// `.terminateLater` the process dies before the teardown task gets to run, and the
+/// `ssh` children survive with PPID 1 along with their sockets.
+///
+/// The delegate owns the model rather than borrowing it from the window: closing the
+/// last window (⌘W) would otherwise drop the only strong reference, and the quit that
+/// follows would find nothing left to tear down.
+@MainActor
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    let model = AppModel()
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        Task { @MainActor in
+            await model.shutdownAllSessions()
+            sender.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
+    }
+}
+
 @main
 struct HerdrMApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @AppStorage("app.theme") private var themePreference = "system"
 
     private let updaterController: SPUStandardUpdaterController
@@ -25,7 +46,7 @@ struct HerdrMApp: App {
 
     var body: some Scene {
         WindowGroup {
-            RootView()
+            RootView(model: appDelegate.model)
                 .onAppear { Self.applyTheme(themePreference) }
                 .onChange(of: themePreference) { _, newValue in
                     Self.applyTheme(newValue)


### PR DESCRIPTION
## The bug

Quitting herdrm leaves its SSH tunnels behind. Every launch adds another `ssh -N`
that keeps running — reparented to `launchd` — with its forwarded socket still
live in `$TMPDIR/herdrm-tunnels`, so they pile up across quit/relaunch cycles.

Measured on 0.3.0 before the fix:

```
before quit   app 46985   ssh 46999 (ppid=46985)
after  quit   app gone    ssh 46999 (ppid=1)     ← still connected to the server
```

The socket stays usable (`nc -U …` connects), so the tunnel is alive and
functional with no app behind it. One of them had been orphaned for 56 minutes
when I measured it.

## Why it happens

The cleanup code already exists and is correct — nothing calls it on the way out.
`SSHTunnel.tearDown()` kills the process and removes the socket,
`HerdrService.disconnect()` calls it, and `AppModel.stopSession(_:)` chains it
properly — but only when the user disconnects a device by hand. There is no
termination hook in the app.

`SSHTunnel`'s `deinit { process?.terminate() }` doesn't save it: when a process
exits, objects that are still retained are never deallocated, so that `deinit`
never runs. The code looks covered when it isn't.

## The fix

An `AppDelegate` holds termination open with `.terminateLater` while every live
service disconnects, then replies. Reusing `stopSession`'s fire-and-forget
`Task { await service?.disconnect() }` would not work here — the process dies
before the task gets to run, which is the bug itself.

Two details worth flagging for review:

- **The delegate owns the `AppModel`** instead of borrowing it from the window.
  With a `weak` reference to the view's `@StateObject`, closing the last window
  (⌘W) drops the only strong reference, and the quit that follows finds nothing
  left to tear down — the leak comes back silently. `RootView` now takes the
  model instead of creating it, which also matches the app being a single-window
  console: one model, not one per window.
- **`ensureUp` checks for cancellation before spawning.** Its remote probe can
  suspend for seconds; if the app quits during that window, the teardown runs,
  the probe then resumes and spawns a tunnel nobody is left to close.

If the teardown ever hangs, macOS terminates the app anyway after its own
timeout, so this cannot make the app unquittable.

## Verification

Built Debug, `swift test` 36 tests / 0 failures, and the `RemoteSSHTests` E2E
suite against a real remote host, 0 failures.

Behaviour measured by hand against a connected SSH device, since there is no UI
harness for this:

| | tunnel after quit | socket |
|---|---|---|
| before the fix (control) | survives, `ppid=1` | left behind |
| after the fix, plain ⌘Q | gone | removed |
| after the fix, ⌘W then ⌘Q | gone | removed |

Three consecutive open/quit cycles leave **0** accumulated `ssh` processes, so
it isn't one lucky shutdown. A legitimate tunnel has `ppid` = the app's pid; an
orphan has `ppid=1`, which makes `ps -Ao pid,ppid,command | grep herdrm-tunnels`
an unambiguous check.

## Not covered

An external `SIGTERM` (`killall`) and `SIGKILL`/Force Quit don't go through the
delegate — a Cocoa app can't handle those. Sweeping pre-existing orphans at
launch is deliberately left out: killing stray `ssh` processes at startup could
kill those of another legitimate herdrm instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)