### PR TITLE
fix: add Intel (x86_64) support via universal binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
           xcodegen generate
           xcodebuild -project HerdrM.xcodeproj -scheme HerdrM -configuration Release \
             -derivedDataPath build build -skipPackagePluginValidation \
+            ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
             MARKETING_VERSION="$VERSION" CURRENT_PROJECT_VERSION="$GITHUB_RUN_NUMBER" \
             OTHER_CODE_SIGN_FLAGS="--timestamp" CODE_SIGN_INJECT_BASE_ENTITLEMENTS=NO
 

--- a/project.yml
+++ b/project.yml
@@ -58,5 +58,8 @@ targets:
         Debug:
           # real identity so UserNotifications & friends work in dev builds
           CODE_SIGN_IDENTITY: "Developer ID Application: MOE AI LLC (NCFNX3LJ83)"
+          ONLY_ACTIVE_ARCH: YES
         Release:
           CODE_SIGN_IDENTITY: "Developer ID Application: MOE AI LLC (NCFNX3LJ83)"
+          ONLY_ACTIVE_ARCH: NO
+          ARCHS: "arm64 x86_64"


### PR DESCRIPTION
Closes #12

Intel Macs currently fail with:

```
Error: herdrm: This cask depends on hardware architecture being one of [{type: :arm, bits: 64}], but you are running {type: :intel, bits: 64}.
```

Root cause: `Casks/herdrm.rb` restricts to `arm64` and the Release artifact is `arm64`-only (`lipo -info` shows single arch, `Sparkle.framework` is already universal).

Changes in this repo:

- `project.yml:58-63` — set `Release: ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO` (Debug stays `YES` for fast local builds). Verified via `xcodebuild -showBuildSettings` and `HerdrM.xcodeproj/project.pbxproj`.
- `.github/workflows/release.yml:42` — pass `ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO` to `xcodebuild` so the shipped zip is a fat binary. Local verification:

```bash
xcodegen generate
xcodebuild -project HerdrM.xcodeproj -scheme HerdrM -configuration Release \
  -derivedDataPath build build -skipPackagePluginValidation \
  ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
lipo -info build/Build/Products/Release/herdrm.app/Contents/MacOS/herdrm
# Architectures in the fat file: ... are: x86_64 arm64
```

Follow-up in `OwO-Network/homebrew-brew`:

- `Casks/herdrm.rb:14` — remove `depends_on arch: :arm64` (or use `on_arm`/`on_intel`) once a universal Release is published. The auto-bump in `release.yml` only updates `version`/`sha256`.

Tests: `swift test` (HerdrKit) passes, `Debug` stays single-arch, `Release` becomes universal.