### PR TITLE
feat(search): order ⌘K by agent status and show the status glyph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ the Sparkle update description — a release without a section here fails CI.
   Claude Code's bold text especially — look heavy and smudged; **Weight**
   (Light/Regular/Medium) for the system monospaced font; and **Line spacing**
   (100%–140%). (#4)
+- ⌘K now lists agents in the same order as the sidebar — the ones waiting on you
+  first, then done, working and idle — and each row carries its status glyph plus
+  a "needs input" label, so the agent that needs you is the first thing you see. (#6)
 
 ## [0.3.7] - 2026-08-20
 

--- a/Sources/HerdrM/SearchView.swift
+++ b/Sources/HerdrM/SearchView.swift
@@ -40,7 +40,15 @@ struct SearchSheet: View {
                 || entry.workspace.label.lowercased().contains(q)
                 || entry.device.name.lowercased().contains(q)
         }
-        return agents.map(Result.agent) + spaces.map(Result.space)
+        // Same ordering as the sidebar (AppModel.visibleAgents): whoever needs the
+        // user first, then most recently updated inside each bucket.
+        let ranked = agents.sorted {
+            if $0.agent.status.sortBucket != $1.agent.status.sortBucket {
+                return $0.agent.status.sortBucket < $1.agent.status.sortBucket
+            }
+            return ($0.agent.revision ?? 0) > ($1.agent.revision ?? 0)
+        }
+        return ranked.map(Result.agent) + spaces.map(Result.space)
     }
 
     var body: some View {
@@ -141,7 +149,13 @@ struct SearchSheet: View {
                     .font(.system(size: 13))
                     .foregroundStyle(Theme.text)
                     .lineLimit(1)
+                AgentStatusGlyph(status: entry.agent.status)
                 Spacer(minLength: 8)
+                if entry.agent.status == .blocked {
+                    Text("needs input")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Theme.warning)
+                }
                 trailing(
                     "\(entry.agent.agent) · \(model.spaceName(deviceID: entry.device.id, workspaceID: entry.agent.workspaceID))",
                     device: entry.device

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -223,7 +223,7 @@ struct SidebarView: View {
                         .foregroundStyle(Theme.text)
                         .lineLimit(1)
                     Spacer(minLength: 0)
-                    statusGlyph(agent.status)
+                    AgentStatusGlyph(status: agent.status)
                 }
                 HStack(spacing: 5) {
                     AgentKindBadge(kind: agent.agent)
@@ -255,25 +255,6 @@ struct SidebarView: View {
     /// Tinted name chip marking which device a row belongs to.
     private func deviceBadge(_ device: Device) -> some View {
         DeviceChip(device: device)
-    }
-
-    @ViewBuilder
-    private func statusGlyph(_ status: AgentStatus) -> some View {
-        switch status {
-        case .working:
-            SpinnerView(color: Theme.working)
-                .frame(width: 12, height: 12)
-        case .blocked:
-            Image(systemName: "exclamationmark.circle")
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(Theme.warning)
-        case .done:
-            Image(systemName: "checkmark")
-                .font(.system(size: 10.5, weight: .bold))
-                .foregroundStyle(Theme.success)
-        case .idle, .unknown:
-            EmptyView()
-        }
     }
 
     @ViewBuilder

--- a/Sources/HerdrM/Theme.swift
+++ b/Sources/HerdrM/Theme.swift
@@ -67,3 +67,27 @@ enum Theme {
         }
     }
 }
+
+/// Status marker shared by the sidebar rows and the ⌘K search results, so both
+/// surfaces speak the same visual language for "working / needs input / done".
+struct AgentStatusGlyph: View {
+    let status: AgentStatus
+
+    var body: some View {
+        switch status {
+        case .working:
+            SpinnerView(color: Theme.working)
+                .frame(width: 12, height: 12)
+        case .blocked:
+            Image(systemName: "exclamationmark.circle")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Theme.warning)
+        case .done:
+            Image(systemName: "checkmark")
+                .font(.system(size: 10.5, weight: .bold))
+                .foregroundStyle(Theme.success)
+        case .idle, .unknown:
+            EmptyView()
+        }
+    }
+}


### PR DESCRIPTION
The ⌘K list came out in session arrival order and showed no status at all, so the agent actually waiting on you sat buried among idle ones — and the only icon on the row is the agent's brand mark, which reads like a status but isn't.

**What changes**

- `SearchView.results` now ranks agents with `AgentStatus.sortBucket` and, inside a bucket, `revision` descending — character for character the rule `AppModel.visibleAgents` already uses for the sidebar, so both surfaces agree: needs-input first, then done, working, idle. Spaces still come after all agents, and the order holds with a query typed.
- Each agent row carries the sidebar's status glyph (spinner / exclamation / checkmark) plus a `needs input` label when the agent is blocked. The `BrandIcon` is untouched — it's identity, not state.
- The glyph moved out of `SidebarView` into a shared `AgentStatusGlyph` in `Theme.swift` (next to `Theme.statusColor`, which already switches on the same enum), so the two surfaces can't drift. Sizes, weights and colors are unchanged.

No new files, no `project.yml`, signing or dependency changes. Verified by hand: with a blocked, a done, a working and an idle agent, ⌘K lists them in that order with the right glyphs, and the ordering survives a typed query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)