### PR TITLE
feat: paste files into local and remote agent terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Added
+- Paste files and images straight into a Claude Code or Copilot pane. On a
+  remote device the file is streamed over SSH into a private cache under
+  `~/.cache/herdrm/attachments` (0700, entries dropped after seven days) and
+  its remote path is pasted into the agent; on a local device the paste is
+  forwarded as Ctrl+V so the agent reads the clipboard itself. Uploads are
+  capped at 50 MB and show an indicator while they run.
+
 ### Fixed
 - Settings → Terminal: the preview no longer sits indented by the form's label
   column, and the mouse-reporting description no longer truncates.

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -475,6 +475,18 @@ public actor HerdrService {
         )
     }
 
+    /// Makes a local file readable by this device and returns the device-local path.
+    /// Remote files are streamed over SSH into the user's private cache.
+    public func stageAttachment(from localURL: URL) async throws -> String {
+        switch device.kind {
+        case .local:
+            return localURL.path
+        case .ssh:
+            guard let tunnel else { throw HerdrError.tunnelFailed("missing tunnel") }
+            return try await tunnel.uploadFile(from: localURL)
+        }
+    }
+
     // MARK: - Events
 
     public func events() throws -> AsyncThrowingStream<HerdrEvent, Error> {

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -478,11 +478,14 @@ public actor HerdrService {
     /// Makes a local file readable by this device and returns the device-local path.
     /// Remote files are streamed over SSH into the user's private cache.
     public func stageAttachment(from localURL: URL) async throws -> String {
+        try SSHTunnel.validateUploadCandidate(localURL)
         switch device.kind {
         case .local:
             return localURL.path
         case .ssh:
-            guard let tunnel else { throw HerdrError.tunnelFailed("missing tunnel") }
+            guard let tunnel else {
+                throw HerdrError.fileTransferFailed("no SSH connection for this device")
+            }
             return try await tunnel.uploadFile(from: localURL)
         }
     }

--- a/Packages/HerdrKit/Sources/HerdrKit/Models.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/Models.swift
@@ -47,6 +47,17 @@ public struct AgentInfo: Codable, Sendable, Identifiable, Equatable {
         return agent
     }
 
+    /// Whether the agent's TUI takes an attachment as a pasted file path.
+    /// herdr reports both bare and vendor-prefixed spellings ("claude" /
+    /// "claude-code", "copilot" / "github-copilot"), and nil until detection lands.
+    public static func acceptsPastedAttachments(agentKind: String?) -> Bool {
+        guard let agentKind else { return false }
+        let normalized = agentKind.lowercased().replacingOccurrences(of: "_", with: "-")
+        return ["claude", "copilot"].contains { family in
+            normalized == family || normalized.hasSuffix("-\(family)") || normalized.hasPrefix("\(family)-")
+        }
+    }
+
     enum CodingKeys: String, CodingKey {
         case terminalID = "terminal_id"
         case agentKindRaw = "agent"
@@ -171,6 +182,7 @@ public enum HerdrError: Error, LocalizedError, Sendable {
     case malformedResponse(String)
     case incompatibleProtocol(Int)
     case tunnelFailed(String)
+    case fileTransferFailed(String)
 
     public var errorDescription: String? {
         switch self {
@@ -183,6 +195,7 @@ public enum HerdrError: Error, LocalizedError, Sendable {
         case .malformedResponse(let reason): return "malformed response: \(reason)"
         case .incompatibleProtocol(let version): return "herdr protocol \(version) is too old (need >= 17)"
         case .tunnelFailed(let reason): return "SSH tunnel failed: \(reason)"
+        case .fileTransferFailed(let reason): return "file transfer failed: \(reason)"
         }
     }
 }

--- a/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
@@ -37,6 +37,8 @@ private final class SSHErrorBuffer: @unchecked Sendable {
 /// (`ssh -N -L local.sock:remote.sock target`), so remote devices reuse SocketRPC as-is.
 /// Auth uses OpenSSH config/agent/Tailscale SSH, with Keychain-backed askpass as a fallback.
 public actor SSHTunnel {
+    static let maximumUploadBytes = 50 * 1024 * 1024
+
     public let target: String
     public private(set) var localSocketPath: String?
     private let credentialID: UUID?
@@ -274,6 +276,116 @@ public actor SSHTunnel {
         let os = output.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !os.isEmpty else { throw HerdrError.tunnelFailed("empty OS probe result") }
         return os
+    }
+
+    // MARK: - File transfer
+
+    /// Streams one regular file to a private cache on the remote host and returns
+    /// its absolute remote path. The generated name preserves only a safe extension.
+    public func uploadFile(from localURL: URL) async throws -> String {
+        guard localURL.isFileURL else {
+            throw HerdrError.tunnelFailed("file upload requires a local file URL")
+        }
+        let values = try localURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+        guard values.isRegularFile == true else {
+            throw HerdrError.tunnelFailed("file upload supports regular files only")
+        }
+        let fileSize = values.fileSize ?? 0
+        guard fileSize <= Self.maximumUploadBytes else {
+            throw HerdrError.tunnelFailed("file is larger than the 50 MB upload limit")
+        }
+
+        return try await Self.uploadFile(
+            target: target,
+            localURL: localURL,
+            remoteFilename: Self.uploadFilename(for: localURL),
+            credentialID: credentialID
+        )
+    }
+
+    static func uploadFile(
+        target: String,
+        localURL: URL,
+        remoteFilename: String,
+        credentialID: UUID?,
+        executableURL: URL = URL(fileURLWithPath: "/usr/bin/ssh")
+    ) async throws -> String {
+        let command = """
+        umask 077
+        dir="${XDG_CACHE_HOME:-$HOME/.cache}/herdrm/attachments"
+        mkdir -p "$dir" && chmod 700 "$dir"
+        find "$dir" -type f -mtime +7 -delete 2>/dev/null || true
+        tmp="$dir/.\(remoteFilename).part"
+        path="$dir/\(remoteFilename)"
+        if cat > "$tmp" && chmod 600 "$tmp" && mv -f "$tmp" "$path"; then
+            printf '%s\\n' "$path"
+        else
+            rm -f "$tmp"
+            exit 1
+        fi
+        """
+
+        return try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let proc = Process()
+                proc.executableURL = executableURL
+                let authentication = authenticationConfiguration(for: credentialID)
+                defer { authentication.discardAuthorization() }
+                proc.arguments = authentication.arguments + [
+                    "-o", "StrictHostKeyChecking=accept-new",
+                    "-o", "ConnectTimeout=8",
+                    "-o", "ServerAliveInterval=15",
+                    sshDestination(target),
+                    command,
+                ]
+                proc.environment = ProcessInfo.processInfo.environment.merging(authentication.environment) { _, new in new }
+                let output = Pipe()
+                let errorOutput = Pipe()
+                proc.standardOutput = output
+                proc.standardError = errorOutput
+                do {
+                    proc.standardInput = try FileHandle(forReadingFrom: localURL)
+                    try proc.run()
+                } catch {
+                    continuation.resume(throwing: HerdrError.tunnelFailed("file upload spawn: \(error.localizedDescription)"))
+                    return
+                }
+                DispatchQueue.global().asyncAfter(deadline: .now() + 60) {
+                    if proc.isRunning { proc.terminate() }
+                }
+                proc.waitUntilExit()
+                let data = output.fileHandleForReading.readDataToEndOfFile()
+                guard proc.terminationStatus == 0 else {
+                    let errorData = errorOutput.fileHandleForReading.readDataToEndOfFile()
+                    continuation.resume(throwing: HerdrError.tunnelFailed(
+                        "file upload: \(failureReason(status: proc.terminationStatus, stderr: errorData))"
+                    ))
+                    return
+                }
+                let lines = String(data: data, encoding: .utf8)?
+                    .split(whereSeparator: \.isNewline)
+                    .map(String.init) ?? []
+                guard let remotePath = lines.last(where: { $0.hasPrefix("/") }) else {
+                    continuation.resume(throwing: HerdrError.tunnelFailed("file upload returned no remote path"))
+                    return
+                }
+                continuation.resume(returning: remotePath)
+            }
+        }
+    }
+
+    static func uploadFilename(for localURL: URL) -> String {
+        let rawExtension = localURL.pathExtension.lowercased()
+        let isSafeExtension = !rawExtension.isEmpty
+            && rawExtension.utf8.count <= 16
+            && rawExtension.utf8.allSatisfy { byte in
+                switch byte {
+                case 48...57, 97...122: return true
+                default: return false
+                }
+            }
+        let suffix = isSafeExtension ? ".\(rawExtension)" : ""
+        return "\(UUID().uuidString.lowercased())\(suffix)"
     }
 
     // MARK: - One-shot exec

--- a/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
@@ -283,24 +283,39 @@ public actor SSHTunnel {
     /// Streams one regular file to a private cache on the remote host and returns
     /// its absolute remote path. The generated name preserves only a safe extension.
     public func uploadFile(from localURL: URL) async throws -> String {
-        guard localURL.isFileURL else {
-            throw HerdrError.tunnelFailed("file upload requires a local file URL")
-        }
-        let values = try localURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
-        guard values.isRegularFile == true else {
-            throw HerdrError.tunnelFailed("file upload supports regular files only")
-        }
-        let fileSize = values.fileSize ?? 0
-        guard fileSize <= Self.maximumUploadBytes else {
-            throw HerdrError.tunnelFailed("file is larger than the 50 MB upload limit")
-        }
-
+        let fileSize = try Self.validateUploadCandidate(localURL)
         return try await Self.uploadFile(
             target: target,
             localURL: localURL,
             remoteFilename: Self.uploadFilename(for: localURL),
-            credentialID: credentialID
+            credentialID: credentialID,
+            timeout: Self.uploadTimeout(fileSizeBytes: fileSize)
         )
+    }
+
+    /// Rejects what the upload path cannot stream, and returns the size in bytes.
+    @discardableResult
+    static func validateUploadCandidate(_ localURL: URL) throws -> Int {
+        guard localURL.isFileURL else {
+            throw HerdrError.fileTransferFailed("a local file is required")
+        }
+        let values = try localURL.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey])
+        guard values.isRegularFile == true else {
+            throw HerdrError.fileTransferFailed("only regular files can be transferred")
+        }
+        let fileSize = values.fileSize ?? 0
+        guard fileSize <= maximumUploadBytes else {
+            throw HerdrError.fileTransferFailed(
+                "the file is larger than the \(maximumUploadBytes / (1024 * 1024)) MB limit"
+            )
+        }
+        return fileSize
+    }
+
+    /// A hard deadline generous enough for a slow link (~256 KB/s) — stalled
+    /// sessions are caught much earlier by ServerAlive, not by this watchdog.
+    static func uploadTimeout(fileSizeBytes: Int) -> TimeInterval {
+        min(600, 30 + Double(fileSizeBytes) / 262_144)
     }
 
     static func uploadFile(
@@ -308,8 +323,14 @@ public actor SSHTunnel {
         localURL: URL,
         remoteFilename: String,
         credentialID: UUID?,
+        timeout: TimeInterval = 60,
         executableURL: URL = URL(fileURLWithPath: "/usr/bin/ssh")
     ) async throws -> String {
+        // The name lands inside a remote shell script, so nothing but the
+        // generated form of uploadFilename(for:) may reach it.
+        guard isSafeRemoteFilename(remoteFilename) else {
+            throw HerdrError.fileTransferFailed("unsafe remote filename")
+        }
         let command = """
         umask 077
         dir="${XDG_CACHE_HOME:-$HOME/.cache}/herdrm/attachments"
@@ -335,6 +356,7 @@ public actor SSHTunnel {
                     "-o", "StrictHostKeyChecking=accept-new",
                     "-o", "ConnectTimeout=8",
                     "-o", "ServerAliveInterval=15",
+                    "-o", "ServerAliveCountMax=4",
                     sshDestination(target),
                     command,
                 ]
@@ -347,18 +369,18 @@ public actor SSHTunnel {
                     proc.standardInput = try FileHandle(forReadingFrom: localURL)
                     try proc.run()
                 } catch {
-                    continuation.resume(throwing: HerdrError.tunnelFailed("file upload spawn: \(error.localizedDescription)"))
+                    continuation.resume(throwing: HerdrError.fileTransferFailed("ssh spawn: \(error.localizedDescription)"))
                     return
                 }
-                DispatchQueue.global().asyncAfter(deadline: .now() + 60) {
+                DispatchQueue.global().asyncAfter(deadline: .now() + timeout) {
                     if proc.isRunning { proc.terminate() }
                 }
                 proc.waitUntilExit()
                 let data = output.fileHandleForReading.readDataToEndOfFile()
                 guard proc.terminationStatus == 0 else {
                     let errorData = errorOutput.fileHandleForReading.readDataToEndOfFile()
-                    continuation.resume(throwing: HerdrError.tunnelFailed(
-                        "file upload: \(failureReason(status: proc.terminationStatus, stderr: errorData))"
+                    continuation.resume(throwing: HerdrError.fileTransferFailed(
+                        failureReason(status: proc.terminationStatus, stderr: errorData)
                     ))
                     return
                 }
@@ -366,7 +388,7 @@ public actor SSHTunnel {
                     .split(whereSeparator: \.isNewline)
                     .map(String.init) ?? []
                 guard let remotePath = lines.last(where: { $0.hasPrefix("/") }) else {
-                    continuation.resume(throwing: HerdrError.tunnelFailed("file upload returned no remote path"))
+                    continuation.resume(throwing: HerdrError.fileTransferFailed("the remote host returned no path"))
                     return
                 }
                 continuation.resume(returning: remotePath)
@@ -386,6 +408,18 @@ public actor SSHTunnel {
             }
         let suffix = isSafeExtension ? ".\(rawExtension)" : ""
         return "\(UUID().uuidString.lowercased())\(suffix)"
+    }
+
+    static func isSafeRemoteFilename(_ name: String) -> Bool {
+        guard !name.isEmpty, name.utf8.count <= 64, !name.hasPrefix("."), !name.contains("..") else {
+            return false
+        }
+        return name.utf8.allSatisfy { byte in
+            switch byte {
+            case 48...57, 97...122, UInt8(ascii: "-"), UInt8(ascii: "."): return true
+            default: return false
+            }
+        }
     }
 
     // MARK: - One-shot exec

--- a/Packages/HerdrKit/Tests/HerdrKitTests/RemoteSSHTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/RemoteSSHTests.swift
@@ -50,6 +50,28 @@ final class RemoteSSHTests: XCTestCase {
         await service.disconnect()
     }
 
+    func testUploadFileRoundTrip() async throws {
+        guard let target else { throw XCTSkip("HERDRM_E2E_SSH_TARGET not set") }
+        let localURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdrm-e2e-\(UUID().uuidString).txt")
+        let payload = "herdrm remote upload \(UUID().uuidString)"
+        try Data(payload.utf8).write(to: localURL)
+        defer { try? FileManager.default.removeItem(at: localURL) }
+
+        let tunnel = SSHTunnel(target: target)
+        let remotePath = try await tunnel.uploadFile(from: localURL)
+        XCTAssertTrue(remotePath.hasPrefix("/"))
+        XCTAssertTrue(remotePath.hasSuffix(".txt"))
+
+        let quotedPath = shellQuote(remotePath)
+        let output = try await SSHTunnel.runSSH(
+            target: target,
+            command: "cat \(quotedPath); rm -f \(quotedPath)",
+            timeout: 15
+        )
+        XCTAssertEqual(output, payload)
+    }
+
     func testForwardedSocketStartsAgentInNewPane() async throws {
         let environment = ProcessInfo.processInfo.environment
         guard let socketPath = environment["HERDRM_E2E_SOCKET_PATH"] else {
@@ -87,5 +109,9 @@ final class RemoteSSHTests: XCTestCase {
             throw error
         }
         await service.disconnect()
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 }

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
@@ -133,3 +133,58 @@ final class AttachBinarySelectionTests: XCTestCase {
         XCTAssertTrue(remote.args.last?.hasPrefix("exec /bin/sh -c '") == true)
     }
 }
+
+final class SSHFileTransferTests: XCTestCase {
+    func testUploadStreamsFileAndReturnsRemotePath() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdrm-upload-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let sourceURL = directory.appendingPathComponent("source.png")
+        let capturedURL = directory.appendingPathComponent("captured.bin")
+        let argumentsURL = directory.appendingPathComponent("arguments.txt")
+        let executableURL = directory.appendingPathComponent("fake-ssh")
+        let payload = Data([0x00, 0x01, 0x0A, 0xFF, 0x42])
+        try payload.write(to: sourceURL)
+
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' "$@" > \(shellQuote(argumentsURL.path))
+        cat > \(shellQuote(capturedURL.path))
+        printf '/home/test/.cache/herdrm/attachments/test.png\\n'
+        """
+        try script.write(to: executableURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executableURL.path)
+
+        let remotePath = try await SSHTunnel.uploadFile(
+            target: "test@example.invalid:2222",
+            localURL: sourceURL,
+            remoteFilename: "test.png",
+            credentialID: nil,
+            executableURL: executableURL
+        )
+
+        XCTAssertEqual(remotePath, "/home/test/.cache/herdrm/attachments/test.png")
+        XCTAssertEqual(try Data(contentsOf: capturedURL), payload)
+        let arguments = try String(contentsOf: argumentsURL, encoding: .utf8)
+        XCTAssertTrue(arguments.contains("ssh://test@example.invalid:2222"))
+        XCTAssertTrue(arguments.contains("umask 077"))
+        XCTAssertTrue(arguments.contains("chmod 700"))
+        XCTAssertTrue(arguments.contains("chmod 600"))
+        XCTAssertTrue(arguments.contains("test.png.part"))
+    }
+
+    func testUploadFilenamePreservesOnlySafeExtension() {
+        let png = SSHTunnel.uploadFilename(for: URL(fileURLWithPath: "/tmp/private design.PNG"))
+        XCTAssertTrue(png.hasSuffix(".png"))
+        XCTAssertFalse(png.contains("private"))
+
+        let unsafe = SSHTunnel.uploadFilename(for: URL(fileURLWithPath: "/tmp/file.bad$ext"))
+        XCTAssertFalse(unsafe.contains("bad$ext"))
+    }
+
+    private func shellQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
@@ -179,12 +179,64 @@ final class SSHFileTransferTests: XCTestCase {
         let png = SSHTunnel.uploadFilename(for: URL(fileURLWithPath: "/tmp/private design.PNG"))
         XCTAssertTrue(png.hasSuffix(".png"))
         XCTAssertFalse(png.contains("private"))
+        XCTAssertTrue(SSHTunnel.isSafeRemoteFilename(png))
 
         let unsafe = SSHTunnel.uploadFilename(for: URL(fileURLWithPath: "/tmp/file.bad$ext"))
         XCTAssertFalse(unsafe.contains("bad$ext"))
+        XCTAssertTrue(SSHTunnel.isSafeRemoteFilename(unsafe))
+    }
+
+    func testUploadRejectsUnsafeRemoteFilename() async {
+        for name in ["a\"; rm -rf ~; echo \".png", "../escape.png", ".hidden.png", "sp ace.png", ""] {
+            XCTAssertFalse(SSHTunnel.isSafeRemoteFilename(name), name)
+        }
+        do {
+            _ = try await SSHTunnel.uploadFile(
+                target: "test@example.invalid",
+                localURL: URL(fileURLWithPath: "/dev/null"),
+                remoteFilename: "$(id).png",
+                credentialID: nil
+            )
+            XCTFail("expected an unsafe filename to be rejected")
+        } catch {
+            XCTAssertTrue(error.localizedDescription.contains("unsafe remote filename"))
+        }
+    }
+
+    func testUploadTimeoutScalesWithFileSize() {
+        XCTAssertEqual(SSHTunnel.uploadTimeout(fileSizeBytes: 0), 30)
+        // A 50 MB paste must not be killed by a fixed one-minute watchdog.
+        XCTAssertGreaterThan(SSHTunnel.uploadTimeout(fileSizeBytes: SSHTunnel.maximumUploadBytes), 180)
+        XCTAssertLessThanOrEqual(SSHTunnel.uploadTimeout(fileSizeBytes: Int.max / 2), 600)
+    }
+
+    func testUploadRejectsOversizedAndIrregularFiles() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdrm-upload-guard-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        XCTAssertThrowsError(try SSHTunnel.validateUploadCandidate(directory))
+        XCTAssertThrowsError(try SSHTunnel.validateUploadCandidate(URL(string: "https://example.com/a.png")!))
+
+        let fileURL = directory.appendingPathComponent("small.bin")
+        try Data([0x01]).write(to: fileURL)
+        XCTAssertEqual(try SSHTunnel.validateUploadCandidate(fileURL), 1)
     }
 
     private func shellQuote(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
+    }
+}
+
+final class AgentAttachmentSupportTests: XCTestCase {
+    func testAcceptsPastedAttachmentsCoversVendorPrefixedKinds() {
+        for kind in ["claude", "claude-code", "claude_code", "Claude", "copilot", "github-copilot"] {
+            XCTAssertTrue(AgentInfo.acceptsPastedAttachments(agentKind: kind), kind)
+        }
+        for kind in ["codex", "gemini", "cursor-agent", "agent", ""] {
+            XCTAssertFalse(AgentInfo.acceptsPastedAttachments(agentKind: kind), kind)
+        }
+        XCTAssertFalse(AgentInfo.acceptsPastedAttachments(agentKind: nil))
     }
 }

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -209,10 +209,12 @@ struct DetailView: View {
                 device: entry.device,
                 paneID: entry.agent.paneID,
                 serverVersion: model.serverVersion(deviceID: entry.device.id),
+                agentKind: entry.agent.agent,
                 fontName: terminalFontName,
                 fontSize: terminalFontSize,
                 dark: colorScheme == .dark,
-                mouseReporting: terminalMouseReporting
+                mouseReporting: terminalMouseReporting,
+                onAttachmentError: { model.actionError = $0 }
             )
                 .id("attach-\(entry.id)-\(colorScheme)")
                 .padding(.horizontal, 10)

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -201,6 +201,7 @@ struct DetailView: View {
     @AppStorage(TerminalDefaults.fontSizeKey) private var terminalFontSize = TerminalDefaults.defaultFontSize
     @AppStorage("terminal.mouseReporting") private var terminalMouseReporting = true
     @Environment(\.colorScheme) private var colorScheme
+    @State private var uploadingAttachment = false
 
     @ViewBuilder
     private var terminal: some View {
@@ -209,18 +210,23 @@ struct DetailView: View {
                 device: entry.device,
                 paneID: entry.agent.paneID,
                 serverVersion: model.serverVersion(deviceID: entry.device.id),
-                agentKind: entry.agent.agent,
+                agentKind: entry.agent.agentKindRaw,
                 fontName: terminalFontName,
                 fontSize: terminalFontSize,
                 dark: colorScheme == .dark,
                 mouseReporting: terminalMouseReporting,
-                onAttachmentError: { model.actionError = $0 }
+                onAttachmentError: { model.actionError = $0 },
+                onAttachmentUploadingChanged: { uploadingAttachment = $0 }
             )
                 .id("attach-\(entry.id)-\(colorScheme)")
                 .padding(.horizontal, 10)
                 .padding(.vertical, 8)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Theme.terminalBackground)
+                .overlay(alignment: .bottomTrailing) {
+                    if uploadingAttachment { uploadIndicator }
+                }
+                .onChange(of: entry.id) { uploadingAttachment = false }
         } else {
             VStack(spacing: 10) {
                 Image(systemName: "terminal")
@@ -244,6 +250,20 @@ struct DetailView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Theme.terminalBackground)
         }
+    }
+
+    private var uploadIndicator: some View {
+        HStack(spacing: 6) {
+            ProgressView().controlSize(.small)
+            Text("Uploading…")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.regularMaterial, in: Capsule())
+        .padding(.trailing, 20)
+        .padding(.bottom, 18)
     }
 
     private var showsStartAgentShortcut: Bool {

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -2,6 +2,7 @@ import AppKit
 import HerdrKit
 import SwiftTerm
 import SwiftUI
+import UniformTypeIdentifiers
 
 enum TerminalDefaults {
     static let fontNameKey = "terminal.fontName"   // "" = system monospaced
@@ -70,6 +71,25 @@ enum TerminalDefaults {
             guard let font = NSFont(name: family, size: 12) else { return false }
             return font.isFixedPitch
         }.sorted()
+    }
+}
+
+private struct ClipboardFile: Sendable {
+    let localURL: URL
+    let removeAfterUpload: Bool
+}
+
+private enum ClipboardFileError: LocalizedError {
+    case unsupportedItem
+    case imageEncodingFailed
+    case transferUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedItem: return "Remote paste supports regular files, not folders or special files."
+        case .imageEncodingFailed: return "The clipboard image could not be encoded as PNG."
+        case .transferUnavailable: return "The remote file transfer service is unavailable."
+        }
     }
 }
 
