### PR TITLE
fix: surface dead attach sessions instead of freezing the terminal

### DIFF
--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -423,6 +423,11 @@ public actor HerdrService {
                 args: ["-tt"] + authentication.arguments + [
                     "-o", "StrictHostKeyChecking=accept-new",
                     "-o", "ConnectTimeout=10",
+                    // Same keepalives as the tunnel: without them a dropped network
+                    // path leaves the terminal frozen on its last frame, eating input
+                    // forever, because ssh never learns the peer is gone.
+                    "-o", "ServerAliveInterval=15",
+                    "-o", "ServerAliveCountMax=3",
                     target, remote,
                 ],
                 environment: authentication.environment,

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -201,23 +201,38 @@ struct DetailView: View {
     @AppStorage(TerminalDefaults.fontSizeKey) private var terminalFontSize = TerminalDefaults.defaultFontSize
     @AppStorage("terminal.mouseReporting") private var terminalMouseReporting = true
     @Environment(\.colorScheme) private var colorScheme
+    /// The entry whose attach process exited, and how. Keyed by entry id so a stale
+    /// exit from a previously selected pane never covers a live terminal.
+    @State private var endedAttachKey: String?
+    @State private var endedAttachCode: Int32?
+    @State private var attachRetry = 0
 
     @ViewBuilder
     private var terminal: some View {
         if let entry = model.selectedEntry {
-            AttachTerminalView(
-                device: entry.device,
-                paneID: entry.agent.paneID,
-                fontName: terminalFontName,
-                fontSize: terminalFontSize,
-                dark: colorScheme == .dark,
-                mouseReporting: terminalMouseReporting
-            )
-                .id("attach-\(entry.id)-\(colorScheme)")
-                .padding(.horizontal, 10)
-                .padding(.vertical, 8)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Theme.terminalBackground)
+            ZStack {
+                AttachTerminalView(
+                    device: entry.device,
+                    paneID: entry.agent.paneID,
+                    fontName: terminalFontName,
+                    fontSize: terminalFontSize,
+                    dark: colorScheme == .dark,
+                    mouseReporting: terminalMouseReporting,
+                    onExit: { code in
+                        endedAttachKey = entry.id
+                        endedAttachCode = code
+                    }
+                )
+                    .id("attach-\(entry.id)-\(colorScheme)-\(attachRetry)")
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                if endedAttachKey == entry.id {
+                    attachEndedOverlay(entry)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Theme.terminalBackground)
+            .onChange(of: entry.id) { _, _ in endedAttachKey = nil }
         } else {
             VStack(spacing: 10) {
                 Image(systemName: "terminal")
@@ -241,6 +256,33 @@ struct DetailView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Theme.terminalBackground)
         }
+    }
+
+    /// ssh exits 255 for transport failures; everything else is the far end closing
+    /// (takeover by another client, the pane going away, herdr stopping).
+    private func attachEndedOverlay(_ entry: AppModel.AgentEntry) -> some View {
+        let dropped = endedAttachCode == 255
+        return VStack(spacing: 10) {
+            Image(systemName: dropped ? "bolt.horizontal.circle" : "rectangle.slash")
+                .font(.system(size: 28, weight: .light))
+                .foregroundStyle(Theme.textGhost)
+            Text(dropped ? "Connection to \(entry.device.name) dropped" : "Terminal session ended")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(Theme.text)
+            Text(dropped
+                ? "The SSH connection behind this terminal went away."
+                : "Another client took this pane over, or the attach closed.")
+                .font(.system(size: 11.5))
+                .foregroundStyle(Theme.textTertiary)
+            Button("Reconnect") {
+                endedAttachKey = nil
+                attachRetry += 1
+            }
+            .controlSize(.small)
+            .keyboardShortcut(.defaultAction)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.terminalBackground.opacity(0.94))
     }
 
     private var showsStartAgentShortcut: Bool {

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -123,12 +123,18 @@ struct AttachTerminalView: NSViewRepresentable {
     /// When false, mouse drags always select text locally even if the TUI
     /// requested mouse reporting (Shift+drag bypasses it either way).
     var mouseReporting: Bool = true
+    /// Called on the main queue when the attach process exits: the pane was taken
+    /// over by another client, the SSH connection dropped, or herdr went away. A
+    /// dead session otherwise keeps its last frame and silently eats every
+    /// keystroke, which reads as a freeze.
+    var onExit: ((Int32?) -> Void)? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> LocalProcessTerminalView {
         let view = LineBreakTerminalView(frame: .zero)
         view.processDelegate = context.coordinator
+        context.coordinator.onExit = onExit
         configureAppearance(view)
 
         let service = HerdrService(device: device)
@@ -150,10 +156,13 @@ struct AttachTerminalView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: LocalProcessTerminalView, context: Context) {
+        context.coordinator.onExit = onExit
         configureAppearance(nsView)
     }
 
     static func dismantleNSView(_ nsView: LocalProcessTerminalView, coordinator: Coordinator) {
+        // A view being torn down must not report its own terminate() as an exit.
+        coordinator.onExit = nil
         nsView.terminate()
     }
 
@@ -176,6 +185,7 @@ struct AttachTerminalView: NSViewRepresentable {
 
     final class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
         var authorizationID: UUID?
+        var onExit: ((Int32?) -> Void)?
 
         deinit {
             discardAuthorization()
@@ -198,6 +208,9 @@ struct AttachTerminalView: NSViewRepresentable {
         func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
         func processTerminated(source: TerminalView, exitCode: Int32?) {
             discardAuthorization()
+            let callback = onExit
+            onExit = nil  // report once
+            DispatchQueue.main.async { callback?(exitCode) }
         }
     }
 }


### PR DESCRIPTION
## The freeze

Reported by a user watching a long-running grok conversation on a remote device: the terminal sits on the agent's loading frame forever, and no input lands — no cancel, no shortcuts, nothing. The app itself stays responsive; only the pane is dead.

Two paths produce exactly that, and neither is a rendering problem:

- **The attach ssh has no keepalives.** The tunnel ssh carries `ServerAliveInterval=15`, the attach ssh carries none, so a dropped network path (sleep, Wi-Fi change, Tailscale path flap) leaves ssh reading a dead socket indefinitely. The last frame stays up — for a working agent that frame usually shows a spinner — and every keystroke goes into the dead socket. Measured: profiling the adapter, the parser, and an offscreen view replica all clear 10 MB/s, so a CPU freeze was ruled out first.
- **A `--takeover` from any other client ends the attach, and the app ignores it.** Measured against a live pane: the kicked side receives `herdr: server shut down: terminal attach taken over` and EOF, `processTerminated` fires, and the view keeps the stale frame while eating input.

## The fix

- The attach ssh now carries the same `ServerAliveInterval=15` / `ServerAliveCountMax=3` as the tunnel, so a dead path ends the process within ~45 s and enters the same exit path as a takeover.
- `AttachTerminalView` reports process exit to the detail view, which covers the stale frame with an explanation and a Reconnect button; ssh exit code 255 tells "connection dropped" apart from "taken over / attach closed". Reconnect re-creates the attach in place. Exit state is keyed by agent entry, so a stale exit from a previously selected pane never covers a live terminal, and a view being dismantled doesn't report its own `terminate()`.

<p align="center">
  <img src="https://raw.githubusercontent.com/lcandy2/herdrm/pr-assets/assets/fix-kicked.png" width="760" alt="After a takeover the terminal shows Terminal session ended with a Reconnect button" />
</p>

## Validation

- Live takeover cycle against a streaming pane: attach in the app, kick it with `herdr agent attach --takeover` from a second client, the overlay appears (screenshot above); Reconnect resumes the live stream in place ([after](https://raw.githubusercontent.com/lcandy2/herdrm/pr-assets/assets/fix-reconnected.png)).
- `swift build` for HerdrKit and the app target; the kit test suite stays green (no test asserts the attach argument list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015LkfR46dSiw29FrqQhjSoU
