### PR TITLE
feat(terminal): thin strokes, font weight and line spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Added
+- Terminal legibility settings: **Thin strokes** (on by default) turns off the
+  macOS font smoothing that thickens glyph stems and makes agent output —
+  Claude Code's bold text especially — look heavy and smudged; **Weight**
+  (Light/Regular/Medium) for the system monospaced font; and **Line spacing**
+  (100%–140%). (#4)
+
 ## [0.3.7] - 2026-08-20
 
 ### Added

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -199,6 +199,9 @@ struct DetailView: View {
 
     @AppStorage(TerminalDefaults.fontNameKey) private var terminalFontName = ""
     @AppStorage(TerminalDefaults.fontSizeKey) private var terminalFontSize = TerminalDefaults.defaultFontSize
+    @AppStorage(TerminalDefaults.thinStrokesKey) private var terminalThinStrokes = true
+    @AppStorage(TerminalDefaults.fontWeightKey) private var terminalFontWeight = TerminalDefaults.defaultFontWeight
+    @AppStorage(TerminalDefaults.lineSpacingKey) private var terminalLineSpacing = TerminalDefaults.defaultLineSpacing
     @AppStorage("terminal.mouseReporting") private var terminalMouseReporting = true
     @Environment(\.colorScheme) private var colorScheme
     /// The entry whose attach process exited, and how. Keyed by entry id so a stale
@@ -219,6 +222,9 @@ struct DetailView: View {
                     agentKind: entry.agent.agentKindRaw,
                     fontName: terminalFontName,
                     fontSize: terminalFontSize,
+                    thinStrokes: terminalThinStrokes,
+                    fontWeight: terminalFontWeight,
+                    lineSpacing: terminalLineSpacing,
                     dark: colorScheme == .dark,
                     mouseReporting: terminalMouseReporting,
                     onAttachmentError: { model.actionError = $0 },

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -130,6 +130,9 @@ struct SettingsView: View {
 struct TerminalSettingsView: View {
     @AppStorage(TerminalDefaults.fontNameKey) private var fontName = ""
     @AppStorage(TerminalDefaults.fontSizeKey) private var fontSize = TerminalDefaults.defaultFontSize
+    @AppStorage(TerminalDefaults.thinStrokesKey) private var thinStrokes = true
+    @AppStorage(TerminalDefaults.fontWeightKey) private var fontWeight = TerminalDefaults.defaultFontWeight
+    @AppStorage(TerminalDefaults.lineSpacingKey) private var lineSpacing = TerminalDefaults.defaultLineSpacing
     @AppStorage("terminal.mouseReporting") private var mouseReporting = true
 
     private let families = TerminalDefaults.monospacedFamilies()
@@ -157,6 +160,35 @@ struct TerminalSettingsView: View {
                         .labelsHidden()
                 }
 
+                Picker("Weight", selection: $fontWeight) {
+                    Text("Light").tag(Double(NSFont.Weight.light.rawValue))
+                    Text("Regular").tag(TerminalDefaults.defaultFontWeight)
+                    Text("Medium").tag(Double(NSFont.Weight.medium.rawValue))
+                }
+                .pickerStyle(.segmented)
+                .disabled(!fontName.isEmpty)
+                .help("Only the system monospaced font has selectable weights.")
+
+                HStack {
+                    Slider(value: $lineSpacing, in: 1.0...1.4, step: 0.05) {
+                        Text("Line spacing")
+                    }
+                    Text(String(format: "%.0f%%", lineSpacing * 100))
+                        .font(.system(size: 11.5).monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .frame(width: 52, alignment: .trailing)
+                }
+
+                Toggle(isOn: $thinStrokes) {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("Thin strokes")
+                        Text("Turns off macOS font smoothing, which thickens glyph stems and makes agent output — Claude Code's bold text especially — look heavy and smudged.")
+                            .font(.system(size: 10.5))
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
                 Toggle(isOn: $mouseReporting) {
                     VStack(alignment: .leading, spacing: 1) {
                         Text("Mouse reporting")
@@ -170,6 +202,9 @@ struct TerminalSettingsView: View {
                 Button("Reset to Defaults") {
                     fontName = ""
                     fontSize = TerminalDefaults.defaultFontSize
+                    fontWeight = TerminalDefaults.defaultFontWeight
+                    lineSpacing = TerminalDefaults.defaultLineSpacing
+                    thinStrokes = true
                     mouseReporting = true
                 }
             }
@@ -181,7 +216,7 @@ struct TerminalSettingsView: View {
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
                 Text("❯ herdr agent attach w1:p1 — 中文 ABC 0123")
-                    .font(Font(TerminalDefaults.font(name: fontName, size: fontSize)))
+                    .font(Font(TerminalDefaults.font(name: fontName, size: fontSize, weight: fontWeight)))
                     .lineLimit(1)
                     .padding(8)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -7,7 +7,14 @@ import UniformTypeIdentifiers
 enum TerminalDefaults {
     static let fontNameKey = "terminal.fontName"   // "" = system monospaced
     static let fontSizeKey = "terminal.fontSize"
+    static let thinStrokesKey = "terminal.thinStrokes"
+    static let fontWeightKey = "terminal.fontWeight"
+    static let lineSpacingKey = "terminal.lineSpacing"
     static let defaultFontSize: Double = 12.5
+    /// `NSFont.Weight` rawValue; 0 is `.regular`. Only the system monospaced font
+    /// has selectable weights — named families ship fixed faces and ignore this.
+    static let defaultFontWeight: Double = 0
+    static let defaultLineSpacing: Double = 1.0
     static let darkBackground = NSColor(
         srgbRed: 0x10 / 255,
         green: 0x10 / 255,
@@ -57,11 +64,11 @@ enum TerminalDefaults {
         )
     }
 
-    static func font(name: String, size: Double) -> NSFont {
+    static func font(name: String, size: Double, weight: Double = defaultFontWeight) -> NSFont {
         if !name.isEmpty, let custom = NSFont(name: name, size: size) {
             return custom
         }
-        return NSFont.monospacedSystemFont(ofSize: size, weight: .regular)
+        return NSFont.monospacedSystemFont(ofSize: size, weight: NSFont.Weight(weight))
     }
 
     /// Fixed-pitch font families available on this Mac, for the settings picker.
@@ -425,6 +432,12 @@ struct AttachTerminalView: NSViewRepresentable {
     let agentKind: String?
     var fontName: String = ""
     var fontSize: Double = TerminalDefaults.defaultFontSize
+    /// macOS font smoothing dilates glyph stems, which reads as fake bold at
+    /// terminal sizes. Off is SwiftTerm's `fontSmoothing = false` — iTerm2's
+    /// "Thin strokes".
+    var thinStrokes: Bool = true
+    var fontWeight: Double = TerminalDefaults.defaultFontWeight
+    var lineSpacing: Double = TerminalDefaults.defaultLineSpacing
     /// From SwiftUI's environment so theme switches re-render immediately.
     var dark: Bool = false
     /// When false, mouse drags always select text locally even if the TUI
@@ -491,11 +504,23 @@ struct AttachTerminalView: NSViewRepresentable {
     }
 
     private func configureAppearance(_ view: LocalProcessTerminalView) {
-        let font = TerminalDefaults.font(name: fontName, size: fontSize)
+        let font = TerminalDefaults.font(name: fontName, size: fontSize, weight: fontWeight)
         if view.font != font {
             view.font = font
         }
         view.allowMouseReporting = mouseReporting
+        // Compared against the inverted value on purpose: thinStrokes on means
+        // smoothing off. The setter only stores the flag, so repaint by hand.
+        if view.fontSmoothing == thinStrokes {
+            view.fontSmoothing = !thinStrokes
+            view.needsDisplay = true
+        }
+        // This setter calls resetFont(), which recomputes metrics and resizes the
+        // terminal, so it is only assigned when it actually changes.
+        if view.lineSpacing != CGFloat(lineSpacing) {
+            view.lineSpacing = CGFloat(lineSpacing)
+        }
+        // Everything below is theme-only and returns early; keep font work above it.
         guard let view = view as? LineBreakTerminalView,
               view.appliedDarkAppearance != dark
         else { return }


### PR DESCRIPTION
## Problem

macOS font smoothing dilates glyph stems, which reads as fake bold at terminal sizes. Agent output suffers most — Claude Code's UI uses a lot of bold, and in a dark pane it looks heavy and smudged. Picking a different font family does not help, because the thickening comes from the renderer, not the typeface.

## What this does

Turns font smoothing off by default (SwiftTerm's `fontSmoothing`, what iTerm2 calls "Thin strokes") and adds three controls to Settings → Terminal:

- **Thin strokes** — the smoothing switch, on by default.
- **Weight** — Light / Regular / Medium for the system monospaced font.
- **Line spacing** — 100 %–140 %.

Measured on rasterized agent output over `#101012`, average ink per channel: thin strokes alone is −10.6 % on regular text and −9.8 % on bold; light + thin strokes is −23 % against the bold that renders today.

## Notes on the details

- **The default is on.** That does change how a fresh install looks, which is deliberate: the current default is what gets reported as hard to read, and it matches iTerm2 and Ghostty on Retina. If you would rather ship it conservative, it is one `true` → `false` in three places.
- **Weight is disabled for named families.** Applying a weight trait through `fontDescriptor` to Menlo, Monaco or Courier New returns the same face, so the picker would be lying. Only the system monospaced font has selectable weights.
- **Weight does not change the column count.** `.light` and `.regular` of the system mono share the same advance (7.727 pt at 12.5).
- **The new work sits above the early return in `configureAppearance`.** That guard only covers the theme colors; putting the font work below it would apply the settings on the first pass only.
- `fontSmoothing`'s setter just stores the flag, so it is followed by an explicit `needsDisplay`. `lineSpacing`'s setter calls `resetFont()` and repaints on its own, so it is only assigned when the value actually changes.

Replacing the bold face itself is out of scope: `fontSet` is `internal` and the macOS `TerminalView` has no `setFonts(normal:bold:italic:boldItalic:)` (only iOS does), so it would need a change in SwiftTerm first.

## Verification

- `xcodebuild -project HerdrM.xcodeproj -scheme HerdrM -configuration Debug` → `** BUILD SUCCEEDED **`
- `cd Packages/HerdrKit && swift test` → 58 tests, 0 failures
- Checked by hand on a running app: bold reads thinner on a clean install with no settings touched; toggling Thin strokes repaints an already-visible pane without waiting for new output; line spacing at 120 % resizes without clipping; Light does not move the right edge of the output; Weight greys out with Menlo; Reset to Defaults restores Regular / 100 % / on.

CHANGELOG entry added under `## [Unreleased]`.