### PR TITLE
feat: Shift+Enter inserts a line break in the agent terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Added
+- Shift+Enter in the agent terminal inserts a line break instead of submitting
+  — sent as ESC+CR, which coding-agent TUIs already understand. Inert when a
+  TUI negotiates the kitty keyboard protocol (it already distinguishes the
+  modifier).
+
 ## [0.3.0] - 2026-08-19
 
 ### Added

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -25,6 +25,30 @@ enum TerminalDefaults {
     }
 }
 
+/// Sends ESC CR for Shift+Return so agent TUIs insert a line break instead of
+/// submitting: legacy terminal encoding sends the same bare `\r` for Enter and
+/// Shift+Enter, so the modifier never reaches the TUI. SwiftTerm's `keyDown`
+/// and `doCommand` are public, not open, so `interpretKeyEvents` is the only
+/// hook a subclass can take — and it only sees Return in legacy mode, leaving
+/// this inert when a TUI negotiates the kitty keyboard protocol.
+final class LineBreakTerminalView: LocalProcessTerminalView {
+    override func interpretKeyEvents(_ eventArray: [NSEvent]) {
+        if eventArray.count == 1,
+           let event = eventArray.first,
+           event.type == .keyDown,
+           event.keyCode == 36 || event.keyCode == 76,  // Return, keypad Enter
+           !hasMarkedText() {
+            let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            if modifiers.contains(.shift),
+               modifiers.isDisjoint(with: [.command, .control, .option]) {
+                send(txt: "\u{1b}\r")
+                return
+            }
+        }
+        super.interpretKeyEvents(eventArray)
+    }
+}
+
 /// Embeds a SwiftTerm terminal running `herdr agent attach` (directly or over ssh).
 struct AttachTerminalView: NSViewRepresentable {
     let device: Device
@@ -40,7 +64,7 @@ struct AttachTerminalView: NSViewRepresentable {
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> LocalProcessTerminalView {
-        let view = LocalProcessTerminalView(frame: .zero)
+        let view = LineBreakTerminalView(frame: .zero)
         view.processDelegate = context.coordinator
         configureAppearance(view)
 


### PR DESCRIPTION
## Problem

Shift+Enter in the embedded terminal submits instead of breaking the line. In legacy terminal encoding, Enter and Shift+Enter both send the same bare `\r`, so the modifier is discarded before the agent TUI ever sees it — nothing in `AttachTerminalView` distinguishes them today.

## Fix

A small `LocalProcessTerminalView` subclass (`LineBreakTerminalView`) intercepts Shift+Return / Shift+keypad-Enter and sends `ESC CR` (`\x1b\r`) — the sequence coding-agent TUIs (Claude Code and other Ink-based UIs, codex, etc.) already treat as "insert newline". Plain Enter is untouched.

Why `interpretKeyEvents` and not `keyDown`: SwiftTerm declares `keyDown(with:)` and `doCommand(by:)` as `public`, not `open`, so they can't be overridden outside SwiftTerm's module. `interpretKeyEvents(_:)` is NSResponder's (open), SwiftTerm never redeclares it, and SwiftTerm's `keyDown` funnels Return through it — in legacy mode only. Two properties fall out of that for free:

- **Inert under the kitty keyboard protocol**: when a TUI negotiates it, SwiftTerm encodes Shift+Enter itself and returns before `interpretKeyEvents`, so this hook never fires.
- **IME-safe**: guarded by `hasMarkedText()`, so composition still confirms with Enter as usual.

## Testing

Built with `make build` and verified against a live agent on macOS: Shift+Enter breaks the line in the Claude input box, plain Enter still submits, IME composition unaffected.

CHANGELOG entry added under `[Unreleased]` per the release-automation requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)