### PR TITLE
feat: inline directory browser in the New Space sheet

### DIFF
--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -210,6 +210,49 @@ public actor HerdrService {
         }
     }
 
+    /// "~" and "~/…" resolve against this device's home; anything else passes through.
+    public func absolutePath(_ path: String) async throws -> String {
+        if path == "~" { return try await homeDirectory() }
+        if path.hasPrefix("~/") { return try await homeDirectory() + "/" + path.dropFirst(2) }
+        return path
+    }
+
+    /// The visible subdirectories of a directory on this device ("~"-relative paths
+    /// allowed), sorted the way Finder sorts. Feeds the New Space directory browser.
+    /// Throws when the directory can't be read — callers decide how quiet to be.
+    public func listDirectories(at path: String) async throws -> [String] {
+        let absolute = try await absolutePath(path)
+        let names: [String]
+        switch device.kind {
+        case .local:
+            let manager = FileManager.default
+            names = try manager.contentsOfDirectory(atPath: absolute).filter { name in
+                guard !name.hasPrefix(".") else { return false }
+                var isDirectory: ObjCBool = false
+                // fileExists follows symlinks, so a linked project directory still lists.
+                return manager.fileExists(atPath: "\(absolute)/\(name)", isDirectory: &isDirectory)
+                    && isDirectory.boolValue
+            }
+        case .ssh(let target):
+            let output = try await SSHTunnel.runSSH(
+                target: target,
+                command: "cd \(Self.shellQuoted(absolute)) && LC_ALL=C ls -1p",
+                timeout: 15,
+                credentialID: device.id
+            )
+            names = output.split(separator: "\n").compactMap { line in
+                line.hasSuffix("/") ? String(line.dropLast()) : nil
+            }
+        }
+        return names.sorted { $0.localizedStandardCompare($1) == .orderedAscending }
+    }
+
+    /// Wraps a path for the remote shell. Single quotes so nothing inside expands;
+    /// the quote dance survives sh, zsh, and fish login shells alike.
+    static func shellQuoted(_ path: String) -> String {
+        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+
     /// Creates a workspace (herdr "space") rooted at a directory.
     /// Returns its id and the root pane (a bare shell terminal).
     public func createWorkspace(label: String?, cwd: String?) async throws -> (workspaceID: String, rootPaneID: String?) {

--- a/Packages/HerdrKit/Tests/HerdrKitTests/DirectoryListingTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/DirectoryListingTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import HerdrKit
+
+/// Local-device coverage for the New Space directory browser; every path lives in a
+/// per-test temp directory. The SSH side reuses `runSSH` and is exercised by the
+/// remote E2E suite.
+final class DirectoryListingTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hk-ls-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        for name in ["beta", "Alpha", ".hidden"] {
+            try FileManager.default.createDirectory(
+                at: root.appendingPathComponent(name, isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
+        try Data("not a directory".utf8).write(to: root.appendingPathComponent("file.txt"))
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent("linked"),
+            withDestinationURL: root.appendingPathComponent("beta")
+        )
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func makeLocalService() -> HerdrService {
+        HerdrService(device: Device(name: "Test", kind: .local), localServer: nil)
+    }
+
+    func testListsOnlyVisibleDirectoriesSortedLikeFinder() async throws {
+        let names = try await makeLocalService().listDirectories(at: root.path)
+        // Files and dotfolders stay out; a symlinked directory still counts.
+        XCTAssertEqual(names, ["Alpha", "beta", "linked"])
+    }
+
+    func testUnreadableDirectoryThrows() async {
+        do {
+            _ = try await makeLocalService().listDirectories(at: root.path + "/nope")
+            XCTFail("expected a throw for a missing directory")
+        } catch {}
+    }
+
+    func testTildeResolvesAgainstTheDeviceHome() async throws {
+        let service = makeLocalService()
+        let home = NSHomeDirectory()
+        let bare = try await service.absolutePath("~")
+        let nested = try await service.absolutePath("~/Projects/foo")
+        let absolute = try await service.absolutePath("/opt/data")
+        XCTAssertEqual(bare, home)
+        XCTAssertEqual(nested, "\(home)/Projects/foo")
+        XCTAssertEqual(absolute, "/opt/data")
+    }
+
+    func testShellQuotedSurvivesTheAwkwardCharacters() {
+        XCTAssertEqual(HerdrService.shellQuoted("/plain/path"), "'/plain/path'")
+        XCTAssertEqual(HerdrService.shellQuoted("/it's here"), "'/it'\\''s here'")
+        // Single quotes keep $HOME and backticks literal; no escaping needed inside.
+        XCTAssertEqual(HerdrService.shellQuoted("/a $HOME `b`"), "'/a $HOME `b`'")
+    }
+}

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -533,11 +533,10 @@ final class AppModel: ObservableObject {
             do {
                 let service = service(for: device)
                 var path = directory.trimmingCharacters(in: .whitespaces)
+                // The browser leaves paths slash-terminated; herdr wants them bare.
+                while path.count > 1 && path.hasSuffix("/") { path.removeLast() }
                 if path.isEmpty { path = "~" }
-                if path == "~" || path.hasPrefix("~/") {
-                    let home = try await service.homeDirectory()
-                    path = path == "~" ? home : "\(home)/\(path.dropFirst(2))"
-                }
+                path = try await service.absolutePath(path)
                 let trimmedLabel = label?.trimmingCharacters(in: .whitespaces)
                 let created = try await service.createWorkspace(
                     label: (trimmedLabel?.isEmpty ?? true) ? nil : trimmedLabel,

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -409,7 +409,8 @@ struct NewSpaceSheet: View {
     @ObservedObject var model: AppModel
     @Environment(\.dismiss) private var dismiss
     @State private var deviceID = Device.local.id
-    @State private var directory = "~"
+    // The trailing slash keeps typing in filter position from the first keystroke.
+    @State private var directory = "~/"
     @State private var label = ""
 
     private var chosenDevice: Device {
@@ -440,21 +441,7 @@ struct NewSpaceSheet: View {
                 }
 
                 SheetSectionLabel("DIRECTORY")
-                HStack(spacing: 6) {
-                    TextField("~/Projects/foo", text: $directory)
-                        .textFieldStyle(.roundedBorder)
-                    if chosenDevice.isLocal {
-                        Button("Browse…") {
-                            let panel = NSOpenPanel()
-                            panel.canChooseDirectories = true
-                            panel.canChooseFiles = false
-                            panel.allowsMultipleSelection = false
-                            if panel.runModal() == .OK, let url = panel.url {
-                                directory = (url.path as NSString).abbreviatingWithTildeInPath
-                            }
-                        }
-                    }
-                }
+                DirectoryPickerField(model: model, device: chosenDevice, path: $directory)
                 if !chosenDevice.isLocal {
                     Text("Path on \(chosenDevice.name); ~ expands to its home directory")
                         .font(.system(size: 10.5))
@@ -491,6 +478,185 @@ struct NewSpaceSheet: View {
         .onAppear {
             deviceID = model.deviceFilter ?? model.devices.first?.id ?? Device.local.id
         }
+    }
+}
+
+/// Path field with an inline folder browser: type freely, click a row to descend,
+/// arrow-up to the parent. Local devices list through FileManager (and keep the
+/// native panel behind Browse…); remote devices list over one-shot SSH. A path
+/// segment that isn't a directory yet filters its parent's listing instead, so
+/// "~/de" narrows to Desktop and Developer as you type.
+struct DirectoryPickerField: View {
+    @ObservedObject var model: AppModel
+    let device: Device
+    @Binding var path: String
+
+    /// The directory whose children are on screen. Clicks resolve against it, so a
+    /// half-typed path keeps showing (and completing from) its parent's folders.
+    @State private var listedRoot = ""
+    @State private var entries: [String] = []
+    /// Case-insensitive prefix applied to `entries` while the last typed segment
+    /// isn't a directory of its own.
+    @State private var filter = ""
+    @State private var isListing = false
+    @State private var hoveredEntry: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Button {
+                    path = Self.parent(of: listedRoot.isEmpty ? path : listedRoot)
+                } label: {
+                    Image(systemName: "arrow.up")
+                }
+                .help("Up to the parent folder")
+                .disabled(atRoot)
+                TextField("~/Projects/foo", text: $path)
+                    .textFieldStyle(.roundedBorder)
+                if device.isLocal {
+                    Button("Browse…") {
+                        let panel = NSOpenPanel()
+                        panel.canChooseDirectories = true
+                        panel.canChooseFiles = false
+                        panel.allowsMultipleSelection = false
+                        if panel.runModal() == .OK, let url = panel.url {
+                            path = (url.path as NSString).abbreviatingWithTildeInPath
+                        }
+                    }
+                }
+            }
+            browser
+        }
+        .task(id: "\(device.id.uuidString)|\(path)") {
+            // Debounce: retyping cancels this task before the sleep ends.
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            guard !Task.isCancelled else { return }
+            await refreshListing()
+        }
+    }
+
+    private var visibleEntries: [String] {
+        guard !filter.isEmpty else { return entries }
+        return entries.filter { $0.range(of: filter, options: [.caseInsensitive, .anchored]) != nil }
+    }
+
+    private var browser: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 1) {
+                ForEach(visibleEntries, id: \.self) { name in
+                    Button {
+                        // Trailing slash so the next keystrokes filter inside the
+                        // folder instead of rewriting its name.
+                        path = (listedRoot == "/" ? "/\(name)" : "\(listedRoot)/\(name)") + "/"
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "folder")
+                                .font(.system(size: 11))
+                                .foregroundStyle(Theme.textTertiary)
+                            Text(name)
+                                .font(.system(size: 12.5))
+                                .foregroundStyle(Theme.text)
+                                .lineLimit(1)
+                            Spacer(minLength: 0)
+                        }
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .contentShape(Rectangle())
+                        .background(
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(hoveredEntry == name ? Theme.itemWash : .clear)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .onHover { hovering in
+                        if hovering {
+                            hoveredEntry = name
+                        } else if hoveredEntry == name {
+                            hoveredEntry = nil
+                        }
+                    }
+                }
+                if visibleEntries.isEmpty && !isListing {
+                    Text(entries.isEmpty ? "No subfolders" : "No folders match \"\(filter)\"")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Theme.textGhost)
+                        .padding(8)
+                }
+            }
+            .padding(4)
+        }
+        .frame(height: 150)
+        .background(RoundedRectangle(cornerRadius: 7).fill(Theme.contentBackground))
+        .overlay(RoundedRectangle(cornerRadius: 7).strokeBorder(Theme.hairline, lineWidth: 1))
+        .overlay(alignment: .topTrailing) {
+            if isListing {
+                ProgressView()
+                    .controlSize(.small)
+                    .padding(6)
+            }
+        }
+    }
+
+    private var atRoot: Bool {
+        let current = Self.normalized(listedRoot.isEmpty ? path : listedRoot)
+        return current == "/" || current == "~"
+    }
+
+    @MainActor
+    private func refreshListing() async {
+        let service = model.service(for: device)
+        let typed = path.trimmingCharacters(in: .whitespaces)
+        let root = Self.normalized(typed.isEmpty ? "~" : typed)
+        if root == listedRoot {
+            filter = ""
+            return
+        }
+        let partial = Self.lastComponent(of: root)
+        // Typing inside the directory already on screen filters it right away; the
+        // fetch below still lets a fully typed (or dot-hidden) folder take over. A
+        // trailing slash is an explicit "list this folder", never a filter.
+        if !typed.hasSuffix("/"), Self.parent(of: root) == listedRoot {
+            filter = partial
+        }
+        isListing = true
+        defer { isListing = false }
+        for candidate in [root, Self.parent(of: root)] {
+            if candidate == listedRoot {
+                // Already on screen; keep the listing, keep the filter, skip the fetch.
+                filter = partial
+                return
+            }
+            guard let names = try? await service.listDirectories(at: candidate) else { continue }
+            // A slow reply for a path the user already left must not clobber the new one.
+            guard !Task.isCancelled else { return }
+            listedRoot = candidate
+            entries = names
+            filter = candidate == root ? "" : partial
+            return
+        }
+        guard !Task.isCancelled else { return }
+        entries = []
+        filter = ""
+    }
+
+    /// "~/a/b" → "b"; the segment the filter matches against.
+    static func lastComponent(of path: String) -> String {
+        (normalized(path) as NSString).lastPathComponent
+    }
+
+    /// "~/a/b" → "~/a"; stops at "~" and "/".
+    static func parent(of path: String) -> String {
+        let normalized = normalized(path)
+        if normalized == "~" || normalized == "/" { return normalized }
+        let parent = (normalized as NSString).deletingLastPathComponent
+        return parent.isEmpty ? "~" : parent
+    }
+
+    /// Trims trailing slashes so paths compose predictably ("/" itself survives).
+    static func normalized(_ path: String) -> String {
+        var trimmed = path
+        while trimmed.count > 1 && trimmed.hasSuffix("/") { trimmed.removeLast() }
+        return trimmed
     }
 }
 


### PR DESCRIPTION
## What this adds

Creating a space on a remote device meant typing the full path blind. The DIRECTORY field now carries an inline folder browser: type freely, click to descend, filter as you go.

<p align="center">
  <img src="https://raw.githubusercontent.com/lcandy2/herdrm/pr-assets/assets/shot-browse.png" width="400" alt="New Space sheet browsing the home directory of a remote device" />
  <img src="https://raw.githubusercontent.com/lcandy2/herdrm/pr-assets/assets/shot-filter.png" width="400" alt="Typing ~/de narrows the listing to Desktop and Developer" />
</p>

- The list shows the subfolders of the typed path: FileManager locally, one-shot SSH for remote devices (same BatchMode and askpass arguments as every other probe).
- A segment that isn't a directory filters its parent's listing instead, case-insensitive prefix: `~/de` narrows to Desktop and Developer while you type.
- A click descends and leaves the path slash-terminated, so the next keystrokes keep filtering inside the folder just entered instead of rewriting its name.
- The arrow-up button walks to the parent; it stops at `~` and `/`.
- Local devices keep the native Browse… panel.
- The browser never gates creation: the field stays free text, an unreadable path just leaves the list empty, and Create Space works as before.

## HerdrKit

- `listDirectories(at:)` lists visible subdirectories on either device kind, Finder-sorted, symlinked folders included locally.
- `absolutePath(_:)` resolves `~` against the device home; `createNewSpace` now shares it instead of expanding `~` by hand.
- Remote paths travel single-quoted, so spaces, `$`, and backticks survive sh, zsh, and fish login shells.

## Validation

- `swift build` plus the new `DirectoryListingTests`: visible-directories-only with Finder sorting and a symlinked folder, a missing directory throwing, tilde resolution, and the quoting rules. The rest of the kit suite stays green.
- Live against a Mac mini reached through an ssh alias; both screenshots are captures of that session. A spaced remote path (`~/Library/Application Support`, 92 subfolders) listed correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LkfR46dSiw29FrqQhjSoU