@@ -206,6 +226,174 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
         }
         super.interpretKeyEvents(eventArray)
     }
+
+    var forwardsLocalImagePaste = false
+    var handlesRemoteFilePaste = false
+    var attachmentService: HerdrService?
+    var onAttachmentError: ((String) -> Void)?
+    private var remotePasteTask: Task<Void, Never>?
+
+    deinit {
+        remotePasteTask?.cancel()
+    }
+
+    override func paste(_ sender: Any) {
+        if handlesRemoteFilePaste {
+            do {
+                if let files = try Self.clipboardFiles(in: NSPasteboard.general) {
+                    enqueueRemotePaste(files)
+                    return
+                }
+            } catch {
+                reportAttachmentError(error)
+                return
+            }
+        }
+
+        guard forwardsLocalImagePaste,
+              Self.containsImage(in: NSPasteboard.general)
+        else {
+            super.paste(sender)
+            return
+        }
+
+        guard let controlV = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: .control,
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window?.windowNumber ?? 0,
+            context: nil,
+            characters: "\u{16}",
+            charactersIgnoringModifiers: "v",
+            isARepeat: false,
+            keyCode: 9
+        ) else {
+            let bytes: [UInt8] = [0x16]
+            send(source: self, data: bytes[...])
+            return
+        }
+        super.keyDown(with: controlV)
+    }
+
+    private func enqueueRemotePaste(_ files: [ClipboardFile]) {
+        guard let attachmentService else {
+            reportAttachmentError(ClipboardFileError.transferUnavailable)
+            return
+        }
+        let previousTask = remotePasteTask
+        remotePasteTask = Task { [weak self] in
+            defer {
+                for file in files where file.removeAfterUpload {
+                    try? FileManager.default.removeItem(at: file.localURL)
+                }
+            }
+            await previousTask?.value
+            guard !Task.isCancelled else { return }
+
+            do {
+                var remotePaths: [String] = []
+                for file in files {
+                    try Task.checkCancellation()
+                    remotePaths.append(
+                        try await attachmentService.stageAttachment(from: file.localURL)
+                    )
+                }
+                try Task.checkCancellation()
+                await MainActor.run { [weak self] in
+                    self?.sendPastedText(remotePaths.joined(separator: " "))
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                await MainActor.run { [weak self] in
+                    self?.reportAttachmentError(error)
+                }
+            }
+        }
+    }
+
+    private func sendPastedText(_ text: String) {
+        if terminal.bracketedPasteMode {
+            let start = Array("\u{1B}[200~".utf8)
+            send(source: self, data: start[...])
+        }
+        let bytes = Array(text.utf8)
+        send(source: self, data: bytes[...])
+        if terminal.bracketedPasteMode {
+            let end = Array("\u{1B}[201~".utf8)
+            send(source: self, data: end[...])
+        }
+    }
+
+    private func reportAttachmentError(_ error: Error) {
+        onAttachmentError?("Remote paste failed: \(error.localizedDescription)")
+    }
+
+    private static func clipboardFiles(in pasteboard: NSPasteboard) throws -> [ClipboardFile]? {
+        if let fileURLs = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL], !fileURLs.isEmpty {
+            return try fileURLs.map { url in
+                let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+                guard values.isRegularFile == true else {
+                    throw ClipboardFileError.unsupportedItem
+                }
+                return ClipboardFile(localURL: url, removeAfterUpload: false)
+            }
+        }
+
+        guard let image = pasteboard.readObjects(
+            forClasses: [NSImage.self],
+            options: nil
+        )?.first as? NSImage else {
+            return nil
+        }
+        guard let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let png = bitmap.representation(using: .png, properties: [:])
+        else {
+            throw ClipboardFileError.imageEncodingFailed
+        }
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdrm-clipboard", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: directory.path
+        )
+        let localURL = directory.appendingPathComponent("\(UUID().uuidString.lowercased()).png")
+        try png.write(to: localURL, options: .atomic)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o600],
+            ofItemAtPath: localURL.path
+        )
+        return [ClipboardFile(localURL: localURL, removeAfterUpload: true)]
+    }
+
+    private static func containsImage(in pasteboard: NSPasteboard) -> Bool {
+        if pasteboard.canReadObject(forClasses: [NSImage.self], options: nil) {
+            return true
+        }
+        guard let fileURLs = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] else {
+            return false
+        }
+        return fileURLs.contains { url in
+            guard let values = try? url.resourceValues(forKeys: [.contentTypeKey]),
+                  let contentType = values.contentType
+            else { return false }
+            return contentType.conforms(to: .image)
+        }
+    }
 }
 
 /// Embeds a SwiftTerm terminal running `herdr agent attach` (directly or over ssh).
