### PR TITLE
fix: discover NVM and Grok agent CLIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ the Sparkle update description — a release without a section here fails CI.
   (Light/Regular/Medium) for the system monospaced font; and **Line spacing**
   (100%–140%). (#4)
 
+### Fixed
+- The New Agent picker now finds CLIs installed by NVM, plus Grok's user-level
+  installer, when herdrm starts outside a login shell locally or over SSH.
+
 ## [0.3.7] - 2026-08-20
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SSHTunnel.swift
@@ -49,7 +49,8 @@ public actor SSHTunnel {
 
     /// PATH prepended on the remote side; sshd exec is not a login shell (mirrors Heeler).
     public static let remotePathExport =
-        "export PATH=\"$HOME/.local/bin:$HOME/.cargo/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\""
+        "for d in \"$HOME\"/.nvm/versions/node/*/bin; do [ -d \"$d\" ] && PATH=\"$d:$PATH\"; done; "
+        + "export PATH=\"$HOME/.local/bin:$HOME/.cargo/bin:$HOME/.grok/bin:/opt/homebrew/bin:/usr/local/bin:$PATH\""
 
     public init(target: String, credentialID: UUID? = nil) {
         self.target = target

--- a/Packages/HerdrKit/Tests/HerdrKitTests/AgentDiscoveryTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/AgentDiscoveryTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import XCTest
+@testable import HerdrKit
+
+final class AgentDiscoveryTests: XCTestCase {
+    func testRemotePathExportFindsNVMAndGrokBinaries() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdrm-discovery-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let nvmBin = home.appendingPathComponent(".nvm/versions/node/v22.14.0/bin", isDirectory: true)
+        let grokBin = home.appendingPathComponent(".grok/bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: nvmBin, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: grokBin, withIntermediateDirectories: true)
+
+        let codex = nvmBin.appendingPathComponent("codex")
+        let grok = grokBin.appendingPathComponent("grok")
+        for executable in [codex, grok] {
+            XCTAssertTrue(FileManager.default.createFile(atPath: executable.path, contents: Data()))
+            try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: executable.path)
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            "\(SSHTunnel.remotePathExport); command -v codex; command -v grok",
+        ]
+        process.environment = ["HOME": home.path, "PATH": "/usr/bin:/bin"]
+        let output = Pipe()
+        process.standardOutput = output
+        process.standardError = output
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        let paths = String(decoding: data, as: UTF8.self)
+            .split(whereSeparator: \.isNewline)
+            .map(String.init)
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertEqual(paths, [codex.path, grok.path])
+    }
+}


### PR DESCRIPTION
## Summary

- add every installed NVM Node bin directory to the PATH used for agent discovery
- add Grok's user-level `~/.grok/bin` directory
- cover both locations with a hermetic shell test and document the fix

## Why

The New Agent picker probes each manifest binary with `command -v` after applying `SSHTunnel.remotePathExport`. Finder-launched apps and commands run by `sshd` do not necessarily initialize a login shell, so agents installed under `~/.nvm/versions/node/*/bin` or `~/.grok/bin` can be omitted even though they are installed and executable.

The NVM loop checks that each glob result is a directory, so hosts without NVM keep the existing behavior.

## Testing

- `swift test --package-path Packages/HerdrKit` — 59 tests executed, 5 opt-in remote E2E tests skipped, 0 failures
- `xcodegen generate`
- `xcodebuild -project HerdrM.xcodeproj -scheme HerdrM -configuration Debug -derivedDataPath build -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO build` — `BUILD SUCCEEDED`
