### PR TITLE
feat(terminal): split the terminal pane with a local login shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Added
+- The terminal pane can now split to run a local login shell alongside the
+  agent attach — ⌘D splits vertically, ⇧⌘D horizontally, and the divider
+  drags with a persisted ratio. Splitting moves the keyboard to the new shell,
+  and closing the split hands it back to the agent. ⌘W closes the split first
+  and only closes the window once it's gone. First phase of a series; keyboard
+  focus/resize controls and a remote shell over SSH follow in later issues.
+
 ## [0.3.9] - 2026-08-21
 
 ### Changed

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -38,6 +38,9 @@ struct SSHAuthenticationRequest: Identifiable {
     var id: UUID { deviceID }
 }
 
+/// vertical = panes lado a lado, divisor vertical (convención iTerm2).
+enum SplitAxis { case vertical, horizontal }
+
 @MainActor
 final class AppModel: ObservableObject {
     @Published var devices: [Device]
@@ -51,6 +54,7 @@ final class AppModel: ObservableObject {
     @Published var showNewAgent = false
     @Published var showNewSpace = false
     @Published var showSearch = false
+    @Published var shellSplitAxis: SplitAxis?
     /// In-window device panel (NSPopover crashes in ViewBridge on macOS 26+ betas).
     @Published var showDevicePanel = false
     @Published var deviceToEdit: Device?

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -108,6 +108,11 @@ struct DetailView: View {
             Rectangle().fill(Theme.hairline).frame(height: 1)
             terminal
                 .clipped()
+                // Losing the selected agent tears the SplitContainer down without
+                // resetting the axis, which would leave the same phantom split.
+                .onChange(of: model.selectedEntry?.id) { _, id in
+                    if id == nil { model.shellSplitAxis = nil }
+                }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Theme.contentBackground.ignoresSafeArea())
@@ -203,6 +208,7 @@ struct DetailView: View {
     @AppStorage(TerminalDefaults.fontWeightKey) private var terminalFontWeight = TerminalDefaults.defaultFontWeight
     @AppStorage(TerminalDefaults.lineSpacingKey) private var terminalLineSpacing = TerminalDefaults.defaultLineSpacing
     @AppStorage("terminal.mouseReporting") private var terminalMouseReporting = true
+    @AppStorage("terminal.splitRatio") private var splitRatio = 0.5
     @Environment(\.colorScheme) private var colorScheme
     /// The entry whose attach process exited, and how. Keyed by entry id so a stale
     /// exit from a previously selected pane never covers a live terminal.
@@ -214,15 +220,39 @@ struct DetailView: View {
     @ViewBuilder
     private var terminal: some View {
         if let entry = model.selectedEntry {
-            ZStack {
-                AttachTerminalView(
-                    device: entry.device,
-                    paneID: entry.agent.paneID,
-                    serverVersion: model.serverVersion(deviceID: entry.device.id),
-                    attachmentCapabilities: model.attachmentCapabilities(
-                        deviceID: entry.device.id,
-                        agentKind: entry.agent.agentKindRaw
-                    ),
+            SplitContainer(axis: model.shellSplitAxis, ratio: $splitRatio) {
+                ZStack {
+                    AttachTerminalView(
+                        device: entry.device,
+                        paneID: entry.agent.paneID,
+                        serverVersion: model.serverVersion(deviceID: entry.device.id),
+                        attachmentCapabilities: model.attachmentCapabilities(
+                            deviceID: entry.device.id,
+                            agentKind: entry.agent.agentKindRaw
+                        ),
+                        fontName: terminalFontName,
+                        fontSize: terminalFontSize,
+                        thinStrokes: terminalThinStrokes,
+                        fontWeight: terminalFontWeight,
+                        lineSpacing: terminalLineSpacing,
+                        dark: colorScheme == .dark,
+                        mouseReporting: terminalMouseReporting,
+                        onAttachmentError: { model.actionError = $0 },
+                        onAttachmentUploadingChanged: { uploadingAttachment = $0 },
+                        onExit: { code in
+                            endedAttachKey = entry.id
+                            endedAttachCode = code
+                        }
+                    )
+                        .id("attach-\(entry.id)-\(colorScheme)-\(attachRetry)")
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 8)
+                    if endedAttachKey == entry.id {
+                        attachEndedOverlay(entry)
+                    }
+                }
+            } second: {
+                ShellTerminalView(
                     fontName: terminalFontName,
                     fontSize: terminalFontSize,
                     thinStrokes: terminalThinStrokes,
@@ -230,19 +260,15 @@ struct DetailView: View {
                     lineSpacing: terminalLineSpacing,
                     dark: colorScheme == .dark,
                     mouseReporting: terminalMouseReporting,
-                    onAttachmentError: { model.actionError = $0 },
-                    onAttachmentUploadingChanged: { uploadingAttachment = $0 },
-                    onExit: { code in
-                        endedAttachKey = entry.id
-                        endedAttachCode = code
-                    }
+                    onExit: { _ in model.shellSplitAxis = nil }
                 )
-                    .id("attach-\(entry.id)-\(colorScheme)-\(attachRetry)")
+                    // Deliberately not keyed on colorScheme like the attach above:
+                    // a new id tears the view down and kills the shell with whatever
+                    // was running in it, and unlike a herdr pane a local shell has no
+                    // server-side state to reattach to. updateNSView re-themes it.
+                    .id("shell")
                     .padding(.horizontal, 10)
                     .padding(.vertical, 8)
-                if endedAttachKey == entry.id {
-                    attachEndedOverlay(entry)
-                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Theme.terminalBackground)
@@ -252,6 +278,11 @@ struct DetailView: View {
             .onChange(of: entry.id) { _, _ in
                 endedAttachKey = nil
                 uploadingAttachment = false
+            }
+            // Splitting moves the keyboard to the shell, so closing the split has to
+            // hand it back — by ⌘W or by the shell exiting on its own.
+            .onChange(of: model.shellSplitAxis) { _, axis in
+                if axis == nil { focusRemainingTerminal() }
             }
         } else {
             VStack(spacing: 10) {

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -83,6 +83,30 @@ struct HerdrMApp: App {
                     updaterController.checkForUpdates(nil)
                 }
             }
+
+            CommandMenu("Terminal") {
+                // Guarded on selectedEntry, not just on the model: with the placeholder
+                // on screen there is no SplitContainer to render into, so a split would
+                // be invisible yet leave shellSplitAxis non-nil — and the next ⌘W would
+                // "close" that phantom instead of the window.
+                Button("Split Vertically") { focusedModel?.shellSplitAxis = .vertical }
+                    .keyboardShortcut("d", modifiers: .command)
+                    .disabled(focusedModel?.selectedEntry == nil)
+                Button("Split Horizontally") { focusedModel?.shellSplitAxis = .horizontal }
+                    .keyboardShortcut("d", modifiers: [.command, .shift])
+                    .disabled(focusedModel?.selectedEntry == nil)
+            }
+            CommandGroup(replacing: .saveItem) {
+                // ⌘W prioriza el split — mismo trade-off que ⌘N con New Agent.
+                Button(focusedModel?.shellSplitAxis != nil ? "Close Split" : "Close") {
+                    if let model = focusedModel, model.shellSplitAxis != nil {
+                        model.shellSplitAxis = nil
+                    } else {
+                        NSApp.keyWindow?.performClose(nil)
+                    }
+                }
+                .keyboardShortcut("w", modifiers: .command)
+            }
         }
 
         Settings {

--- a/Sources/HerdrM/SplitContainer.swift
+++ b/Sources/HerdrM/SplitContainer.swift
@@ -1,0 +1,97 @@
+import AppKit
+import SwiftUI
+
+/// A two-pane split with a draggable divider and a persisted ratio. `axis == nil` shows
+/// `first()` filling the whole area; the second pane and the divider are what come and go.
+///
+/// The `GeometryReader` and the layout are present in every state on purpose, and the axis
+/// is switched with `AnyLayout` rather than by branching. Do not "simplify" this into
+/// `if axis != nil { … } else { first() }`: SwiftUI does not preserve identity across a
+/// `_ConditionalContent` branch swap, so `first()` would be destroyed and rebuilt on every
+/// split — which killed the agent's attach process and relaunched it with `--takeover`.
+struct SplitContainer<First: View, Second: View>: View {
+    let axis: SplitAxis?
+    @Binding var ratio: Double
+    @ViewBuilder var first: () -> First
+    @ViewBuilder var second: () -> Second
+
+    /// The ratio when the current drag began. `DragGesture.translation` is a delta,
+    /// so the divider follows the mouse from wherever it was; `location` would be
+    /// measured against the divider's own origin, not the container's, and make the
+    /// divider jump on mouse-down.
+    @State private var dragStartRatio: Double?
+
+    var body: some View {
+        // One structural position for first()/second(), always. Putting first() in two
+        // branches of a conditional made SwiftUI destroy and rebuild it on every split:
+        // identity does not survive a _ConditionalContent branch swap, .id() included, so
+        // the agent's attach process was killed and relaunched with --takeover. AnyLayout
+        // swaps the axis without touching child identity.
+        GeometryReader { proxy in
+            let total = axis == .vertical ? proxy.size.width : proxy.size.height
+            let firstLength = total * SplitContainerRatioBounds.clamp(ratio)
+            let layout = axis == .horizontal
+                ? AnyLayout(VStackLayout(spacing: 0))
+                : AnyLayout(HStackLayout(spacing: 0))
+            layout {
+                first()
+                    .frame(
+                        width: axis == .vertical ? firstLength : nil,
+                        height: axis == .horizontal ? firstLength : nil
+                    )
+                if let axis {
+                    divider(axis: axis, total: total)
+                    second()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            // ponytail: a gesture cancelled without onEnded leaves a stale
+            // anchor; clearing on axis change covers the case that shows.
+            .onChange(of: axis) { _, _ in dragStartRatio = nil }
+        }
+    }
+
+    private func divider(axis: SplitAxis, total: CGFloat) -> some View {
+        Rectangle()
+            .fill(Theme.hairline)
+            .frame(width: axis == .vertical ? 1 : nil, height: axis == .horizontal ? 1 : nil)
+            .overlay(
+                Rectangle()
+                    .fill(.clear)
+                    .frame(width: axis == .vertical ? 7 : nil, height: axis == .horizontal ? 7 : nil)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture()
+                            .onChanged { value in
+                                guard total > 0 else { return }
+                                let start = dragStartRatio ?? SplitContainerRatioBounds.clamp(ratio)
+                                if dragStartRatio == nil { dragStartRatio = start }
+                                let travelled = axis == .vertical
+                                    ? value.translation.width
+                                    : value.translation.height
+                                ratio = SplitContainerRatioBounds.clamp(start + travelled / total)
+                            }
+                            .onEnded { _ in dragStartRatio = nil }
+                    )
+                    // set() instead of push()/pop(): closing the split with the
+                    // pointer over the divider never delivers onHover(false), and an
+                    // unbalanced push leaves the resize cursor stuck app-wide.
+                    .onHover { hovering in
+                        if hovering {
+                            (axis == .vertical ? NSCursor.resizeLeftRight : NSCursor.resizeUpDown).set()
+                        } else {
+                            NSCursor.arrow.set()
+                        }
+                    }
+            )
+    }
+}
+
+private enum SplitContainerRatioBounds {
+    static let bounds = 0.2...0.8
+
+    static func clamp(_ value: Double) -> Double {
+        Swift.min(Swift.max(value, bounds.lowerBound), bounds.upperBound)
+    }
+}

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -478,6 +478,33 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
     }
 }
 
+/// Hands the keyboard back to whichever terminal is left after a split closes. The
+/// shell view that held first responder is gone by then, and AppKit falls back to the
+/// window itself, which reads as a dead keyboard until the user clicks.
+func focusRemainingTerminal() {
+    DispatchQueue.main.async {
+        guard let window = NSApp.keyWindow,
+              let terminal = window.contentView?.firstTerminalDescendant()
+        else { return }
+        // Only fill a focus vacuum. If the shell died on its own while the user was
+        // typing in the sidebar filter or in Search, that field is still first
+        // responder and yanking the keyboard into a live agent session is worse than
+        // doing nothing.
+        guard window.firstResponder === window else { return }
+        window.makeFirstResponder(terminal)
+    }
+}
+
+private extension NSView {
+    func firstTerminalDescendant() -> LocalProcessTerminalView? {
+        if let terminal = self as? LocalProcessTerminalView { return terminal }
+        for subview in subviews {
+            if let found = subview.firstTerminalDescendant() { return found }
+        }
+        return nil
+    }
+}
+
 /// Embeds a SwiftTerm terminal running `herdr agent attach` (directly or over ssh).
 struct AttachTerminalView: NSViewRepresentable {
     let device: Device
@@ -568,32 +595,16 @@ struct AttachTerminalView: NSViewRepresentable {
     }
 
     private func configureAppearance(_ view: LocalProcessTerminalView) {
-        let font = TerminalDefaults.font(name: fontName, size: fontSize, weight: fontWeight)
-        if view.font != font {
-            view.font = font
-        }
-        view.allowMouseReporting = mouseReporting
-        // Compared against the inverted value on purpose: thinStrokes on means
-        // smoothing off. The setter only stores the flag, so repaint by hand.
-        if view.fontSmoothing == thinStrokes {
-            view.fontSmoothing = !thinStrokes
-            view.needsDisplay = true
-        }
-        // This setter calls resetFont(), which recomputes metrics and resizes the
-        // terminal, so it is only assigned when it actually changes.
-        if view.lineSpacing != CGFloat(lineSpacing) {
-            view.lineSpacing = CGFloat(lineSpacing)
-        }
-        // Everything below is theme-only and returns early; keep font work above it.
-        guard let view = view as? LineBreakTerminalView,
-              view.appliedDarkAppearance != dark
-        else { return }
-        view.appliedDarkAppearance = dark
-        view.usesLightColors = !dark
-        view.nativeBackgroundColor = dark ? TerminalDefaults.darkBackground : TerminalDefaults.lightBackground
-        view.nativeForegroundColor = dark ? TerminalDefaults.darkForeground : TerminalDefaults.lightForeground
-        view.installColors(dark ? TerminalDefaults.darkPalette : TerminalDefaults.lightPalette)
-        view.needsDisplay = true
+        applyTerminalAppearance(
+            view,
+            fontName: fontName,
+            fontSize: fontSize,
+            thinStrokes: thinStrokes,
+            fontWeight: fontWeight,
+            lineSpacing: lineSpacing,
+            dark: dark,
+            mouseReporting: mouseReporting
+        )
     }
 
     final class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
@@ -621,6 +632,120 @@ struct AttachTerminalView: NSViewRepresentable {
         func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
         func processTerminated(source: TerminalView, exitCode: Int32?) {
             discardAuthorization()
+            let callback = onExit
+            onExit = nil  // report once
+            DispatchQueue.main.async { callback?(exitCode) }
+        }
+    }
+}
+
+func applyTerminalAppearance(
+    _ view: LocalProcessTerminalView,
+    fontName: String, fontSize: Double, thinStrokes: Bool,
+    fontWeight: Double, lineSpacing: Double, dark: Bool, mouseReporting: Bool
+) {
+    let font = TerminalDefaults.font(name: fontName, size: fontSize, weight: fontWeight)
+    if view.font != font {
+        view.font = font
+    }
+    view.allowMouseReporting = mouseReporting
+    // Compared against the inverted value on purpose: thinStrokes on means
+    // smoothing off. The setter only stores the flag, so repaint by hand.
+    if view.fontSmoothing == thinStrokes {
+        view.fontSmoothing = !thinStrokes
+        view.needsDisplay = true
+    }
+    // This setter calls resetFont(), which recomputes metrics and resizes the
+    // terminal, so it is only assigned when it actually changes.
+    if view.lineSpacing != CGFloat(lineSpacing) {
+        view.lineSpacing = CGFloat(lineSpacing)
+    }
+    // Everything below is theme-only and returns early; keep font work above it.
+    guard let view = view as? LineBreakTerminalView,
+          view.appliedDarkAppearance != dark
+    else { return }
+    view.appliedDarkAppearance = dark
+    view.usesLightColors = !dark
+    view.nativeBackgroundColor = dark ? TerminalDefaults.darkBackground : TerminalDefaults.lightBackground
+    view.nativeForegroundColor = dark ? TerminalDefaults.darkForeground : TerminalDefaults.lightForeground
+    view.installColors(dark ? TerminalDefaults.darkPalette : TerminalDefaults.lightPalette)
+    view.needsDisplay = true
+}
+
+/// A local login shell, side by side with the agent attach — no herdr pane and no
+/// attachment paste. It does take first responder when it appears, so splitting hands the
+/// keyboard to the new shell; closing the split gives it back via `focusRemainingTerminal`.
+struct ShellTerminalView: NSViewRepresentable {
+    var fontName: String = ""
+    var fontSize: Double = TerminalDefaults.defaultFontSize
+    var thinStrokes: Bool = true
+    var fontWeight: Double = TerminalDefaults.defaultFontWeight
+    var lineSpacing: Double = TerminalDefaults.defaultLineSpacing
+    var dark: Bool = false
+    var mouseReporting: Bool = true
+    var onExit: ((Int32?) -> Void)? = nil
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeNSView(context: Context) -> LocalProcessTerminalView {
+        let view = LineBreakTerminalView(frame: .zero)
+        view.processDelegate = context.coordinator
+        context.coordinator.onExit = onExit
+        applyTerminalAppearance(
+            view,
+            fontName: fontName,
+            fontSize: fontSize,
+            thinStrokes: thinStrokes,
+            fontWeight: fontWeight,
+            lineSpacing: lineSpacing,
+            dark: dark,
+            mouseReporting: mouseReporting
+        )
+
+        var environment = Terminal.getEnvironmentVariables(termName: "xterm-256color")
+        environment.append("LANG=en_US.UTF-8")
+        view.startProcess(
+            executable: "/bin/sh",
+            args: ["-c", "cd \"$HOME\"; exec \"${SHELL:-/bin/zsh}\" -l"],
+            environment: environment
+        )
+        // Splitting hands the keyboard to the new shell: `makeNSView` runs only when
+        // the split opens (the `.id` is stable across theme changes), so this fires
+        // once per split and never steals focus back afterwards. The hop to the next
+        // runloop pass is required — the view has no `window` yet while this runs.
+        DispatchQueue.main.async { [weak view] in
+            guard let view, let window = view.window else { return }
+            window.makeFirstResponder(view)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: LocalProcessTerminalView, context: Context) {
+        context.coordinator.onExit = onExit
+        applyTerminalAppearance(
+            nsView,
+            fontName: fontName,
+            fontSize: fontSize,
+            thinStrokes: thinStrokes,
+            fontWeight: fontWeight,
+            lineSpacing: lineSpacing,
+            dark: dark,
+            mouseReporting: mouseReporting
+        )
+    }
+
+    static func dismantleNSView(_ nsView: LocalProcessTerminalView, coordinator: Coordinator) {
+        coordinator.onExit = nil
+        nsView.terminate()
+    }
+
+    final class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
+        var onExit: ((Int32?) -> Void)?
+
+        func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
+        func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}
+        func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
+        func processTerminated(source: TerminalView, exitCode: Int32?) {
             let callback = onExit
             onExit = nil  // report once
             DispatchQueue.main.async { callback?(exitCode) }


### PR DESCRIPTION
Splits the terminal pane so a local login shell can run beside the agent — `htop`, `lazygit`, a quick `git` without leaving the app.

**⌘D** splits vertically, **⇧⌘D** horizontally, **⌘W** closes the split and only closes the window once there is no split. The divider drags; the ratio persists in `terminal.splitRatio`, clamped to `0.2...0.8`. Splitting hands the keyboard to the new shell, and closing it gives the keyboard back to the agent.

This is **phase 1 of 3**. Phase 2 adds keyboard focus/resize commands and dimming of the inactive pane; phase 3 adds a remote shell over SSH. Kept separate so each can be reviewed on its own.

### Decisions, and what else was considered

**A hand-rolled split, not `HSplitView`.** `HSplitView` gives no programmatic control of the ratio, and phase 2 needs exactly that for keyboard resize. Building it here means the ratio is a plain `@AppStorage` value that a keyboard command can set later.

**One structural position for both panes, with `AnyLayout` switching the axis.** The obvious shape — `if axis != nil { HStack{…} } else { first() }` — is a trap: SwiftUI does not preserve identity across a `_ConditionalContent` branch swap, and `.id()` does not save it because it sits inside the position that disappears. The first version did exactly this, and every ⌘D destroyed the `AttachTerminalView`, so `dismantleNSView` terminated `herdr agent attach` and a fresh one came up with `--takeover`. It looked fine, because herdr repaints the pane on reattach; the ssh PID going `<defunct>` with a new one beside it is what gave it away. `AnyLayout` swaps `HStackLayout`/`VStackLayout` without touching child identity. There is a comment on the type saying so, because the buggy shape is the one that reads as simpler.

**The drag uses `DragGesture.translation`, not `.location`.** `location` is measured against the view the gesture is attached to — the 7pt hit strip — not the container, so `location / total` collapsed to the lower clamp and the divider jumped on mouse-down. `.coordinateSpace(.named(_:))` would also work but is macOS 15+, and this target is 14.0, so the anchor-plus-delta approach it is.

**A local child process, not a herdr pane.** Attaching a herdr pane with no agent in it was the first idea; `herdr agent attach` rejects it with `agent_not_found` (checked against a live 0.8.0 socket). So the shell is `/bin/sh -c 'cd "$HOME"; exec "${SHELL:-/bin/zsh}" -l'`. The `exec` is load-bearing rather than cosmetic: `LocalProcess.terminate()` only `SIGTERM`s the direct child, so exec'ing over `/bin/sh` is what keeps a closed split from leaving a stray process behind.

**Two panes, not a grid.** No nesting, no N-way splits — the use case is one agent plus one shell.

**⌘W prefers the split.** Same trade-off this app already made with ⌘N for New Agent. The menu item retitles itself to "Close Split" so the binding is visible, and the split buttons are disabled without a selected agent — otherwise a split could be set but invisible, and the next ⌘W would close nothing.

### Notes for review

- `configureAppearance` moved out of `AttachTerminalView` into a file-level `applyTerminalAppearance` so the shell shares it. The body is unchanged; only the signature is new.
- The shell gets no `attachmentService`/`attachmentCapabilities`, so attachment paste stays off for it.
- One pre-existing wart this now exercises more often: `LocalProcess.terminate()` does not `waitpid`, so each closed split leaves a `<defunct>` child for the app's lifetime. Shared with the attach path and untouched here — happy to fix separately if you want it.

Verified: Debug build clean, `swift test` in `Packages/HerdrKit` 64 passing (the Kit is untouched), and the interactive behaviour above exercised by hand — split both ways with `lazygit` inside, divider drag and ratio surviving a relaunch, focus in and out, both halves of ⌘W, and `exit` closing the split on its own.