@@ -214,6 +402,7 @@ struct AttachTerminalView: NSViewRepresentable {
     let paneID: String
     /// The device's herdr server version, so attach picks a matching CLI binary.
     var serverVersion: String?
+    let agentKind: String
     var fontName: String = ""
     var fontSize: Double = TerminalDefaults.defaultFontSize
     /// From SwiftUI's environment so theme switches re-render immediately.
@@ -221,15 +410,20 @@ struct AttachTerminalView: NSViewRepresentable {
     /// When false, mouse drags always select text locally even if the TUI
     /// requested mouse reporting (Shift+drag bypasses it either way).
     var mouseReporting: Bool = true
+    var onAttachmentError: (String) -> Void = { _ in }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> LocalProcessTerminalView {
         let view = LineBreakTerminalView(frame: .zero)
+        view.forwardsLocalImagePaste = device.isLocal
+        view.handlesRemoteFilePaste = !device.isLocal && ["claude", "copilot"].contains(agentKind)
+        view.onAttachmentError = onAttachmentError
         view.processDelegate = context.coordinator
         configureAppearance(view)
 
         let service = HerdrService(device: device)
+        view.attachmentService = service
         let command = service.attachCommand(paneID: paneID, serverVersion: serverVersion)
         var environment = Terminal.getEnvironmentVariables(termName: "xterm-256color")
         environment.append("LANG=en_US.UTF-8")
@@ -248,6 +442,9 @@ struct AttachTerminalView: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: LocalProcessTerminalView, context: Context) {
+        if let view = nsView as? LineBreakTerminalView {
+            view.onAttachmentError = onAttachmentError
+        }
         configureAppearance(nsView)
     }
 

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -231,10 +231,12 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
     var handlesRemoteFilePaste = false
     var attachmentService: HerdrService?
     var onAttachmentError: ((String) -> Void)?
-    private var remotePasteTask: Task<Void, Never>?
+    var onAttachmentUploadingChanged: ((Bool) -> Void)?
+    private var pendingUploads: [[ClipboardFile]] = []
+    private var uploadTask: Task<Void, Never>?
 
     deinit {
-        remotePasteTask?.cancel()
+        uploadTask?.cancel()
     }
 
     override func paste(_ sender: Any) {
@@ -278,38 +280,47 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
 
     private func enqueueRemotePaste(_ files: [ClipboardFile]) {
         guard let attachmentService else {
+            discardTemporaries(in: files)
             reportAttachmentError(ClipboardFileError.transferUnavailable)
             return
         }
-        let previousTask = remotePasteTask
-        remotePasteTask = Task { [weak self] in
-            defer {
-                for file in files where file.removeAfterUpload {
-                    try? FileManager.default.removeItem(at: file.localURL)
-                }
-            }
-            await previousTask?.value
-            guard !Task.isCancelled else { return }
+        pendingUploads.append(files)
+        guard uploadTask == nil else { return }
+        onAttachmentUploadingChanged?(true)
+        uploadTask = Task { [weak self] in
+            await self?.drainUploads(using: attachmentService)
+        }
+    }
 
+    /// Uploads one paste at a time so paths reach the agent in paste order.
+    @MainActor
+    private func drainUploads(using service: HerdrService) async {
+        while !pendingUploads.isEmpty {
+            let files = pendingUploads.removeFirst()
+            defer { discardTemporaries(in: files) }
             do {
                 var remotePaths: [String] = []
                 for file in files {
                     try Task.checkCancellation()
-                    remotePaths.append(
-                        try await attachmentService.stageAttachment(from: file.localURL)
-                    )
+                    remotePaths.append(try await service.stageAttachment(from: file.localURL))
                 }
                 try Task.checkCancellation()
-                await MainActor.run { [weak self] in
-                    self?.sendPastedText(remotePaths.joined(separator: " "))
-                }
+                sendPastedText(remotePaths.joined(separator: " "))
             } catch is CancellationError {
-                return
+                break
             } catch {
-                await MainActor.run { [weak self] in
-                    self?.reportAttachmentError(error)
-                }
+                reportAttachmentError(error)
             }
+        }
+        pendingUploads.forEach(discardTemporaries(in:))
+        pendingUploads.removeAll()
+        uploadTask = nil
+        onAttachmentUploadingChanged?(false)
+    }
+
+    private func discardTemporaries(in files: [ClipboardFile]) {
+        for file in files where file.removeAfterUpload {
+            try? FileManager.default.removeItem(at: file.localURL)
         }
     }
 
@@ -327,7 +338,7 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
     }
 
     private func reportAttachmentError(_ error: Error) {
-        onAttachmentError?("Remote paste failed: \(error.localizedDescription)")
+        onAttachmentError?(error.localizedDescription)
     }
 
     private static func clipboardFiles(in pasteboard: NSPasteboard) throws -> [ClipboardFile]? {
@@ -344,10 +355,12 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
             }
         }
 
-        guard let image = pasteboard.readObjects(
-            forClasses: [NSImage.self],
-            options: nil
-        )?.first as? NSImage else {
+        guard !hasText(in: pasteboard),
+              let image = pasteboard.readObjects(
+                  forClasses: [NSImage.self],
+                  options: nil
+              )?.first as? NSImage
+        else {
             return nil
         }
         guard let tiff = image.tiffRepresentation,
@@ -378,7 +391,7 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
     }
 
     private static func containsImage(in pasteboard: NSPasteboard) -> Bool {
-        if pasteboard.canReadObject(forClasses: [NSImage.self], options: nil) {
+        if !hasText(in: pasteboard), pasteboard.canReadObject(forClasses: [NSImage.self], options: nil) {
             return true
         }
         guard let fileURLs = pasteboard.readObjects(
@@ -394,6 +407,12 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
             return contentType.conforms(to: .image)
         }
     }
+
+    /// Keynote, Excel and Preview attach a TIFF snapshot to copied text, so a
+    /// pasteboard only counts as an image when it carries no text at all.
+    private static func hasText(in pasteboard: NSPasteboard) -> Bool {
+        pasteboard.canReadObject(forClasses: [NSString.self], options: nil)
+    }
 }
 
 /// Embeds a SwiftTerm terminal running `herdr agent attach` (directly or over ssh).
@@ -402,7 +421,8 @@ struct AttachTerminalView: NSViewRepresentable {
     let paneID: String
     /// The device's herdr server version, so attach picks a matching CLI binary.
     var serverVersion: String?
-    let agentKind: String
+    /// nil until herdr finishes detecting the agent in a freshly started pane.
+    let agentKind: String?
     var fontName: String = ""
     var fontSize: Double = TerminalDefaults.defaultFontSize
     /// From SwiftUI's environment so theme switches re-render immediately.
@@ -411,14 +431,13 @@ struct AttachTerminalView: NSViewRepresentable {
     /// requested mouse reporting (Shift+drag bypasses it either way).
     var mouseReporting: Bool = true
     var onAttachmentError: (String) -> Void = { _ in }
+    var onAttachmentUploadingChanged: (Bool) -> Void = { _ in }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
     func makeNSView(context: Context) -> LocalProcessTerminalView {
         let view = LineBreakTerminalView(frame: .zero)
-        view.forwardsLocalImagePaste = device.isLocal
-        view.handlesRemoteFilePaste = !device.isLocal && ["claude", "copilot"].contains(agentKind)
-        view.onAttachmentError = onAttachmentError
+        configurePasteHandling(view)
         view.processDelegate = context.coordinator
         configureAppearance(view)
 
@@ -443,9 +462,19 @@ struct AttachTerminalView: NSViewRepresentable {
 
     func updateNSView(_ nsView: LocalProcessTerminalView, context: Context) {
         if let view = nsView as? LineBreakTerminalView {
-            view.onAttachmentError = onAttachmentError
+            configurePasteHandling(view)
         }
         configureAppearance(nsView)
+    }
+
+    /// Re-applied on update: herdr reports the agent kind as nil until detection
+    /// lands, and the view identity doesn't change when it does.
+    private func configurePasteHandling(_ view: LineBreakTerminalView) {
+        let acceptsAttachments = AgentInfo.acceptsPastedAttachments(agentKind: agentKind)
+        view.forwardsLocalImagePaste = device.isLocal && acceptsAttachments
+        view.handlesRemoteFilePaste = !device.isLocal && acceptsAttachments
+        view.onAttachmentError = onAttachmentError
+        view.onAttachmentUploadingChanged = onAttachmentUploadingChanged
     }
 
     static func dismantleNSView(_ nsView: LocalProcessTerminalView, coordinator: Coordinator) {


### PR DESCRIPTION
## What this adds

Pasting an image into a local agent works because the CLI can read the Mac clipboard directly. That breaks for remote agents: the CLI runs on another machine, cannot access the local clipboard, and cannot read a local filesystem path.

This PR bridges that gap for Copilot CLI and Claude Code.

- Local image paste forwards the Ctrl+V shortcut expected by agent CLIs.
- Remote Finder files are uploaded before their paths are pasted.
- Copied files are uploaded byte-for-byte in their original format.
- Clipboard-only bitmap data with no backing file is materialized as a temporary PNG before upload.
- Multiple files preserve their original order.
- Normal text paste remains unchanged.
- Pasting never submits the prompt automatically.

## Remote transfer

Attachments are streamed through SSH stdin into `${XDG_CACHE_HOME:-$HOME/.cache}/herdrm/attachments`. The transfer reuses Keychain-backed SSH authentication, supports custom SSH ports, limits files to 50 MB, uses randomized safe filenames, writes with private permissions, atomically moves completed uploads into place, and removes files older than seven days.

Upload failures use the existing application error alert and never insert a local path into the remote prompt.

## Testing

- `swift test --package-path Packages/HerdrKit`: 54 tests total, 49 passed, 5 opt-in remote E2E tests skipped because no target was configured
- Deterministic SSH streaming tests cover binary stdin, permissions, atomic placement, returned paths, custom ports, and extension sanitization
- Opt-in remote upload round-trip test via `HERDRM_E2E_SSH_TARGET`
- Unsigned Debug application build succeeded
- `git diff --check` passed