### PR TITLE
fix: report "herdr isn't running on <host>" instead of "malformed response: empty reply"

### DIFF
--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -42,7 +42,16 @@ public actor HerdrService {
             socketPath = try await tunnel.ensureUp()
         }
         let client = SocketRPC(socketPath: socketPath)
-        let pong = try await ping(client, socketPath: socketPath)
+        let pong: PingResult
+        do {
+            pong = try await ping(client, socketPath: socketPath)
+        } catch let error as HerdrError where Self.isSilentForward(error) {
+            guard let tunnel, let diagnosis = await tunnel.diagnoseSilentForward() else {
+                throw error
+            }
+            await tunnel.tearDown()
+            throw diagnosis
+        }
         guard pong.protocolVersion >= Self.minimumProtocolVersion else {
             throw HerdrError.incompatibleProtocol(pong.protocolVersion)
         }
@@ -89,6 +98,17 @@ public actor HerdrService {
             return reason.contains("connect():") && reason.contains("Connection refused")
         default: return false
         }
+    }
+
+    /// The shape a dead SSH forward takes: the tunnel is up, ssh accepts the local
+    /// connection, fails to open the remote side, and closes it — the first read hits
+    /// EOF and the reply comes back empty. Matched on the text
+    /// `SocketRPC.decodeResponse` builds, the way `isServerDown` matches `connect()`'s
+    /// wording. Everything else proves somebody replied (or the local socket itself
+    /// failed) and must surface unchanged.
+    static func isSilentForward(_ error: HerdrError) -> Bool {
+        if case .malformedResponse("empty reply") = error { return true }
+        return false
     }
 
     public func disconnect() async {

--- a/Packages/HerdrKit/Sources/HerdrKit/Models.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/Models.swift
@@ -166,6 +166,7 @@ public enum HerdrError: Error, LocalizedError, Sendable {
     case socketUnavailable(String)
     case connectionFailed(String)
     case herdrNotInstalled
+    case remoteHerdrDown(target: String, socketPath: String)
     case rpc(code: String, message: String)
     case malformedResponse(String)
     case incompatibleProtocol(Int)
@@ -176,6 +177,8 @@ public enum HerdrError: Error, LocalizedError, Sendable {
         case .socketUnavailable(let path): return "herdr socket not found at \(path)"
         case .connectionFailed(let reason): return "connection failed: \(reason)"
         case .herdrNotInstalled: return "herdr not found on herdrm's PATH — install it with \"brew install herdr\""
+        case .remoteHerdrDown(let target, let socketPath):
+            return "herdr isn't running on \(target) — nothing listens at \(socketPath); start it by running \"herdr\" on that machine"
         case .rpc(let code, let message): return "herdr error \(code): \(message)"
         case .malformedResponse(let reason): return "malformed response: \(reason)"
         case .incompatibleProtocol(let version): return "herdr protocol \(version) is too old (need >= 17)"

--- a/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
@@ -124,6 +124,52 @@ public actor SSHTunnel {
         localSocketPath = nil
     }
 
+    // MARK: - Silent-forward diagnosis
+
+    /// Explains a forward that answers with silence: ssh accepted the local connection,
+    /// failed to open the far side, and closed it, so the first read hit EOF before any
+    /// reply. The session itself is fine — the home probe and the tunnel both came up —
+    /// which points at the remote end of the forward. One extra round-trip tells the two
+    /// cases apart: no socket file (herdr isn't running over there, by far the common
+    /// case) vs a socket that exists but stays mute. OpenSSH's own stderr can't be
+    /// relied on here: a stock remote sshd reports the failed channel as just
+    /// "connect failed: open failed", and when the user's ssh config muxes the
+    /// connection (ControlMaster), the message lands on the master's stderr, not ours.
+    public func diagnoseSilentForward() async -> HerdrError? {
+        guard let remoteSock = try? await remoteSocketPath(),
+              let output = try? await Self.runSSH(
+                  target: target,
+                  command: "test -S \"\(remoteSock)\" && echo exists || echo missing",
+                  timeout: 10,
+                  credentialID: credentialID
+              )
+        else { return nil }
+        return Self.silentForwardDiagnosis(
+            probeOutput: output,
+            target: target,
+            remoteSocketPath: remoteSock
+        )
+    }
+
+    static func silentForwardDiagnosis(
+        probeOutput: String,
+        target: String,
+        remoteSocketPath: String
+    ) -> HerdrError? {
+        switch probeOutput.trimmingCharacters(in: .whitespacesAndNewlines) {
+        case "missing":
+            return .remoteHerdrDown(target: target, socketPath: remoteSocketPath)
+        case "exists":
+            return .tunnelFailed(
+                "\(remoteSocketPath) exists on \(target) but forwarded connections get no reply"
+                    + " — herdr may have left a stale socket, or sshd forbids Unix-socket"
+                    + " forwards (AllowStreamLocalForwarding)"
+            )
+        default:
+            return nil
+        }
+    }
+
     /// Sniffs the remote OS: "macos", an os-release ID like "ubuntu"/"debian", or a uname fallback.
     public static func probeOS(target: String, credentialID: UUID? = nil) async throws -> String {
         let command = """

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalServerTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalServerTests.swift
@@ -464,6 +464,9 @@ final class LocalServerTests: XCTestCase {
         XCTAssertFalse(HerdrService.isServerDown(.incompatibleProtocol(3)))
         XCTAssertFalse(HerdrService.isServerDown(.tunnelFailed("ssh exited 255")))
         XCTAssertFalse(HerdrService.isServerDown(.herdrNotInstalled))
+        XCTAssertFalse(HerdrService.isServerDown(
+            .remoteHerdrDown(target: "vincent@10.10.10.87", socketPath: "/home/vincent/.config/herdr/herdr.sock")
+        ))
     }
 
     // MARK: - Helpers

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SilentForwardTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SilentForwardTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import HerdrKit
+
+final class SilentForwardTests: XCTestCase {
+    func testOnlyAnEmptyReplyReadsAsASilentForward() {
+        XCTAssertTrue(HerdrService.isSilentForward(.malformedResponse("empty reply")))
+        // Everything below proves somebody replied (or the local socket itself failed);
+        // replacing those errors with a forward diagnosis would hide the real failure.
+        XCTAssertFalse(HerdrService.isSilentForward(.malformedResponse("undecodable reply")))
+        XCTAssertFalse(HerdrService.isSilentForward(.connectionFailed("connect(): Connection refused")))
+        XCTAssertFalse(HerdrService.isSilentForward(.socketUnavailable("/tmp/herdr.sock")))
+        XCTAssertFalse(HerdrService.isSilentForward(.rpc(code: "unknown_method", message: "nope")))
+        XCTAssertFalse(HerdrService.isSilentForward(.tunnelFailed("ssh exited 255")))
+        XCTAssertFalse(HerdrService.isSilentForward(.incompatibleProtocol(3)))
+    }
+
+    func testMissingRemoteSocketMeansHerdrIsDownOverThere() throws {
+        let error = try XCTUnwrap(SSHTunnel.silentForwardDiagnosis(
+            probeOutput: "missing\n",
+            target: "vincent@10.10.10.87",
+            remoteSocketPath: "/home/vincent/.config/herdr/herdr.sock"
+        ))
+        guard case .remoteHerdrDown(let target, let socketPath) = error else {
+            return XCTFail("expected remoteHerdrDown, got \(error)")
+        }
+        XCTAssertEqual(target, "vincent@10.10.10.87")
+        XCTAssertEqual(socketPath, "/home/vincent/.config/herdr/herdr.sock")
+    }
+
+    func testExistingButMuteSocketBlamesTheForwardInstead() throws {
+        let error = try XCTUnwrap(SSHTunnel.silentForwardDiagnosis(
+            probeOutput: " exists\n",
+            target: "vincent@10.10.10.87",
+            remoteSocketPath: "/home/vincent/.config/herdr/herdr.sock"
+        ))
+        guard case .tunnelFailed(let reason) = error else {
+            return XCTFail("expected tunnelFailed, got \(error)")
+        }
+        XCTAssertTrue(reason.contains("AllowStreamLocalForwarding"))
+    }
+
+    func testUnrecognizedProbeOutputStaysUndiagnosed() {
+        // e.g. a login shell that chokes on the probe; the original error must surface.
+        XCTAssertNil(SSHTunnel.silentForwardDiagnosis(
+            probeOutput: "zsh: command not found: test",
+            target: "vincent@10.10.10.87",
+            remoteSocketPath: "/home/vincent/.config/herdr/herdr.sock"
+        ))
+    }
+}


### PR DESCRIPTION
## What happens today

Add a remote device whose machine has no herdr running and the connection fails with `malformed response: empty reply`. Nothing in that message points at the machine; I spent a while suspecting my ssh alias, and the alias was fine.

The chain: the home probe succeeds, the tunnel comes up, ssh creates the local socket. On the first ping ssh fails to open the remote side of the forward and closes the connection; `SocketRPC` reads EOF before any bytes and reports the reply as empty.

## Why not parse ssh's stderr

Two things I measured against a stock macOS remote (OpenSSH 10.3 on the far end):

- the client logs the failed channel as `channel 1: open failed: connect failed: open failed`; the useful reason never makes it across.
- when the user's ssh config muxes the host (ControlMaster), the message lands on the mux master's stderr, not on the ssh process herdrm spawned; the captured pipe stays empty.

Related: #16 takes the stderr route. The two can compose; this one covers the cases where stderr says nothing usable.

## What this PR does

When the first ping on a fresh SSH tunnel reads EOF, run one probe over the existing target (`test -S` on the remote socket path) and report what it finds:

- socket missing: the new `HerdrError.remoteHerdrDown`, rendered as `herdr isn't running on <target> — nothing listens at <path>; start it by running "herdr" on that machine`, kept as its own case so the UI can special-case it later
- socket present but mute: a `tunnelFailed` naming the stale-socket and `AllowStreamLocalForwarding` suspects
- probe inconclusive (a login shell that chokes on it): the original error surfaces unchanged

The failed tunnel is torn down before rethrowing, so the reconnect loop starts clean.

## Validation

- `swift build`; new unit tests in `SilentForwardTests` cover the probe-output mapping and the error-shape matching, and the `isServerDown` table in `LocalServerTests` gains the new case
- live against a Mac mini with no herdr installed, through an ssh alias and through `user@host`: before, `malformed response: empty reply`; after, the message above
- live against the same host with a scratch NDJSON responder bound at `~/.config/herdr/herdr.sock`: connect and ping succeed through the same alias, so the happy path is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LkfR46dSiw29FrqQhjSoU
