### PR TITLE
fix(search): scroll the ⌘K list to follow the keyboard selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ the Sparkle update description — a release without a section here fails CI.
   (Light/Regular/Medium) for the system monospaced font; and **Line spacing**
   (100%–140%). (#4)
 
+### Fixed
+- The ⌘K result list now scrolls to follow the keyboard selection. Arrowing past
+  the eighth row used to move the highlight out of view and leave the list
+  standing still; typing a new query, or reopening the sheet, now also brings the
+  list back to the top. (#7)
+
 ## [0.3.7] - 2026-08-20
 
 ### Added

--- a/Sources/HerdrM/SearchView.swift
+++ b/Sources/HerdrM/SearchView.swift
@@ -79,17 +79,30 @@ struct SearchSheet: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 24)
             } else {
-                ScrollView {
-                    VStack(spacing: 1) {
-                        ForEach(Array(results.enumerated()), id: \.element.id) { index, result in
-                            row(result, isHighlighted: index == highlighted)
-                                .onTapGesture { choose(result) }
-                                .onHover { if $0 { highlighted = index } }
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        VStack(spacing: 1) {
+                            ForEach(Array(results.enumerated()), id: \.element.id) { index, result in
+                                row(result, isHighlighted: index == highlighted)
+                                    .onTapGesture { choose(result) }
+                                    .onHover { if $0 { highlighted = index } }
+                            }
                         }
+                        .padding(8)
                     }
-                    .padding(8)
+                    .frame(maxHeight: 320)
+                    // anchor: nil moves the minimum to reveal the row — a no-op when it
+                    // is already visible, so hovering never yanks the scroll position.
+                    .onChange(of: highlighted) { _, index in
+                        guard results.indices.contains(index) else { return }
+                        proxy.scrollTo(results[index].id, anchor: nil)
+                    }
+                    // Reopening ⌘K starts at the top even if the sheet was left
+                    // scrolled to the bottom.
+                    .onAppear {
+                        if let first = results.first { proxy.scrollTo(first.id, anchor: .top) }
+                    }
                 }
-                .frame(maxHeight: 320)
             }
 
             Rectangle().fill(Theme.hairline).frame(height: 1)


### PR DESCRIPTION
> **Builds on missuo/herdrm#29 (same file) — please merge #29 first.**

Arrowing through the ⌘K results with ↑/↓ moved the highlight but never moved the list. Rows are 36pt in a 320pt-tall `ScrollView`, so from the ninth result on the selection walked out of the viewport and you were navigating blind.

The result `ScrollView` is now wrapped in a `ScrollViewReader` and follows the selection:

- `onChange(of: highlighted)` → `proxy.scrollTo(results[index].id, anchor: nil)`. `anchor: nil` is deliberate: it moves the minimum needed to reveal the row and is a no-op when the row is already visible, so hovering (which also moves the highlight) never yanks the scroll position.
- `onAppear` → `proxy.scrollTo(first.id, anchor: .top)`, so reopening the sheet starts at the top instead of wherever it was left. `.top` is deliberate here — on open we want the top, not the minimum movement.
- Typing a new query already reset `highlighted` to 0; that now scrolls the list back up as a consequence, no extra code.

No animation (keyboard navigation reads better with a hard jump, and nothing else in this sheet animates), no `LazyVStack` (the list is tens of rows), no `.id()` added — the `ForEach` already keys rows by `\.element.id`.

Verified by hand on a build with ≥9 results: arrowing past the eighth row scrolls and keeps the selection visible, ↑ back to the first reveals it, typing returns to the top, reopening starts at the top, and hovering causes no scroll jumps.
