### PR TITLE
feat(terminal): focus, dim and keyboard-resize the ⌘D split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ the Sparkle update description — a release without a section here fails CI.
   and closing the split hands it back to the agent. ⌘W closes the split first
   and only closes the window once it's gone. First phase of a series; keyboard
   focus/resize controls and a remote shell over SSH follow in later issues.
+- The ⌘D split now shows which terminal has the keyboard and can be driven
+  without the mouse: the active pane stays at full opacity while the inactive
+  one dims. **Focus Left/Right Pane** (⌥⌘←/→) and **Focus Top/Bottom Pane**
+  (⌥⌘↑/↓) move focus directionally, so repeating a shortcut is idempotent
+  rather than toggling. **Widen/Narrow Active Pane** (⌃⌘→/←) and **Grow/Shrink
+  Active Pane** (⌃⌘↓/↑) resize in 5% steps, clamped to the same 20%/80% the
+  divider already enforces. Jumping to an agent from ⌘K or a notification puts
+  the keyboard on the agent's side. (#9)
 
 ## [0.3.9] - 2026-08-21
 

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import HerdrKit
+import SwiftTerm
 import SwiftUI
 
 enum ConnectionState: Equatable {
@@ -41,6 +42,10 @@ struct SSHAuthenticationRequest: Identifiable {
 /// vertical = panes side by side with a vertical divider (iTerm2's convention).
 enum SplitAxis { case vertical, horizontal }
 
+/// Identifies one of the two panes in the ⌘D split. Used for focus tracking and
+/// keyboard-driven resize; standalone `ShellSession`s are not part of this.
+enum SplitSide { case agent, shell }
+
 /// A standalone local shell shown as its own sidebar entry — not a herdr pane
 /// (herdr refuses to attach agent-less panes) and not the ⌘D split.
 struct ShellSession: Identifiable, Equatable {
@@ -62,6 +67,22 @@ final class AppModel: ObservableObject {
     @Published var showNewSpace = false
     @Published var showSearch = false
     @Published var shellSplitAxis: SplitAxis?
+    /// The pane that currently holds the keyboard within the ⌘D split. Reset to
+    /// the agent side whenever the split closes so reopening it is predictable.
+    @Published var activeSplitSide: SplitSide = .agent
+    /// Persisted divider ratio for the ⌘D split, shared with the resize commands.
+    /// Deliberately not `@AppStorage`: that publishes only from inside a View, so the
+    /// menu commands would write UserDefaults without ever redrawing the split.
+    @Published var splitRatio: Double =
+        UserDefaults.standard.object(forKey: AppModel.splitRatioKey) as? Double ?? 0.5
+    {
+        didSet { UserDefaults.standard.set(splitRatio, forKey: AppModel.splitRatioKey) }
+    }
+    static let splitRatioKey = "terminal.splitRatio"
+    /// Live terminal views of the ⌘D split, used by menu commands to move focus.
+    /// Held weakly so the views are not kept alive by the model.
+    weak var splitAgentView: LocalProcessTerminalView?
+    weak var splitShellView: LocalProcessTerminalView?
     /// Standalone local terminals. Their views stay alive while deselected —
     /// unlike agents, a local shell has no server side to reattach to.
     @Published var shellSessions: [ShellSession] = []
@@ -224,7 +245,12 @@ final class AppModel: ObservableObject {
         }
     }
 
-    /// Jump target used by notification clicks.
+    /// Set by `reveal` when a jump lands while the ⌘D split is open, and consumed once the
+    /// main window is key again. Only an actual jump sets it: dismissing the search with
+    /// Escape never calls `reveal`, and the sidebar assigns `selectedPane` directly.
+    @Published var pendingSplitAgentFocus = false
+
+    /// Jump target used by the search sheet and by notification clicks.
     func reveal(_ ref: PaneRef) {
         if let filter = deviceFilter, filter != ref.deviceID {
             deviceFilter = nil
@@ -232,6 +258,16 @@ final class AppModel: ObservableObject {
         selectedSpace = nil
         selectedPane = ref
         selectedShellID = nil
+        // Only the search sheet needs the deferred request: its dismissal restores the
+        // parent window's previous responder after the view tree has asked for focus.
+        // `showSearch` is still true here — SearchView calls this before dismissing.
+        //
+        // Notification clicks deliberately do NOT arm it. With the app already frontmost
+        // there may be no key-window transition at all, so nothing would consume the flag
+        // and a later unrelated activation would cash it in, pulling the keyboard out of
+        // the shell. Those clicks get focus from the recreated attach and from the
+        // entry-change request instead.
+        if shellSplitAxis != nil, showSearch { pendingSplitAgentFocus = true }
     }
 
     // MARK: - Shell terminals

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -49,6 +49,7 @@ struct RootView: View {
                 .hidden()
         )
         .focusedSceneValue(\.appModel, model)
+        .focusedSceneValue(\.splitAxis, model.shellSplitAxis)
         .sheet(isPresented: $model.showSearch) { SearchSheet(model: model) }
         .ignoresSafeArea(.container, edges: .top)
         .frame(minWidth: 980, minHeight: 620)
@@ -110,6 +111,13 @@ struct DetailView: View {
                 .clipped()
                 // Losing the selected agent tears the SplitContainer down without
                 // resetting the axis, which would leave the same phantom split.
+                //
+                // Load-bearing beyond that: this is the ONLY thing that clears the axis
+                // when the agent goes away. `dismantleNSView` nils the coordinator's
+                // onExit before killing the shell, so the shell's own onExit never fires
+                // on teardown. Remove this and "split open with no agent selected"
+                // becomes reachable, which is a state a deferred focus request can be
+                // armed into with nothing left in the tree to consume it.
                 .onChange(of: model.selectedEntry?.id) { _, id in
                     if id == nil { model.shellSplitAxis = nil }
                 }
@@ -219,7 +227,6 @@ struct DetailView: View {
     @AppStorage(TerminalDefaults.fontWeightKey) private var terminalFontWeight = TerminalDefaults.defaultFontWeight
     @AppStorage(TerminalDefaults.lineSpacingKey) private var terminalLineSpacing = TerminalDefaults.defaultLineSpacing
     @AppStorage("terminal.mouseReporting") private var terminalMouseReporting = true
-    @AppStorage("terminal.splitRatio") private var splitRatio = 0.5
     @Environment(\.colorScheme) private var colorScheme
     /// The entry whose attach process exited, and how. Keyed by entry id so a stale
     /// exit from a previously selected pane never covers a live terminal.
@@ -227,6 +234,7 @@ struct DetailView: View {
     @State private var endedAttachCode: Int32?
     @State private var attachRetry = 0
     @State private var uploadingAttachment = false
+    @State private var splitTracker = SplitFocusTracker()
 
     @ViewBuilder
     private var terminal: some View {
@@ -260,7 +268,11 @@ struct DetailView: View {
     @ViewBuilder
     private var agentTerminal: some View {
         if let entry = model.selectedEntry {
-            SplitContainer(axis: model.shellSplitAxis, ratio: $splitRatio) {
+            SplitContainer(
+                axis: model.shellSplitAxis,
+                activeSide: model.activeSplitSide,
+                ratio: $model.splitRatio
+            ) {
                 ZStack {
                     AttachTerminalView(
                         device: entry.device,
@@ -282,6 +294,10 @@ struct DetailView: View {
                         onExit: { code in
                             endedAttachKey = entry.id
                             endedAttachCode = code
+                        },
+                        onViewReady: {
+                            splitTracker.agentView = $0
+                            model.splitAgentView = $0
                         }
                     )
                         .id("attach-\(entry.id)-\(colorScheme)-\(attachRetry)")
@@ -300,7 +316,11 @@ struct DetailView: View {
                     lineSpacing: terminalLineSpacing,
                     dark: colorScheme == .dark,
                     mouseReporting: terminalMouseReporting,
-                    onExit: { _ in model.shellSplitAxis = nil }
+                    onExit: { _ in model.shellSplitAxis = nil },
+                    onViewReady: {
+                        splitTracker.shellView = $0
+                        model.splitShellView = $0
+                    }
                 )
                     // Deliberately not keyed on colorScheme like the attach above:
                     // a new id tears the view down and kills the shell with whatever
@@ -315,16 +335,44 @@ struct DetailView: View {
             .overlay(alignment: .bottomTrailing) {
                 if uploadingAttachment { uploadIndicator }
             }
+            .onAppear {
+                // Single source of truth: the tracker writes straight into the model
+                // instead of holding its own copy for a second onChange to mirror.
+                splitTracker.onSideChanged = { model.activeSplitSide = $0 }
+                splitTracker.start()
+            }
             .onChange(of: entry.id) { _, _ in
                 endedAttachKey = nil
                 uploadingAttachment = false
+                if model.shellSplitAxis != nil { focusTerminal(model.splitAgentView) }
+            }
+            // Keyed on the window becoming key rather than on a delay: that is the event
+            // that follows the sheet's responder restore. Filtered to the terminal's own
+            // window and consumed no matter which window it was, so a pending request can
+            // never survive to a later, unrelated activation — coming back from ⌘Tab or
+            // closing Settings would otherwise yank the keyboard into a live agent.
+            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { note in
+                guard model.pendingSplitAgentFocus else { return }
+                model.pendingSplitAgentFocus = false
+                guard let window = note.object as? NSWindow,
+                      window === model.splitAgentView?.window
+                else { return }
+                focusTerminal(model.splitAgentView)
             }
             // Splitting moves the keyboard to the shell, so closing the split has to
-            // hand it back — by ⌘W or by the shell exiting on its own.
+            // hand it back — by ⌘W or by the shell exiting on its own. Reset the
+            // tracked side to the agent so the next split starts predictably.
             .onChange(of: model.shellSplitAxis) { _, axis in
-                if axis == nil { focusRemainingTerminal() }
+                if axis == nil {
+                    model.activeSplitSide = .agent
+                    model.pendingSplitAgentFocus = false
+                    focusRemainingTerminal()
+                }
             }
         } else {
+            // The .onReceive below only exists on the branch above, so a request armed
+            // while no agent is selected would have no consumer and would be cashed in by
+            // some later activation. Revealing a pane that has since gone away lands here.
             VStack(spacing: 10) {
                 Image(systemName: "terminal")
                     .font(.system(size: 28, weight: .light))
@@ -346,6 +394,7 @@ struct DetailView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Theme.terminalBackground)
+            .onAppear { model.pendingSplitAgentFocus = false }
         }
     }
 

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -2,6 +2,7 @@ import AppKit
 import Darwin
 import HerdrKit
 import Sparkle
+import SwiftTerm
 import SwiftUI
 import UserNotifications
 
@@ -29,10 +30,25 @@ private struct AppModelFocusedValueKey: FocusedValueKey {
     typealias Value = AppModel
 }
 
+/// The split axis travels as its own focused value, not read off the model. `Commands`
+/// gets the AppModel by reference and never subscribes to its objectWillChange, so
+/// `focusedModel?.shellSplitAxis` was evaluated once and stuck: the menu items stayed
+/// disabled with a split open, and a disabled NSMenuItem does not fire its key
+/// equivalent. A value type changes identity, which does invalidate the commands body —
+/// that is also what lets the shortcuts follow the current axis.
+private struct SplitAxisFocusedValueKey: FocusedValueKey {
+    typealias Value = SplitAxis
+}
+
 extension FocusedValues {
     var appModel: AppModel? {
         get { self[AppModelFocusedValueKey.self] }
         set { self[AppModelFocusedValueKey.self] = newValue }
+    }
+
+    var splitAxis: SplitAxis? {
+        get { self[SplitAxisFocusedValueKey.self] }
+        set { self[SplitAxisFocusedValueKey.self] = newValue }
     }
 }
 
@@ -41,6 +57,7 @@ struct HerdrMApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @AppStorage("app.theme") private var themePreference = "system"
     @FocusedValue(\.appModel) private var focusedModel
+    @FocusedValue(\.splitAxis) private var focusedSplitAxis
 
     private let updaterController: SPUStandardUpdaterController
 
@@ -96,6 +113,62 @@ struct HerdrMApp: App {
                 Button("Split Horizontally") { focusedModel?.shellSplitAxis = .horizontal }
                     .keyboardShortcut("d", modifiers: [.command, .shift])
                     .disabled(focusedModel?.selectedEntry == nil)
+
+                Divider()
+
+                // Eight items with FIXED shortcuts, enabled per axis — deliberately not
+                // four items whose shortcut follows the axis. Measured: `.disabled` IS
+                // revalidated when the menu opens, but a key equivalent already registered
+                // in the NSMenu is NOT reassigned when the commands body re-evaluates, so
+                // the arrows stayed frozen on the axis that was current at launch.
+                // Labels name the direction so no two rows read the same.
+                //
+                // Focus is directional and idempotent: the left/top pane is always the
+                // agent, the right/bottom one always the shell.
+                Button("Focus Left Pane") {
+                    if let model = focusedModel { focusSplitSide(.agent, in: model) }
+                }
+                .keyboardShortcut(.leftArrow, modifiers: [.command, .option])
+                .disabled(focusedSplitAxis != .vertical)
+                Button("Focus Right Pane") {
+                    if let model = focusedModel { focusSplitSide(.shell, in: model) }
+                }
+                .keyboardShortcut(.rightArrow, modifiers: [.command, .option])
+                .disabled(focusedSplitAxis != .vertical)
+                Button("Focus Top Pane") {
+                    if let model = focusedModel { focusSplitSide(.agent, in: model) }
+                }
+                .keyboardShortcut(.upArrow, modifiers: [.command, .option])
+                .disabled(focusedSplitAxis != .horizontal)
+                Button("Focus Bottom Pane") {
+                    if let model = focusedModel { focusSplitSide(.shell, in: model) }
+                }
+                .keyboardShortcut(.downArrow, modifiers: [.command, .option])
+                .disabled(focusedSplitAxis != .horizontal)
+
+                Divider()
+
+                // Resize moves the divider by 5% relative to the active pane.
+                Button("Widen Active Pane") {
+                    if let model = focusedModel { resizeSplit(grow: true, in: model) }
+                }
+                .keyboardShortcut(.rightArrow, modifiers: [.command, .control])
+                .disabled(focusedSplitAxis != .vertical)
+                Button("Narrow Active Pane") {
+                    if let model = focusedModel { resizeSplit(grow: false, in: model) }
+                }
+                .keyboardShortcut(.leftArrow, modifiers: [.command, .control])
+                .disabled(focusedSplitAxis != .vertical)
+                Button("Grow Active Pane") {
+                    if let model = focusedModel { resizeSplit(grow: true, in: model) }
+                }
+                .keyboardShortcut(.downArrow, modifiers: [.command, .control])
+                .disabled(focusedSplitAxis != .horizontal)
+                Button("Shrink Active Pane") {
+                    if let model = focusedModel { resizeSplit(grow: false, in: model) }
+                }
+                .keyboardShortcut(.upArrow, modifiers: [.command, .control])
+                .disabled(focusedSplitAxis != .horizontal)
             }
             CommandGroup(replacing: .saveItem) {
                 // ⌘W closes the most local thing first: the split, then the
@@ -130,6 +203,23 @@ struct HerdrMApp: App {
         case "dark": NSApp.appearance = NSAppearance(named: .darkAqua)
         default: NSApp.appearance = nil
         }
+    }
+
+    // MARK: - Split commands
+
+    private func focusSplitSide(_ side: SplitSide, in model: AppModel) {
+        guard model.shellSplitAxis != nil else { return }
+        let target = (side == .agent) ? model.splitAgentView : model.splitShellView
+        guard let target, let window = target.window else { return }
+        window.makeFirstResponder(target)
+    }
+
+    private func resizeSplit(grow: Bool, in model: AppModel) {
+        guard model.shellSplitAxis != nil else { return }
+        let step = 0.05
+        let signed = (model.activeSplitSide == .agent) ? step : -step
+        let delta = grow ? signed : -signed
+        model.splitRatio = min(0.8, max(0.2, model.splitRatio + delta))
     }
 
     private static func runSSHAskPass() -> Never {

--- a/Sources/HerdrM/SplitContainer.swift
+++ b/Sources/HerdrM/SplitContainer.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftTerm
 import SwiftUI
 
 /// A two-pane split with a draggable divider and a persisted ratio. `axis == nil` shows
@@ -11,6 +12,7 @@ import SwiftUI
 /// split — which killed the agent's attach process and relaunched it with `--takeover`.
 struct SplitContainer<First: View, Second: View>: View {
     let axis: SplitAxis?
+    let activeSide: SplitSide
     @Binding var ratio: Double
     @ViewBuilder var first: () -> First
     @ViewBuilder var second: () -> Second
@@ -39,10 +41,12 @@ struct SplitContainer<First: View, Second: View>: View {
                         width: axis == .vertical ? firstLength : nil,
                         height: axis == .horizontal ? firstLength : nil
                     )
+                    .opacity(paneOpacity(for: .agent))
                 if let axis {
                     divider(axis: axis, total: total)
                     second()
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .opacity(paneOpacity(for: .shell))
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -50,6 +54,11 @@ struct SplitContainer<First: View, Second: View>: View {
             // clearing on axis change covers the case that shows.
             .onChange(of: axis) { _, _ in dragStartRatio = nil }
         }
+    }
+
+    private func paneOpacity(for side: SplitSide) -> Double {
+        guard axis != nil else { return 1.0 }
+        return activeSide == side ? 1.0 : inactivePaneOpacity
     }
 
     private func divider(axis: SplitAxis, total: CGFloat) -> some View {
@@ -95,3 +104,68 @@ private enum SplitContainerRatioBounds {
         Swift.min(Swift.max(value, bounds.lowerBound), bounds.upperBound)
     }
 }
+
+/// Tracks which side of the ⌘D split holds the keyboard by KVO-observing the key
+/// window's `firstResponder`. `LocalProcessTerminalView`'s responder methods are
+/// `public override`, not `open`, so they cannot be subclassed.
+///
+/// `NSWindow.firstResponder` is documented as KVO-observable. `NSApplication.keyWindow`
+/// is NOT documented as such, but was verified empirically to fire — including on the
+/// transitions through nil — so the observer reinstalls itself when the key window
+/// changes. Treat that half as a measured, non-contractual dependency on AppKit.
+///
+/// This class holds no copy of the active side on purpose: it reports every computed
+/// value to `onSideChanged` without deduplicating. A cached side here went stale when
+/// the split closed and then silently stopped reporting, which drew the active pane
+/// dimmed and inverted the resize direction.
+///
+/// AppKit changes `firstResponder` and `keyWindow` on the main thread, so the callback
+/// is delivered there too.
+final class SplitFocusTracker {
+    /// Called with the side that now holds the keyboard. Fires on every observed
+    /// change, even when the value repeats — see the note above.
+    var onSideChanged: ((SplitSide) -> Void)?
+
+    weak var agentView: LocalProcessTerminalView?
+    weak var shellView: LocalProcessTerminalView?
+
+    private var keyWindowObservation: NSKeyValueObservation?
+    private var firstResponderObservation: NSKeyValueObservation?
+
+    func start() {
+        keyWindowObservation = NSApp.observe(\.keyWindow, options: [.new]) { [weak self] _, _ in
+            self?.installFirstResponderObserver()
+        }
+        installFirstResponderObserver()
+    }
+
+    private func installFirstResponderObserver() {
+        firstResponderObservation?.invalidate()
+        firstResponderObservation = NSApp.keyWindow?.observe(
+            \.firstResponder,
+            options: [.new]
+        ) { [weak self] _, _ in
+            self?.updateActiveSide()
+        }
+        updateActiveSide()
+    }
+
+    private func updateActiveSide() {
+        guard let responder = NSApp.keyWindow?.firstResponder as? NSView else { return }
+        var view: NSView? = responder
+        while let current = view {
+            if current === agentView { onSideChanged?(.agent); return }
+            if current === shellView { onSideChanged?(.shell); return }
+            view = current.superview
+        }
+    }
+
+    deinit {
+        keyWindowObservation?.invalidate()
+        firstResponderObservation?.invalidate()
+    }
+}
+
+/// Dims the inactive pane enough to show which side has the keyboard without making
+/// its text unreadable. Tuned visually; deliberately not exposed as a setting.
+private let inactivePaneOpacity = 0.55

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -503,6 +503,15 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
     }
 }
 
+/// Puts the keyboard in a specific terminal, one runloop pass later so it lands after
+/// AppKit has finished its own first-responder bookkeeping for the current event.
+func focusTerminal(_ view: LocalProcessTerminalView?) {
+    DispatchQueue.main.async {
+        guard let view, let window = view.window else { return }
+        window.makeFirstResponder(view)
+    }
+}
+
 /// Hands the keyboard back to whichever terminal is left after a split closes. The
 /// shell view that held first responder is gone by then, and AppKit falls back to the
 /// window itself, which reads as a dead keyboard until the user clicks.
@@ -558,6 +567,9 @@ struct AttachTerminalView: NSViewRepresentable {
     /// dead session otherwise keeps its last frame and silently eats every
     /// keystroke, which reads as a freeze.
     var onExit: ((Int32?) -> Void)? = nil
+    /// Delivers the created view so a focus tracker can observe its window's
+    /// first responder without retaining the terminal itself.
+    var onViewReady: ((LocalProcessTerminalView) -> Void)? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -593,6 +605,7 @@ struct AttachTerminalView: NSViewRepresentable {
             guard let view, let window = view.window else { return }
             window.makeFirstResponder(view)
         }
+        onViewReady?(view)
         return view
     }
 
@@ -735,6 +748,9 @@ struct ShellTerminalView: NSViewRepresentable {
     var dark: Bool = false
     var mouseReporting: Bool = true
     var onExit: ((Int32?) -> Void)? = nil
+    /// Delivers the created view so a focus tracker can observe its window's
+    /// first responder without retaining the terminal itself.
+    var onViewReady: ((LocalProcessTerminalView) -> Void)? = nil
 
     func makeCoordinator() -> Coordinator { Coordinator() }
 
@@ -772,6 +788,7 @@ struct ShellTerminalView: NSViewRepresentable {
             guard let view, let window = view.window else { return }
             window.makeFirstResponder(view)
         }
+        onViewReady?(view)
         return view
     }
 


### PR DESCRIPTION
Phase 2 of 3, building on #36. **Please merge #36 first** — this branch assumes the `SplitContainer` and the Terminal menu it introduced.

### What came out of your review of #36

Your two follow-ups on that PR shaped this one, so before anything else:

- **The comment hygiene you had to fix by hand is now a gate, not a good intention.** You stripped a `ponytail:` marker (a codename from my own tooling that had no business in this repo) and translated a Spanish doc comment in `AppModel.swift`. Both were my leak. I added two mechanical greps that run before the PR is cut and refuse non-English comments and any tooling marker in `Sources/` and `Packages/`. Run against #36's diff retroactively, the gate catches exactly the marker you deleted. This diff is clean by that gate, and so will the next one be.
- **Your `SIGHUP` fix stands untouched, and it corrected me.** I had reported the closed split as leaving a zombie; you found it leaving a *live* orphaned `zsh`, because interactive shells ignore `SIGTERM` on purpose. Nothing here touches `dismantleNSView` or the reaping escalation.
- **The line you drew between the split and standalone terminals is respected.** You said the ⌘D split stays unchanged and separate when you added `shellSessions`, so this phase touches only the split: dimming, focus and resize never look at `shellSessions` or `selectedShellID`. With one standalone terminal selected there is no second pane to move between, so there is nothing to add there.
- **And your reasoning about "the wrong shape" got applied to the menu.** You rejected New Terminal reusing the split because it required a selected agent and read like a mode toggle. Same test here: the first version of these commands was four rows whose shortcut followed the axis, which produced duplicate-looking rows and, worse, did not work. The menu now names each row by direction and enables the pair that matches the current axis.

### What this adds

The active pane keeps full colour and the inactive one dims to `0.55`, so it is obvious which terminal has the keyboard. **⌥⌘←/↑** focuses the agent, **⌥⌘→/↓** the shell — directional, so repeating a key is idempotent rather than ping-ponging. **⌃⌘** plus arrows resizes the active pane by 5%, clamped to the same `0.2...0.8` the divider already uses, with "grow" meaning *take space from the other side* regardless of which pane is active.

### Three AppKit findings worth knowing, all measured rather than reasoned

**Focus tracking cannot subclass the responder methods.** `LocalProcessTerminalView` declares `becomeFirstResponder` and `resignFirstResponder` as `public override`, not `open`. So the active side comes from KVO on the key window's `firstResponder`. `NSWindow.firstResponder` is documented as observable; `NSApplication.keyWindow` is not, but it does fire — verified with a standalone AppKit probe, including the transitions through `nil`, which is what lets the observer reinstall itself when the key window changes. Treating that half as measured rather than contractual is deliberate.

**`Commands` does not observe an `ObservableObject` it receives through `@FocusedValue`.** Reading `focusedModel?.shellSplitAxis` inside the commands body evaluates once and sticks, so the items stayed disabled with a split open — and a disabled `NSMenuItem` never fires its key equivalent. The axis now travels as its own focused value, a value type, which does invalidate the body. Worth flagging because the existing ⌘N and ⌘W items depend on the same mechanism and simply never exposed it: their conditions are non-nil from launch.

**`.disabled` and `.keyboardShortcut` are not revalidated alike.** `.disabled` is re-evaluated when the menu opens, but a key equivalent already registered in the `NSMenu` is *not* reassigned when the body re-evaluates: a shortcut computed from the current axis stayed frozen on whichever axis existed at launch. Hence fixed shortcuts plus per-axis enablement, depending only on the mechanism that demonstrably revalidates.

**Dismissing a sheet restores the parent window's previous first responder.** Jumping to an agent from ⌘K left the keyboard in the shell, because that restore lands after the recreated attach asks for focus. Without a split nothing notices, since the responder being restored no longer exists. The focus request is keyed on the search closing — not on the selected entry changing, because picking the agent that was already selected leaves its id untouched — and is re-asserted on `NSWindow.didBecomeKeyNotification`, the event that follows the restore. No timing delay: the ordering comes from the event.

### Verified

Debug build clean; `swift test` in `Packages/HerdrKit` 64 passing (the Kit is untouched). Exercised by hand: dimming follows the keyboard, both focus directions in both axes, resize hitting the 20/80 stops, the axis switch swapping which arrow pair responds, jumping from search to both a different agent and the already-selected one, and no stray behaviour with no split open. The dimmed pane keeps its text sharp, so thin strokes survive the compositing — that was the one risk I could not settle by reading.

Phase 3 (#10 in my fork) adds a remote shell over SSH for the split.
