### PR TITLE
feat(sidebar): drag-reorder Spaces via workspace.move_block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ the Sparkle update description — a release without a section here fails CI.
   touching emoji or CJK fallback. (#34)
 
 ### Added
+- Spaces in the sidebar can be drag-reordered. The drop calls herdr's
+  `workspace.move_block` (same RPC the TUI uses) so the order is the
+  session's, not a herdrm-only list; worktree groups move as a block.
+  Cross-device drops are ignored. (#38)
 - **New Terminal** in the sidebar opens a standalone local shell as its own
   entry under a TERMINALS section — full pane, selectable like an agent, and
   it keeps running while you switch away. Every click opens another one;

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -310,6 +310,31 @@ public actor HerdrService {
         )
     }
 
+    /// Places one workspace at `insertIndex` in the device's workspace list
+    /// (`0...count`). Prefer `moveWorkspaceBlock` for sidebar drag: it is how
+    /// the herdr TUI reorders spaces, and it moves a worktree group atomically.
+    public func moveWorkspace(workspaceID: String, insertIndex: UInt) async throws {
+        _ = try await client().request(
+            method: "workspace.move",
+            params: .object([
+                "workspace_id": .string(workspaceID),
+                "insert_index": .number(Double(insertIndex)),
+            ])
+        )
+    }
+
+    /// Moves `workspaceIDs` as a block so they sit immediately before
+    /// `beforeWorkspaceID`, or at the end of the list when that is nil.
+    public func moveWorkspaceBlock(workspaceIDs: [String], beforeWorkspaceID: String?) async throws {
+        var params: [String: JSONValue] = [
+            "workspace_ids": .array(workspaceIDs.map { .string($0) }),
+        ]
+        if let beforeWorkspaceID {
+            params["before_workspace_id"] = .string(beforeWorkspaceID)
+        }
+        _ = try await client().request(method: "workspace.move_block", params: .object(params))
+    }
+
     /// Creates a tab (optionally in a workspace/cwd) and returns the new pane id.
     public func createTab(workspaceID: String?, cwd: String?, label: String?) async throws -> String {
         var params: [String: JSONValue] = ["focus": .bool(false)]

--- a/Packages/HerdrKit/Sources/HerdrKit/WorkspaceReorder.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/WorkspaceReorder.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Computes a `workspace.move_block` call from a sidebar drop.
+///
+/// `orderedIDs` is one device's workspace list (herdr's `number` order). The
+/// drop target is another id in that list; `placeAfter` is which half of the
+/// row the pointer was in. Returns `nil` when the drop would not change order
+/// (same row, already adjacent, unknown ids).
+public enum WorkspaceReorder: Sendable {
+    public struct Plan: Equatable, Sendable {
+        public let workspaceIDs: [String]
+        public let beforeWorkspaceID: String?
+
+        public init(workspaceIDs: [String], beforeWorkspaceID: String?) {
+            self.workspaceIDs = workspaceIDs
+            self.beforeWorkspaceID = beforeWorkspaceID
+        }
+    }
+
+    public static func plan(
+        moving: String,
+        onto: String,
+        placeAfter: Bool,
+        orderedIDs: [String]
+    ) -> Plan? {
+        guard orderedIDs.contains(moving), orderedIDs.contains(onto) else { return nil }
+
+        let before: String?
+        if placeAfter {
+            guard let ontoIndex = orderedIDs.firstIndex(of: onto) else { return nil }
+            let next = orderedIDs.index(after: ontoIndex)
+            before = next < orderedIDs.endIndex ? orderedIDs[next] : nil
+        } else {
+            before = onto
+        }
+
+        if before == moving { return nil }
+        if isAlreadyThere(moving: moving, before: before, orderedIDs: orderedIDs) {
+            return nil
+        }
+        return Plan(workspaceIDs: [moving], beforeWorkspaceID: before)
+    }
+
+    /// Applies a block move to a workspace array the same way herdr does:
+    /// pull `workspaceIDs` out, then splice them in before `beforeWorkspaceID`
+    /// (or at the end when that is nil).
+    public static func applying<T>(
+        _ items: [T],
+        id: (T) -> String,
+        plan: Plan
+    ) -> [T] {
+        let moving = Set(plan.workspaceIDs)
+        var remaining = items.filter { !moving.contains(id($0)) }
+        let block = plan.workspaceIDs.compactMap { wanted in items.first { id($0) == wanted } }
+        let insertAt: Int
+        if let before = plan.beforeWorkspaceID {
+            insertAt = remaining.firstIndex { id($0) == before } ?? remaining.count
+        } else {
+            insertAt = remaining.count
+        }
+        remaining.insert(contentsOf: block, at: insertAt)
+        return remaining
+    }
+
+    private static func isAlreadyThere(
+        moving: String,
+        before: String?,
+        orderedIDs: [String]
+    ) -> Bool {
+        guard let movingIndex = orderedIDs.firstIndex(of: moving) else { return false }
+        if let before {
+            return orderedIDs.firstIndex(of: before) == orderedIDs.index(after: movingIndex)
+        }
+        return movingIndex == orderedIDs.index(before: orderedIDs.endIndex)
+    }
+}

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
@@ -127,6 +127,31 @@ final class LocalSocketTests: XCTestCase {
         let result = try await withTimeout(seconds: 10) { try await collector.value }
         XCTAssertFalse(result.isEmpty, "no events received for tab lifecycle")
     }
+
+    func testMoveWorkspaceBlockReordersTemporarySpaces() async throws {
+        try requireLocalHerdr()
+        let service = HerdrService(device: .local, autoStartLocalServer: false)
+        _ = try await service.connect()
+        let cwd = NSTemporaryDirectory()
+        let first = try await service.createWorkspace(label: "herdrm-reorder-a", cwd: cwd)
+        let second = try await service.createWorkspace(label: "herdrm-reorder-b", cwd: cwd)
+        do {
+            try await service.moveWorkspaceBlock(
+                workspaceIDs: [second.workspaceID],
+                beforeWorkspaceID: first.workspaceID
+            )
+            let ids = try await service.workspaces().map(\.workspaceID)
+            let a = try XCTUnwrap(ids.firstIndex(of: first.workspaceID))
+            let b = try XCTUnwrap(ids.firstIndex(of: second.workspaceID))
+            XCTAssertEqual(b + 1, a)
+            try await service.closeWorkspace(workspaceID: first.workspaceID)
+            try await service.closeWorkspace(workspaceID: second.workspaceID)
+        } catch {
+            try? await service.closeWorkspace(workspaceID: first.workspaceID)
+            try? await service.closeWorkspace(workspaceID: second.workspaceID)
+            throw error
+        }
+    }
 }
 
 func withTimeout<T: Sendable>(seconds: TimeInterval, _ body: @escaping @Sendable () async throws -> T) async throws -> T {

--- a/Packages/HerdrKit/Tests/HerdrKitTests/WorkspaceReorderTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/WorkspaceReorderTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import HerdrKit
+
+final class WorkspaceReorderTests: XCTestCase {
+    private let order = ["A", "B", "C"]
+
+    func testDropOnEarlierRowInsertsBeforeIt() {
+        let plan = WorkspaceReorder.plan(
+            moving: "B", onto: "A", placeAfter: false, orderedIDs: order
+        )
+        XCTAssertEqual(plan, WorkspaceReorder.Plan(workspaceIDs: ["B"], beforeWorkspaceID: "A"))
+        XCTAssertEqual(WorkspaceReorder.applying(order, id: { $0 }, plan: plan!), ["B", "A", "C"])
+    }
+
+    func testDropOnLowerHalfOfLastRowAppends() {
+        let plan = WorkspaceReorder.plan(
+            moving: "A", onto: "C", placeAfter: true, orderedIDs: order
+        )
+        XCTAssertEqual(plan, WorkspaceReorder.Plan(workspaceIDs: ["A"], beforeWorkspaceID: nil))
+        XCTAssertEqual(WorkspaceReorder.applying(order, id: { $0 }, plan: plan!), ["B", "C", "A"])
+    }
+
+    func testDropOnLowerHalfWhenNextIsTheDraggedRowIsNoOp() {
+        XCTAssertNil(WorkspaceReorder.plan(
+            moving: "B", onto: "A", placeAfter: true, orderedIDs: order
+        ))
+    }
+
+    func testAlreadyImmediatelyBeforeTheTargetIsNoOp() {
+        XCTAssertNil(WorkspaceReorder.plan(
+            moving: "A", onto: "B", placeAfter: false, orderedIDs: order
+        ))
+        XCTAssertNil(WorkspaceReorder.plan(
+            moving: "C", onto: "C", placeAfter: false, orderedIDs: order
+        ))
+        XCTAssertNil(WorkspaceReorder.plan(
+            moving: "C", onto: "C", placeAfter: true, orderedIDs: order
+        ))
+    }
+
+    func testMoveLastToFront() {
+        let plan = WorkspaceReorder.plan(
+            moving: "C", onto: "A", placeAfter: false, orderedIDs: order
+        )
+        XCTAssertEqual(plan, WorkspaceReorder.Plan(workspaceIDs: ["C"], beforeWorkspaceID: "A"))
+        XCTAssertEqual(WorkspaceReorder.applying(order, id: { $0 }, plan: plan!), ["C", "A", "B"])
+    }
+
+    func testUnknownIdsAreRejected() {
+        XCTAssertNil(WorkspaceReorder.plan(
+            moving: "A", onto: "Z", placeAfter: false, orderedIDs: order
+        ))
+        XCTAssertNil(WorkspaceReorder.plan(
+            moving: "Z", onto: "A", placeAfter: false, orderedIDs: order
+        ))
+    }
+}

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -607,6 +607,40 @@ final class AppModel: ObservableObject {
         }
     }
 
+    /// Reorders a Space by dropping it on another Space of the same device.
+    /// Cross-device drops are ignored; herdr remains the source of truth after refresh.
+    func moveSpace(_ source: SpaceEntry, onto target: SpaceEntry, placeAfter: Bool) {
+        guard source.device.id == target.device.id else { return }
+        let orderedIDs = session(source.device.id).workspaces.map(\.workspaceID)
+        guard let plan = WorkspaceReorder.plan(
+            moving: source.workspace.workspaceID,
+            onto: target.workspace.workspaceID,
+            placeAfter: placeAfter,
+            orderedIDs: orderedIDs
+        ) else { return }
+
+        if let current = sessions[source.device.id]?.workspaces {
+            sessions[source.device.id]?.workspaces = WorkspaceReorder.applying(
+                current,
+                id: \.workspaceID,
+                plan: plan
+            )
+        }
+
+        Task {
+            do {
+                try await service(for: source.device).moveWorkspaceBlock(
+                    workspaceIDs: plan.workspaceIDs,
+                    beforeWorkspaceID: plan.beforeWorkspaceID
+                )
+                await refresh(source.device.id)
+            } catch {
+                await refresh(source.device.id)
+                actionError = actionErrorMessage(error, device: source.device)
+            }
+        }
+    }
+
     /// Creates a workspace rooted at the given directory ("~" expands to the device's
     /// home, local or remote), then goes straight into the New Agent sheet for it.
     func createNewSpace(device: Device, directory: String, label: String?) {

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -1,5 +1,7 @@
+import AppKit
 import HerdrKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct VisualEffectView: NSViewRepresentable {
     var material: NSVisualEffectView.Material = .sidebar
@@ -21,6 +23,8 @@ struct SidebarView: View {
     @ObservedObject var model: AppModel
     @Binding var collapsed: Bool
     @State private var deviceButtonHovered = false
+    @State private var draggingSpaceID: String?
+    @State private var spaceDrop: (id: String, after: Bool)?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -80,6 +84,27 @@ struct SidebarView: View {
                     allSpacesRow
                     ForEach(model.visibleSpaces) { entry in
                         spaceRow(entry)
+                            .opacity(draggingSpaceID == entry.id ? 0.4 : 1)
+                            .overlay(alignment: (spaceDrop?.after ?? false) ? .bottom : .top) {
+                                if spaceDrop?.id == entry.id {
+                                    Rectangle()
+                                        .fill(Theme.accent)
+                                        .frame(height: 2)
+                                }
+                            }
+                            .onDrag {
+                                draggingSpaceID = entry.id
+                                return NSItemProvider(object: entry.id as NSString)
+                            }
+                            .onDrop(
+                                of: [.utf8PlainText, .text],
+                                delegate: SpaceRowDropDelegate(
+                                    entry: entry,
+                                    model: model,
+                                    draggingSpaceID: $draggingSpaceID,
+                                    spaceDrop: $spaceDrop
+                                )
+                            )
                             .contextMenu {
                                 Button("Rename Space…") {
                                     model.spaceToRename = entry
@@ -587,6 +612,46 @@ struct SidebarRowButtonStyle: ButtonStyle {
                 RoundedRectangle(cornerRadius: 7)
                     .fill(selected || configuration.isPressed ? AnyShapeStyle(Theme.itemWashSelected) : AnyShapeStyle(.clear))
             )
+    }
+}
+
+private struct SpaceRowDropDelegate: DropDelegate {
+    let entry: AppModel.SpaceEntry
+    let model: AppModel
+    @Binding var draggingSpaceID: String?
+    @Binding var spaceDrop: (id: String, after: Bool)?
+
+    func validateDrop(info: DropInfo) -> Bool {
+        info.hasItemsConforming(to: [.utf8PlainText, .text])
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        let after = info.location.y > 15
+        DispatchQueue.main.async {
+            spaceDrop = (entry.id, after)
+        }
+        return DropProposal(operation: .move)
+    }
+
+    func dropExited(info: DropInfo) {
+        DispatchQueue.main.async {
+            if spaceDrop?.id == entry.id { spaceDrop = nil }
+        }
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        let after = info.location.y > 15
+        let target = entry
+        let sourceID = draggingSpaceID
+        Task { @MainActor in
+            draggingSpaceID = nil
+            spaceDrop = nil
+            guard let sourceID,
+                  let source = model.visibleSpaces.first(where: { $0.id == sourceID })
+            else { return }
+            model.moveSpace(source, onto: target, placeAfter: after)
+        }
+        return true
     }
 }
 


### PR DESCRIPTION
Closes #38.

Space rows in the sidebar can be dragged. The drop calls herdr's `workspace.move_block` — the same RPC the TUI uses — so the order is the session's, not a herdrm-only list. Cross-device drops are ignored. Click-to-select, Rename, and Close are unchanged.

`HerdrService` also grows `moveWorkspace` / `moveWorkspaceBlock`, matching the existing `renameWorkspace` socket-RPC wrappers.

### Verified

- `WorkspaceReorder` unit tests (drop-before, drop-after-last, no-op when already adjacent, unknown ids)
- Live `workspace.move_block` against a local herdr 0.8.0 socket: create two throwaway spaces, reorder, assert `number` order, close them

I did not ship a signed `herdrm.app` from this machine (upstream `project.yml` is Developer ID + xcodegen). Happy to adjust the drag/drop if the SwiftUI gesture fights click-to-select on your build.