### PR TITLE
fix(terminal): focus the terminal when the attached agent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ the Sparkle update description — a release without a section here fails CI.
   (Light/Regular/Medium) for the system monospaced font; and **Line spacing**
   (100%–140%). (#4)
 
+### Fixed
+- Jumping to an agent — from ⌘K, the sidebar, or a notification — now leaves the
+  keyboard focus in its terminal. It used to take a mouse click before you could
+  type, and the agent's TUI rendered its cursor as unfocused. (#5)
+
 ## [0.3.7] - 2026-08-20
 
 ### Added

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -476,6 +476,15 @@ struct AttachTerminalView: NSViewRepresentable {
             args: command.args,
             environment: environment
         )
+        // SwiftUI throws this view away and builds a new one whenever the selected
+        // agent changes (the `.id("attach-…")` in ContentView), and a fresh NSView is
+        // never first responder — so keystrokes went nowhere until the user clicked.
+        // The hop to the next runloop pass is required: while `makeNSView` runs the
+        // view has no `window` yet.
+        DispatchQueue.main.async { [weak view] in
+            guard let view, let window = view.window else { return }
+            window.makeFirstResponder(view)
+        }
         return view
     }
 


### PR DESCRIPTION
Jumping to another agent — ⌘K + ↩, a click in the sidebar, a notification, or ⌘N — left the keyboard focus nowhere: you had to click the terminal before you could type, and the agent's TUI drew its cursor in the unfocused style.

**Cause.** `ContentView` tags the terminal with `.id("attach-\(entry.id)")`, and that id changes exactly when the selected agent changes, so SwiftUI destroys the `LocalProcessTerminalView` and builds a fresh one. A newly created `NSView` is never first responder — AppKit only hands it over on a click. Nothing in the app ever called `makeFirstResponder`.

**Fix.** At the end of `makeNSView`, ask the window for first responder on the next runloop pass (during `makeNSView` the view is not in the hierarchy yet, so `view.window` is still `nil`). It goes in `makeNSView` and deliberately *not* in `updateNSView`: the latter runs on every SwiftUI update and would steal focus from the New Agent sheet or the search field while you type.

Verified by hand on all four jump paths (⌘K, sidebar, notification, ⌘N), plus the two non-regressions: typing in the ⌘N sheet still works, and ⌘K + `esc` leaves focus where it was.

+9 lines in one file, plus the CHANGELOG entry. No changes to `project.yml`, signing, or dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)