### PR TITLE
feat: resolve agent CLIs from an interactive login-shell environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,6 @@ HerdrM.xcodeproj/
 Packages/HerdrKit/.build/
 Sources/HerdrM/Info.plist
 *.xcuserstate
+.swiftpm/
+xcuserdata/
 build-rel/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Fixed
+
+- New Agent (and local `herdr` lookup) no longer trust the Finder-launched
+  app's sparse PATH. herdrm captures the login + interactive shell environment
+  once in the background (`zsh -i -l`, then `-l` if the interactive rc hangs),
+  via `env -0` into a private tempfile so rc banners cannot pollute the
+  snapshot. Lookup walks that PATH, then the GUI PATH, then well-known
+  prefixes (Homebrew, bun, cargo, mise, volta). Spawn and terminal attach
+  reuse the same environment and PATH, so a `#!/usr/bin/env node` shim that
+  shows as installed can actually find `node`. Settings → Agents accepts a
+  per-kind binary path when detection is wrong. SSH devices still follow the
+  remote server's manifest catalog.
+
 ## [0.4.0] - 2026-08-22
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -159,9 +159,17 @@ public actor HerdrService {
         ).manifests
     }
 
-    /// The CLI binary a kind installs as (usually the kind itself).
+    /// The CLI binary a kind installs as (usually the kind itself). Cursor's
+    /// installer also ships `agent`, which collides with too many other tools.
     public static func binaryName(for kind: String) -> String {
         kind == "cursor" ? "cursor-agent" : kind
+    }
+
+    /// An advertised kind whose CLI was found on the search PATH (login-shell
+    /// PATH, GUI PATH, well-known prefixes) or via a Settings override.
+    public struct InstalledAgent: Sendable, Equatable {
+        public let kind: String
+        public let path: String
     }
 
     /// Flags that put a kind's CLI into bypass/yolo mode. Only kinds with a verified
@@ -180,47 +188,33 @@ public actor HerdrService {
         }
     }
 
-    /// Sniffs which of the given kinds are actually installed on this device
-    /// (`command -v` locally or over SSH), preserving order.
-    public func installedAgentKinds(from kinds: [String]) async throws -> [String] {
+    /// Local CLIs visible on the login-shell search PATH, preserving manifest
+    /// order. Probe failure does not throw: lookup still walks the GUI PATH and
+    /// well-known prefixes. `overrides` maps a kind to a binary path or command
+    /// name (empty / missing = automatic). `snapshot` is a test seam; production
+    /// callers omit it and share the process-wide capture.
+    public func installedAgents(
+        from kinds: [String],
+        overrides: [String: String] = [:],
+        snapshot: ShellEnvironment? = nil
+    ) async -> [InstalledAgent] {
         guard !kinds.isEmpty else { return [] }
-        let binaries = kinds.map(Self.binaryName)
-        let probe = "for b in \(binaries.joined(separator: " ")); do command -v \"$b\" >/dev/null 2>&1 && echo \"$b\"; done"
-        let output: String
-        switch device.kind {
-        case .local:
-            output = try await Self.runLocalShell("\(LocalHerdrServer.localPathExport); \(probe)")
-        case .ssh(let target):
-            output = try await SSHTunnel.runSSH(
-                target: target,
-                command: "\(SSHTunnel.remotePathExport); \(probe)",
-                timeout: 15,
-                credentialID: device.id
-            )
+        let environment: ShellEnvironment
+        if let snapshot {
+            environment = snapshot
+        } else {
+            environment = await ShellEnvironment.ensure()
         }
-        let found = Set(output.split(separator: "\n").map(String.init))
-        return kinds.filter { found.contains(Self.binaryName(for: $0)) }
-    }
-
-    static func runLocalShell(_ command: String) async throws -> String {
-        try await withCheckedThrowingContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let proc = Process()
-                proc.executableURL = URL(fileURLWithPath: "/bin/sh")
-                proc.arguments = ["-c", command]
-                let out = Pipe()
-                proc.standardOutput = out
-                proc.standardError = FileHandle.nullDevice
-                do {
-                    try proc.run()
-                } catch {
-                    continuation.resume(throwing: HerdrError.connectionFailed(error.localizedDescription))
-                    return
-                }
-                proc.waitUntilExit()
-                let data = out.fileHandleForReading.readDataToEndOfFile()
-                continuation.resume(returning: String(data: data, encoding: .utf8) ?? "")
+        return kinds.compactMap { kind in
+            let query: String
+            if let override = overrides[kind]?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !override.isEmpty {
+                query = override
+            } else {
+                query = Self.binaryName(for: kind)
             }
+            guard let path = environment.findExecutable(query) else { return nil }
+            return InstalledAgent(kind: kind, path: path)
         }
     }
 
@@ -548,16 +542,31 @@ public actor HerdrService {
     /// pick a herdr binary whose protocol matches the server's — see
     /// `attachBinarySelection`.
     public nonisolated func attachCommand(paneID: String, serverVersion: String? = nil) -> AttachCommand {
-        // GUI apps launched from Finder don't inherit a login-shell PATH, and
-        // sshd exec is not a login shell either — hence the PATH export.
-        let script = "\(SSHTunnel.remotePathExport); \(Self.attachBinarySelection(serverVersion: serverVersion)); "
-            + "exec \"$hb\" agent attach '\(paneID)' --takeover"
         switch device.kind {
         case .local:
-            return AttachCommand(executable: "/bin/sh", args: ["-c", script], environment: [:], authorizationID: nil)
+            // Same PATH we used to discover `herdr`: login-shell snapshot, GUI
+            // PATH, well-known prefixes. Discovery and attach must not diverge
+            // or a `#!/usr/bin/env node` shim is found and then fails at exec.
+            // TERM/COLUMNS/LINES stay with SwiftTerm.
+            var environment = (ShellEnvironment.cached ?? .empty).launchEnvironment(binary: nil)
+            environment.removeValue(forKey: "TERM")
+            environment.removeValue(forKey: "COLUMNS")
+            environment.removeValue(forKey: "LINES")
+            let script = "\(Self.attachBinarySelection(serverVersion: serverVersion)); "
+                + "exec \"$hb\" agent attach '\(paneID)' --takeover"
+            return AttachCommand(
+                executable: "/bin/sh",
+                args: ["-c", script],
+                environment: environment,
+                authorizationID: nil
+            )
         case .ssh(let target):
-            // Wrapped in sh explicitly: the ssh remote command runs in the user's
-            // login shell, and the script's sh syntax must not depend on it.
+            // sshd exec is not a login shell — prepend the well-known prefixes
+            // on the far side. Wrapped in sh explicitly: the ssh remote command
+            // runs in the user's login shell, and the script's sh syntax must
+            // not depend on it.
+            let script = "\(SSHTunnel.remotePathExport); \(Self.attachBinarySelection(serverVersion: serverVersion)); "
+                + "exec \"$hb\" agent attach '\(paneID)' --takeover"
             let remote = "exec /bin/sh -c \(Self.shellQuoted(script))"
             let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
             return AttachCommand(

--- a/Packages/HerdrKit/Sources/HerdrKit/LocalServer.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/LocalServer.swift
@@ -23,15 +23,6 @@ public struct LocalHerdrServer: Sendable {
         }
     }
 
-    /// PATH used to find the herdr CLI. GUI apps launched from Finder don't inherit a
-    /// login-shell PATH, hence the same export the SSH side uses, plus mise's shim
-    /// directory: `mise use -g herdr` is one of herdr's install methods and its shims sit
-    /// in none of the other directories. `SSHTunnel.remotePathExport` stays untouched on
-    /// purpose — it is shared with the tunnel and the terminal attach, where the extra
-    /// directory would belong to the remote user, not to this Mac.
-    public static let localPathExport =
-        "\(SSHTunnel.remotePathExport); export PATH=\"$HOME/.local/share/mise/shims:$PATH\""
-
     /// Grace given to the socket after the spawned process exits. `herdr server` also exits
     /// non-zero when another process won the race to bind the socket — that server is
     /// serving, so an exit on its own is not a failure.
@@ -109,29 +100,19 @@ public struct LocalHerdrServer: Sendable {
 
     // MARK: - Collaborators
 
-    /// Locates the herdr CLI (`command -v` under `localPathExport`); nil when not found.
-    /// `environment` overrides what the lookup inherits, which is how a launchd-style PATH
-    /// (or a different `$HOME`) can be exercised without touching this process.
+    /// Locates the herdr CLI on the same search PATH used for agent CLIs: login-shell
+    /// snapshot (when `ensure()` has already run), GUI PATH, well-known prefixes
+    /// including mise shims. `environment` is a test seam that isolates PATH and HOME
+    /// from this process (a launchd-style PATH, a fake `$HOME`).
     public static func resolveBinary(environment: [String: String]? = nil) -> String? {
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/bin/sh")
-        proc.arguments = ["-c", "\(localPathExport); command -v herdr"]
-        if let environment { proc.environment = environment }
-        let out = Pipe()
-        proc.standardOutput = out
-        proc.standardError = FileHandle.nullDevice
-        do {
-            try proc.run()
-        } catch {
-            return nil
+        if let environment {
+            return ShellEnvironment(variables: environment).findExecutable(
+                "herdr",
+                processPath: environment["PATH"],
+                home: environment["HOME"]
+            )
         }
-        let data = out.fileHandleForReading.readDataToEndOfFile()
-        proc.waitUntilExit()
-        let path = (String(data: data, encoding: .utf8) ?? "")
-            .split(separator: "\n").first
-            .map { $0.trimmingCharacters(in: .whitespaces) } ?? ""
-        guard !path.isEmpty, FileManager.default.isExecutableFile(atPath: path) else { return nil }
-        return path
+        return (ShellEnvironment.cached ?? .empty).findExecutable("herdr")
     }
 
     /// Spawns `herdr server` and hands back a handle for watching it.
@@ -145,7 +126,7 @@ public struct LocalHerdrServer: Sendable {
     /// Its output goes to a file for the same reason: an undrained pipe stalls the daemon once
     /// the buffer fills, and closing our end of it would break the daemon's stdout — while a
     /// file still carries the real error text when the start fails.
-    public static func spawn(binary: String) throws -> Launched {
+    public static func spawn(binary: String, environment: [String: String]? = nil) throws -> Launched {
         // Unique per spawn: a fixed name would let a second herdrm (or a second start)
         // truncate a log file the live daemon still holds open at a non-zero offset.
         let logURL = FileManager.default.temporaryDirectory
@@ -157,7 +138,11 @@ public struct LocalHerdrServer: Sendable {
         let proc = Process()
         proc.executableURL = URL(fileURLWithPath: binary)
         proc.arguments = ["server"]
-        proc.environment = serverEnvironment()
+        // Same PATH the lookup walked, plus the binary's directory last: herdr
+        // itself is a real Mach-O, but panes and `#!/usr/bin/env node` shims
+        // still need node / bun / NVM_DIR from the captured block.
+        let base = environment ?? (ShellEnvironment.cached ?? .empty).launchEnvironment(binary: binary)
+        proc.environment = serverEnvironment(base: base)
         proc.standardInput = FileHandle.nullDevice
         proc.standardOutput = log
         proc.standardError = log
@@ -182,8 +167,8 @@ public struct LocalHerdrServer: Sendable {
     /// app started from Finder has no `SHELL` in its environment (`launchctl getenv SHELL` is
     /// empty), so a server spawned from herdrm would give the user `sh` panes instead of their
     /// login shell — no `.zshrc`, and none of the agents installed under `~/.local/bin` (claude
-    /// among them) on PATH. The panes are interactive shells that rebuild their own PATH from
-    /// the rc files, so `SHELL` is the only variable that has to be right here.
+    /// among them) on PATH. Spawn already overlays the login-shell snapshot (PATH, NVM_DIR,
+    /// …) so shims resolve; `SHELL` still has to be right so the pane itself is that shell.
     ///
     /// An explicit `SHELL` is never overwritten: running a shell other than the account's is a
     /// deliberate choice. When the login shell cannot be resolved, nothing is set and herdr

--- a/Packages/HerdrKit/Sources/HerdrKit/ShellEnvironment.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/ShellEnvironment.swift
@@ -1,0 +1,471 @@
+import Darwin
+import Foundation
+
+/// Login + interactive shell environment for a Finder-launched GUI process.
+///
+/// LaunchServices gives herdrm `/usr/bin:/bin:/usr/sbin:/sbin`. The PATH that actually
+/// has `codex`, `claude`, `node`, and fnm/nvm/mise shims lives in the user's shell
+/// startup files, which the desktop never executes. This type asks a real shell to
+/// run those files as code (not by grepping `export PATH=`), snapshots the exported
+/// environment once, and reuses it for both lookup and spawn.
+///
+/// Probe shape (mirrors Waku): tempfile + `env -0`, stdin/out/err discarded,
+/// independent session (so timeout can SIGKILL the group without hanging zsh -i),
+/// 3 s interactive then login-only fallback, 5 s round
+/// budget, SIGKILL the group on timeout. Failure is empty, not an error — lookup
+/// still walks the GUI PATH and the well-known install prefixes.
+public struct ShellEnvironment: Sendable, Equatable {
+    public let variables: [String: String]
+
+    public static let empty = ShellEnvironment(variables: [:])
+
+    public init(variables: [String: String]) {
+        self.variables = variables
+    }
+
+    public subscript(_ name: String) -> String? { variables[name] }
+
+    /// First caller spawns a login shell (must not run on the UI thread); later
+    /// callers share the snapshot. A failed probe is cached as empty so we never
+    /// retry a hanging `.zshrc` on every New Agent sheet.
+    public static func ensure() async -> ShellEnvironment {
+        await Cache.shared.ensure()
+    }
+
+    /// Snapshot from a completed `ensure()`, or nil if nobody has probed yet.
+    public static var cached: ShellEnvironment? { Cache.shared.cached }
+
+    /// Probe that does not touch the process-wide cache. `ensure()` calls this;
+    /// tests call it with an isolated `HOME` / `SHELL`.
+    ///
+    /// `interactiveTimeout` is the budget for `-i -l` (zsh only reads `.zshrc`
+    /// when interactive). The leftover of `roundTimeout` is spent on `-l`.
+    public static func capture(
+        from base: [String: String] = ProcessInfo.processInfo.environment,
+        interactiveTimeout: TimeInterval = 3,
+        roundTimeout: TimeInterval = 5
+    ) -> ShellEnvironment {
+        let roundDeadline = Date().addingTimeInterval(max(roundTimeout, 0.05))
+        for shell in shellCandidates(from: base) {
+            let remaining = roundDeadline.timeIntervalSinceNow
+            guard remaining > 0 else { break }
+            if let snapshot = captureAttempt(
+                shell: shell,
+                arguments: ["-i", "-l", "-c", captureCommand],
+                base: base,
+                timeout: min(interactiveTimeout, remaining)
+            ) {
+                return snapshot
+            }
+            let leftover = roundDeadline.timeIntervalSinceNow
+            guard leftover > 0 else { break }
+            if let snapshot = captureAttempt(
+                shell: shell,
+                arguments: ["-l", "-c", captureCommand],
+                base: base,
+                timeout: leftover
+            ) {
+                return snapshot
+            }
+        }
+        return .empty
+    }
+
+    // MARK: - Lookup
+
+    /// Directories searched for agent (and herdr) binaries, first match wins.
+    /// Order: login-shell PATH, GUI process PATH, user-level prefixes, system
+    /// prefixes. Duplicates dropped, order kept.
+    public func searchDirectories(
+        processPath: String? = nil,
+        home: String? = nil
+    ) -> [String] {
+        let process = ProcessInfo.processInfo.environment
+        let homeDirectory = home
+            ?? variables["HOME"]
+            ?? process["HOME"]
+            ?? NSHomeDirectory()
+        let inheritedPath = processPath ?? process["PATH"] ?? ""
+
+        var directories: [String] = []
+        var seen = Set<String>()
+        func append(_ raw: String) {
+            var path = raw
+            while path.count > 1, path.hasSuffix("/") { path.removeLast() }
+            guard !path.isEmpty, seen.insert(path).inserted else { return }
+            directories.append(path)
+        }
+
+        for directory in Self.splitPath(variables["PATH"]) { append(directory) }
+        for directory in Self.splitPath(inheritedPath) { append(directory) }
+        for directory in Self.wellKnownDirectories(home: homeDirectory) { append(directory) }
+        return directories
+    }
+
+    /// Well-known Unix install prefixes used when the login-shell probe fails
+    /// (or as a backstop when it succeeds but PATH is incomplete).
+    public static func wellKnownDirectories(home: String) -> [String] {
+        [
+            "\(home)/.local/bin",
+            "\(home)/.bun/bin",
+            "\(home)/.cargo/bin",
+            "\(home)/.local/share/mise/shims",
+            "\(home)/.volta/bin",
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+            "/usr/bin",
+            "/bin",
+            "/usr/sbin",
+            "/sbin",
+        ]
+    }
+
+    /// Locate `name` on the search path.
+    ///
+    /// - Bare command (`codex`, `cursor-agent`): walk `searchDirectories`.
+    /// - `~/…`: expand against `HOME`, must already be a file.
+    /// - Absolute or relative path: same, no PATH walk.
+    ///
+    /// Cursor's CLI is `cursor-agent` (not `agent`); callers pass `binaryName(for:)`.
+    public func findExecutable(
+        _ name: String,
+        processPath: String? = nil,
+        home: String? = nil
+    ) -> String? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let homeDirectory = home
+            ?? variables["HOME"]
+            ?? ProcessInfo.processInfo.environment["HOME"]
+            ?? NSHomeDirectory()
+
+        if trimmed == "~"
+            || trimmed.hasPrefix("~/")
+            || trimmed.hasPrefix("/")
+            || trimmed.contains("/")
+        {
+            let path = Self.expandPath(trimmed, home: homeDirectory)
+            return Self.isRunnableFile(path) ? path : nil
+        }
+
+        guard Self.isCommandName(trimmed) else { return nil }
+        for directory in searchDirectories(processPath: processPath, home: homeDirectory) {
+            let candidate = (directory as NSString).appendingPathComponent(trimmed)
+            if Self.isRunnableFile(candidate) { return candidate }
+        }
+        return nil
+    }
+
+    /// Environment handed to a child that will exec an agent shim (`#!/usr/bin/env node`,
+    /// bun, nvm wrappers). The whole captured block is used (so `NVM_DIR` / `FNM_*`
+    /// survive); `PATH` is replaced with the same directory list lookup used, plus
+    /// the binary's own directory last so a match outside PATH still finds `node`
+    /// sitting next to it without reordering the user's PATH.
+    public func launchEnvironment(
+        binary: String? = nil,
+        processEnvironment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> [String: String] {
+        var environment = variables.isEmpty ? processEnvironment : variables
+        var directories = searchDirectories(
+            processPath: processEnvironment["PATH"],
+            home: environment["HOME"] ?? processEnvironment["HOME"]
+        )
+        if let binary {
+            let directory = (binary as NSString).deletingLastPathComponent
+            if !directory.isEmpty { directories.append(directory) }
+        }
+        environment["PATH"] = directories.joined(separator: ":")
+        return environment
+    }
+
+    // MARK: - Capture
+
+    static let captureFileKey = "HERDRM_SHELL_ENV_CAPTURE_FILE"
+
+    static let injectedKeys: Set<String> = [
+        captureFileKey,
+        "DISABLE_AUTO_UPDATE",
+        "DISABLE_UPDATE_PROMPT",
+        "ZSH_DISABLE_COMPFIX",
+        "ZSH_TMUX_AUTOSTART",
+        "ZSH_TMUX_AUTOSTARTED",
+    ]
+
+    private static let captureCommand =
+        "/usr/bin/env -0 > \"$\(captureFileKey)\""
+
+    /// `$SHELL` first (the rc that produced the user's PATH), then passwd
+    /// (`chsh`), then platform fallbacks. The in-app terminal uses passwd first
+    /// because that is the shell the user chose; detection wants the shell that
+    /// currently owns PATH.
+    static func shellCandidates(from environment: [String: String]) -> [String] {
+        var shells: [String] = []
+        func append(_ raw: String?) {
+            let path = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard !path.isEmpty, isRunnableFile(path), !shells.contains(path) else { return }
+            shells.append(path)
+        }
+        append(environment["SHELL"])
+        append(passwdShell())
+        append("/bin/zsh")
+        append("/bin/bash")
+        append("/bin/sh")
+        return shells
+    }
+
+    static func parseNulEnvironment(_ data: Data) -> [String: String] {
+        var environment: [String: String] = [:]
+        var start = data.startIndex
+        while start < data.endIndex {
+            let end = data[start...].firstIndex(of: 0) ?? data.endIndex
+            let entry = data[start..<end]
+            start = end < data.endIndex ? data.index(after: end) : end
+            guard !entry.isEmpty,
+                  let separator = entry.firstIndex(of: UInt8(ascii: "=")),
+                  separator > entry.startIndex
+            else { continue }
+            let name = decodeEnvBytes(Data(entry[..<separator]))
+            guard !injectedKeys.contains(name) else { continue }
+            environment[name] = decodeEnvBytes(Data(entry[entry.index(after: separator)...]))
+        }
+        return environment
+    }
+
+    // MARK: - Internals
+
+    private static func captureAttempt(
+        shell: String,
+        arguments: [String],
+        base: [String: String],
+        timeout: TimeInterval
+    ) -> ShellEnvironment? {
+        guard let file = exclusiveCaptureFile(tmpdir: base["TMPDIR"]) else { return nil }
+        defer { unlink(file) }
+
+        var environment = base
+        environment[captureFileKey] = file
+        environment["DISABLE_AUTO_UPDATE"] = "true"
+        environment["DISABLE_UPDATE_PROMPT"] = "true"
+        environment["ZSH_DISABLE_COMPFIX"] = "true"
+        environment["ZSH_TMUX_AUTOSTART"] = "false"
+        environment["ZSH_TMUX_AUTOSTARTED"] = "true"
+
+        guard let status = TimedProcess.run(
+            executable: shell,
+            arguments: arguments,
+            environment: environment,
+            timeout: timeout
+        ), status == 0 else { return nil }
+
+        guard let data = FileManager.default.contents(atPath: file) else { return nil }
+        let parsed = parseNulEnvironment(data)
+        guard parsed["PATH"] != nil else { return nil }
+        return ShellEnvironment(variables: parsed)
+    }
+
+    private static func exclusiveCaptureFile(tmpdir: String?) -> String? {
+        let root = (tmpdir?.isEmpty == false ? tmpdir! : NSTemporaryDirectory())
+        let directory = root.hasSuffix("/") ? root : root + "/"
+        for _ in 0..<8 {
+            let path = "\(directory).herdrm-shell-env-\(getpid())-\(UUID().uuidString.prefix(8))"
+            let fd = open(path, O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0o600)
+            guard fd >= 0 else { continue }
+            fchmod(fd, 0o600)
+            close(fd)
+            return path
+        }
+        return nil
+    }
+
+    private static func splitPath(_ path: String?) -> [String] {
+        guard let path, !path.isEmpty else { return [] }
+        return path.split(separator: ":", omittingEmptySubsequences: true).map(String.init)
+    }
+
+    private static func expandPath(_ path: String, home: String) -> String {
+        if path == "~" { return home }
+        if path.hasPrefix("~/") { return home + "/" + path.dropFirst(2) }
+        if path.hasPrefix("/") { return path }
+        return (FileManager.default.currentDirectoryPath as NSString).appendingPathComponent(path)
+    }
+
+    static func isCommandName(_ name: String) -> Bool {
+        !name.isEmpty && name.allSatisfy { $0.isLetter || $0.isNumber || "-_+.".contains($0) }
+    }
+
+    static func isRunnableFile(_ path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory),
+              !isDirectory.boolValue
+        else { return false }
+        return FileManager.default.isExecutableFile(atPath: path)
+    }
+
+    /// Account login shell from the password database. `geteuid()` so a
+    /// setuid-adjacent launch still sees the user who should own PATH.
+    static func passwdShell() -> String? {
+        var pwd = passwd()
+        var result: UnsafeMutablePointer<passwd>?
+        var buffer = [CChar](repeating: 0, count: 16_384)
+        let code = buffer.withUnsafeMutableBufferPointer { buf in
+            getpwuid_r(geteuid(), &pwd, buf.baseAddress, buf.count, &result)
+        }
+        guard code == 0, result != nil else { return nil }
+        let shell = String(cString: pwd.pw_shell).trimmingCharacters(in: .whitespaces)
+        return shell.isEmpty ? nil : shell
+    }
+
+    private static func decodeEnvBytes(_ data: Data) -> String {
+        if let utf8 = String(data: data, encoding: .utf8) { return utf8 }
+        return String(data: data, encoding: .isoLatin1) ?? ""
+    }
+}
+
+// MARK: - Process-wide cache
+
+/// `OnceLock` analogue: the probe is expensive and `.zshrc` is not re-entrant-safe
+/// to run per provider. Locking stays off the async path so this builds under
+/// Swift 6's `NSLock` rule.
+private final class Cache: @unchecked Sendable {
+    static let shared = Cache()
+
+    private let lock = NSLock()
+    private var snapshot: ShellEnvironment?
+    private var inFlight: Task<ShellEnvironment, Never>?
+
+    var cached: ShellEnvironment? {
+        lock.lock()
+        defer { lock.unlock() }
+        return snapshot
+    }
+
+    func ensure() async -> ShellEnvironment {
+        if let snapshot = cached { return snapshot }
+        return await probeTask().value
+    }
+
+    private func probeTask() -> Task<ShellEnvironment, Never> {
+        lock.lock()
+        defer { lock.unlock() }
+        if let snapshot {
+            return Task { snapshot }
+        }
+        if let inFlight { return inFlight }
+        let task = Task.detached(priority: .utility) { [self] in
+            let captured = ShellEnvironment.capture()
+            self.store(captured)
+            return captured
+        }
+        inFlight = task
+        return task
+    }
+
+    private func store(_ captured: ShellEnvironment) {
+        lock.lock()
+        snapshot = captured
+        inFlight = nil
+        lock.unlock()
+    }
+}
+
+// MARK: - Timed posix_spawn
+
+/// Foundation `Process` is the wrong primitive here: we need a new session (so a
+/// timed-out nvm/tmux child dies with the shell, and zsh -i does not hang in
+/// `tcsetpgrp`), a child signal mask that unblocks `SIGCHLD` (libdispatch / some
+/// UI runtimes block it and zsh job control then hangs), and stdin/out/err on
+/// `/dev/null` so rc banners never mix with the snapshot. Capture itself is a
+/// tempfile.
+private enum TimedProcess {
+    static func run(
+        executable: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) -> Int32? {
+        let argvStrings = [executable] + arguments
+        let envStrings = environment.map { "\($0.key)=\($0.value)" }
+
+        return withCStrings(argvStrings) { argv in
+            withCStrings(envStrings) { envp in
+                spawnAndWait(
+                    executable: executable,
+                    argv: argv,
+                    envp: envp,
+                    timeout: timeout
+                )
+            }
+        }
+    }
+
+    private static func spawnAndWait(
+        executable: String,
+        argv: UnsafePointer<UnsafeMutablePointer<CChar>?>,
+        envp: UnsafePointer<UnsafeMutablePointer<CChar>?>,
+        timeout: TimeInterval
+    ) -> Int32? {
+        var actions: posix_spawn_file_actions_t?
+        guard posix_spawn_file_actions_init(&actions) == 0 else { return nil }
+        defer { posix_spawn_file_actions_destroy(&actions) }
+        _ = posix_spawn_file_actions_addopen(&actions, STDIN_FILENO, "/dev/null", O_RDONLY, 0)
+        _ = posix_spawn_file_actions_addopen(&actions, STDOUT_FILENO, "/dev/null", O_WRONLY, 0)
+        _ = posix_spawn_file_actions_addopen(&actions, STDERR_FILENO, "/dev/null", O_WRONLY, 0)
+
+        var attr: posix_spawnattr_t?
+        guard posix_spawnattr_init(&attr) == 0 else { return nil }
+        defer { posix_spawnattr_destroy(&attr) }
+
+        // SETSID, not SETPGROUP: zsh -i + setpgrp with no controlling tty
+        // blocks forever in job control (`tcsetpgrp`). A new session has no
+        // tty, so -i still reads `.zshrc` and `-c` returns. The child is a
+        // session leader, so timeout can still SIGKILL the whole group.
+        let flags = Int16(bitPattern: UInt16(
+            POSIX_SPAWN_SETSID | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_CLOEXEC_DEFAULT
+        ))
+        posix_spawnattr_setflags(&attr, flags)
+
+        var empty = sigset_t()
+        sigemptyset(&empty)
+        posix_spawnattr_setsigmask(&attr, &empty)
+
+        var pid: pid_t = 0
+        let spawned = executable.withCString { path in
+            posix_spawn(&pid, path, &actions, &attr, argv, envp)
+        }
+        guard spawned == 0 else { return nil }
+
+        let deadline = Date().addingTimeInterval(max(timeout, 0.05))
+        var status: Int32 = 0
+        while true {
+            let waited = waitpid(pid, &status, WNOHANG)
+            if waited == pid {
+                // Darwin's WIFEXITED / WEXITSTATUS are function-like macros Swift
+                // does not import. `_WSTATUS == 0` means a normal exit.
+                let terminated = status & 0o177
+                return terminated == 0 ? (status >> 8) & 0xff : nil
+            }
+            if waited < 0 { return nil }
+            if Date() >= deadline {
+                kill(-pid, SIGKILL)
+                waitpid(pid, &status, 0)
+                return nil
+            }
+            usleep(20_000)
+        }
+    }
+
+    private static func withCStrings<R>(
+        _ values: [String],
+        _ body: (UnsafePointer<UnsafeMutablePointer<CChar>?>) -> R
+    ) -> R {
+        var pointers: [UnsafeMutablePointer<CChar>?] = values.map { strdup($0) }
+        pointers.append(nil)
+        defer {
+            for pointer in pointers { free(pointer) }
+        }
+        return pointers.withUnsafeMutableBufferPointer { buffer in
+            body(buffer.baseAddress!)
+        }
+    }
+}

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalServerTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalServerTests.swift
@@ -337,8 +337,9 @@ final class LocalServerTests: XCTestCase {
         XCTAssertTrue(FileManager.default.isExecutableFile(atPath: shell), shell)
     }
 
-    /// The condition the PATH export exists for: an app launched from Finder gets launchd's
-    /// PATH, which has none of the places herdr installs into.
+    /// The condition login-shell capture + well-known prefixes exist for: an app
+    /// launched from Finder gets launchd's PATH, which has none of the places herdr
+    /// installs into.
     func testResolverFindsHerdrUnderLaunchdsPath() throws {
         let sessionSocket = (NSHomeDirectory() as NSString)
             .appendingPathComponent(".config/herdr/herdr.sock")

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
@@ -36,7 +36,7 @@ final class LocalSocketTests: XCTestCase {
         // snapshot and dedicated list endpoints must agree
         XCTAssertEqual(Set(snapshot.agents.map(\.paneID)), Set(agents.map(\.paneID)))
         XCTAssertEqual(Set(snapshot.workspaces.map(\.workspaceID)), Set(workspaces.map(\.workspaceID)))
-        XCTAssertFalse(manifests.isEmpty)
+        XCTAssertFalse(manifests.isEmpty, "server advertised no agent manifests")
         _ = AgentAttachmentCapabilityRegistry(manifests: manifests)
         // every agent belongs to a listed workspace
         let workspaceIDs = Set(workspaces.map(\.workspaceID))

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
@@ -125,12 +125,18 @@ final class AttachBinarySelectionTests: XCTestCase {
             .attachCommand(paneID: "w1:p1", serverVersion: "0.8.2")
         XCTAssertEqual(local.executable, "/bin/sh")
         XCTAssertTrue(local.args.last?.contains("exec \"$hb\" agent attach 'w1:p1'") == true)
+        XCTAssertTrue(
+            local.environment["PATH"]?.contains("/opt/homebrew/bin") == true,
+            "local attach must use the same search PATH as lookup"
+        )
+        XCTAssertNil(local.environment["TERM"], "SwiftTerm owns TERM")
 
         let remote = HerdrService(device: Device(name: "R", kind: .ssh(target: "u@h")), localServer: nil)
             .attachCommand(paneID: "w1:p1", serverVersion: "0.8.2")
         XCTAssertEqual(remote.executable, "/usr/bin/ssh")
         // The whole script must run under sh on the far side, not the login shell.
         XCTAssertTrue(remote.args.last?.hasPrefix("exec /bin/sh -c '") == true)
+        XCTAssertTrue(remote.args.last?.contains("export PATH=") == true)
     }
 }
 

--- a/Packages/HerdrKit/Tests/HerdrKitTests/ShellEnvironmentTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/ShellEnvironmentTests.swift
@@ -1,0 +1,265 @@
+import XCTest
+@testable import HerdrKit
+
+final class ShellEnvironmentTests: XCTestCase {
+    private var directory: URL!
+
+    override func setUpWithError() throws {
+        directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hk-shell-env-\(UUID().uuidString.prefix(8))", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    // MARK: - Parser
+
+    func testNulParserPreservesEqualsNewlinesAndDropsInjectedKeys() {
+        var data = Data()
+        data.append(entry("PLAIN", "value"))
+        data.append(entry("EQUALS", "left=right"))
+        data.append(entry("LINES", "one\ntwo"))
+        data.append(entry("EMPTY", ""))
+        data.append(entry(ShellEnvironment.captureFileKey, "/tmp/probe"))
+        data.append(entry("DISABLE_AUTO_UPDATE", "true"))
+        data.append(entry("ZSH_TMUX_AUTOSTART", "false"))
+        data.append(Data("malformed-no-equals".utf8))
+        data.append(0)
+
+        let environment = ShellEnvironment.parseNulEnvironment(data)
+
+        XCTAssertEqual(environment["PLAIN"], "value")
+        XCTAssertEqual(environment["EQUALS"], "left=right")
+        XCTAssertEqual(environment["LINES"], "one\ntwo")
+        XCTAssertEqual(environment["EMPTY"], "")
+        XCTAssertNil(environment[ShellEnvironment.captureFileKey])
+        XCTAssertNil(environment["DISABLE_AUTO_UPDATE"])
+        XCTAssertNil(environment["ZSH_TMUX_AUTOSTART"])
+        XCTAssertNil(environment["malformed-no-equals"])
+    }
+
+    func testNulParserAcceptsLatin1WhenNotUTF8() {
+        var data = Data("PATH=".utf8)
+        data.append(0xFF)
+        data.append(contentsOf: "/bin".utf8)
+        data.append(0)
+
+        let environment = ShellEnvironment.parseNulEnvironment(data)
+        XCTAssertEqual(environment["PATH"]?.unicodeScalars.first, Unicode.Scalar(0xFF))
+        XCTAssertTrue(environment["PATH"]?.hasSuffix("/bin") == true)
+    }
+
+    // MARK: - findExecutable
+
+    func testSearchOrderPrefersShellPathOverProcessPathOverWellKnown() throws {
+        let shellDir = try bin("shell-bin", command: "codex")
+        let processDir = try bin("process-bin", command: "codex")
+        let wellKnown = try bin(".local/bin", command: "codex")
+
+        let snapshot = ShellEnvironment(variables: [
+            "PATH": shellDir.path,
+            "HOME": directory.path,
+        ])
+
+        XCTAssertEqual(
+            snapshot.findExecutable("codex", processPath: processDir.path, home: directory.path),
+            shellDir.appendingPathComponent("codex").path
+        )
+
+        let noShell = ShellEnvironment(variables: ["HOME": directory.path])
+        XCTAssertEqual(
+            noShell.findExecutable("codex", processPath: processDir.path, home: directory.path),
+            processDir.appendingPathComponent("codex").path
+        )
+
+        let empty = ShellEnvironment(variables: ["HOME": directory.path])
+        XCTAssertEqual(
+            empty.findExecutable("codex", processPath: "/usr/bin:/bin", home: directory.path),
+            wellKnown.appendingPathComponent("codex").path
+        )
+    }
+
+    func testFindExecutableExpandsHomeAndRejectsMissingOverride() throws {
+        let nested = try bin("tools", command: "claude")
+        let snapshot = ShellEnvironment(variables: ["HOME": directory.path])
+
+        XCTAssertEqual(
+            snapshot.findExecutable("~/tools/claude", home: directory.path),
+            nested.appendingPathComponent("claude").path
+        )
+        XCTAssertNil(snapshot.findExecutable("~/missing/claude", home: directory.path))
+        XCTAssertNil(snapshot.findExecutable("with space"))
+        XCTAssertNil(snapshot.findExecutable(""))
+    }
+
+    func testCursorKindMapsToCursorAgent() {
+        XCTAssertEqual(HerdrService.binaryName(for: "cursor"), "cursor-agent")
+        XCTAssertEqual(HerdrService.binaryName(for: "codex"), "codex")
+    }
+
+    func testLaunchEnvironmentKeepsWrapperVarsAndAppendsBinaryDirectory() {
+        let snapshot = ShellEnvironment(variables: [
+            "PATH": "/shell/bin",
+            "HOME": directory.path,
+            "NVM_DIR": "\(directory.path)/.nvm",
+            "FNM_MULTISHELL_PATH": "/tmp/fnm",
+        ])
+        let launched = snapshot.launchEnvironment(
+            binary: "/opt/custom/codex",
+            processEnvironment: ["PATH": "/usr/bin:/bin", "HOME": directory.path]
+        )
+
+        XCTAssertEqual(launched["NVM_DIR"], "\(directory.path)/.nvm")
+        XCTAssertEqual(launched["FNM_MULTISHELL_PATH"], "/tmp/fnm")
+        let path = launched["PATH"] ?? ""
+        let parts = path.split(separator: ":").map(String.init)
+        XCTAssertEqual(parts.first, "/shell/bin")
+        XCTAssertTrue(parts.contains("/usr/bin"))
+        XCTAssertTrue(parts.contains("\(directory.path)/.local/bin"))
+        XCTAssertTrue(parts.contains("/opt/homebrew/bin"))
+        XCTAssertEqual(parts.last, "/opt/custom")
+    }
+
+    func testInstalledAgentsHonorsOverrideAndCursorAlias() async throws {
+        let cursor = try bin("bin", command: "cursor-agent")
+        _ = try bin("bin", command: "codex")
+        let snapshot = ShellEnvironment(variables: [
+            "PATH": cursor.path,
+            "HOME": directory.path,
+        ])
+        let service = HerdrService(device: .local, localServer: nil)
+
+        let found = await service.installedAgents(
+            from: ["claude", "cursor", "codex"],
+            snapshot: snapshot
+        )
+        // `claude` is not planted here; a real ~/.local/bin/claude on the
+        // machine must not leak into this assertion.
+        XCTAssertEqual(found.map(\.kind).filter { $0 != "claude" }, ["cursor", "codex"])
+        XCTAssertEqual(
+            found.first { $0.kind == "cursor" }?.path,
+            cursor.appendingPathComponent("cursor-agent").path
+        )
+
+        let overridden = await service.installedAgents(
+            from: ["codex"],
+            overrides: ["codex": "/no/such/codex"],
+            snapshot: snapshot
+        )
+        XCTAssertTrue(overridden.isEmpty, "a missing override must not fall back to auto-detect")
+
+        let redirected = await service.installedAgents(
+            from: ["codex"],
+            overrides: ["codex": "~/bin/cursor-agent"],
+            snapshot: snapshot
+        )
+        XCTAssertEqual(redirected.first?.path, cursor.appendingPathComponent("cursor-agent").path)
+    }
+
+    // MARK: - Real zsh
+
+    func testCaptureRunsLoginAndInteractiveStartupFilesAndIgnoresStdoutBanners() throws {
+        let bin = directory.appendingPathComponent("agent-bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+        try "export HERDRM_LOGIN_MARKER=from-zprofile\n"
+            .write(to: directory.appendingPathComponent(".zprofile"), atomically: true, encoding: .utf8)
+        try """
+        echo 'WELCOME TO ZSH'
+        print -P '%F{red}prompt%f'
+        export HERDRM_INTERACTIVE_MARKER=from-zshrc
+        export HERDRM_COMPLEX_VALUE='left=right
+        second line'
+        export PATH="$HOME/agent-bin:$PATH"
+        """.write(to: directory.appendingPathComponent(".zshrc"), atomically: true, encoding: .utf8)
+
+        let snapshot = ShellEnvironment.capture(from: [
+            "HOME": directory.path,
+            "SHELL": "/bin/zsh",
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "TERM": "dumb",
+        ])
+
+        XCTAssertEqual(snapshot["HERDRM_LOGIN_MARKER"], "from-zprofile")
+        XCTAssertEqual(snapshot["HERDRM_INTERACTIVE_MARKER"], "from-zshrc")
+        XCTAssertEqual(snapshot["HERDRM_COMPLEX_VALUE"], "left=right\nsecond line")
+        XCTAssertEqual(snapshot["PATH"]?.split(separator: ":").first, Substring(bin.path))
+        XCTAssertFalse(snapshot["PATH"]?.contains("WELCOME") == true)
+        XCTAssertNil(snapshot[ShellEnvironment.captureFileKey])
+    }
+
+    func testInteractiveHangFallsBackToLoginShell() throws {
+        try "export HERDRM_LOGIN_MARKER=from-zprofile\n"
+            .write(to: directory.appendingPathComponent(".zprofile"), atomically: true, encoding: .utf8)
+        try """
+        sleep 30
+        export HERDRM_INTERACTIVE_MARKER=from-zshrc
+        """.write(to: directory.appendingPathComponent(".zshrc"), atomically: true, encoding: .utf8)
+
+        let snapshot = ShellEnvironment.capture(
+            from: [
+                "HOME": directory.path,
+                "SHELL": "/bin/zsh",
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "TERM": "dumb",
+            ],
+            interactiveTimeout: 0.4,
+            roundTimeout: 2
+        )
+
+        XCTAssertEqual(snapshot["HERDRM_LOGIN_MARKER"], "from-zprofile")
+        XCTAssertNil(snapshot["HERDRM_INTERACTIVE_MARKER"], "killed -i must not leak a partial interactive rc")
+        XCTAssertNotNil(snapshot["PATH"])
+    }
+
+    func testCapturedPathFindsABinaryTheProcessPathCannotSee() throws {
+        let bin = try bin("agent-bin", command: "codex")
+        try #"export PATH="$HOME/agent-bin:$PATH""#
+            .write(to: directory.appendingPathComponent(".zshrc"), atomically: true, encoding: .utf8)
+
+        let snapshot = ShellEnvironment.capture(from: [
+            "HOME": directory.path,
+            "SHELL": "/bin/zsh",
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "TERM": "dumb",
+        ])
+
+        XCTAssertEqual(
+            snapshot.findExecutable("codex", processPath: "/usr/bin:/bin", home: directory.path),
+            bin.appendingPathComponent("codex").path
+        )
+        XCTAssertNil(
+            ShellEnvironment.empty.findExecutable(
+                "codex",
+                processPath: "/usr/bin:/bin",
+                home: NSTemporaryDirectory()
+            )
+        )
+    }
+
+    func testShellCandidatesPreferProcessShellThenPasswd() {
+        let candidates = ShellEnvironment.shellCandidates(from: ["SHELL": "/bin/zsh"])
+        XCTAssertEqual(candidates.first, "/bin/zsh")
+        XCTAssertTrue(candidates.contains("/bin/sh"))
+    }
+
+    // MARK: - Helpers
+
+    private func bin(_ relative: String, command: String) throws -> URL {
+        let url = directory.appendingPathComponent(relative, isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        let file = url.appendingPathComponent(command)
+        try "#!/bin/sh\nexit 0\n".write(to: file, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: file.path)
+        return url
+    }
+
+    private func entry(_ name: String, _ value: String) -> Data {
+        var data = Data(name.utf8)
+        data.append(UInt8(ascii: "="))
+        data.append(Data(value.utf8))
+        data.append(0)
+        return data
+    }
+}

--- a/README.md
+++ b/README.md
@@ -66,10 +66,12 @@ macOS window on top of it, and it's grown well past "attach to a terminal":
 ### Spaces & Agents, always current
 - **Spaces & Agents sidebar** — every workspace and agent (claude, codex, gemini, grok,
   opencode, …), same canonical order the ⌘K palette uses.
-- **New Agent / New Space** — the picker only lists CLIs actually installed on that device
-  (NVM and user-level installs included), and enables each agent's bypass-permissions flag by
-  default. **⌘N** for a new agent, **⇧⌘N** for a new space. New Space includes an inline
-  directory browser that works over SSH.
+- **New Agent / New Space** — locally the picker only lists advertised CLIs found on the
+  login-shell PATH (captured once from a real interactive + login shell, not by grepping rc
+  files or trusting LaunchServices); SSH devices follow the remote server's manifest catalog
+  and validate on start. Each agent's bypass-permissions flag is on by default. **⌘N** for a
+  new agent, **⇧⌘N** for a new space. New Space includes an inline directory browser that
+  works over SSH. Settings → Agents accepts a per-kind binary path when detection is wrong.
 - Spaces rename straight from the sidebar's context menu.
 
 ### A real terminal, not a chat wrapper

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -10,6 +10,24 @@ enum ConnectionState: Equatable {
     case failed(String)
 }
 
+/// Agent kinds offered by the picker. Local manifests are filtered through the
+/// login-shell search PATH; remote manifests stay server-owned.
+enum AgentCatalogState: Equatable {
+    case loading
+    case loaded(kinds: [String], paths: [String: String] = [:])
+    case failed(String)
+
+    var kinds: [String] {
+        guard case .loaded(let kinds, _) = self else { return [] }
+        return kinds
+    }
+
+    var paths: [String: String] {
+        guard case .loaded(_, let paths) = self else { return [:] }
+        return paths
+    }
+}
+
 /// Global pane identity: pane ids like "w1:p1" collide across devices.
 struct PaneRef: Hashable {
     let deviceID: UUID
@@ -27,8 +45,7 @@ struct DeviceSessionState {
     var agents: [AgentInfo] = []
     var workspaces: [WorkspaceInfo] = []
     var panes: [PaneInfo] = []
-    var agentKinds: [String] = []
-    var installedAgentKinds: [String] = []
+    var agentCatalog: AgentCatalogState = .loading
     var attachmentCapabilities = AgentAttachmentCapabilityRegistry()
 }
 
@@ -51,6 +68,33 @@ enum SplitSide { case agent, shell }
 struct ShellSession: Identifiable, Equatable {
     let id: UUID
     var title: String
+}
+
+/// Per-kind CLI path overrides persisted in user defaults. Empty means automatic
+/// lookup on the login-shell search PATH. Invalid paths hide that kind until
+/// the user fixes or clears the field — they never silently fall back.
+enum AgentBinaryOverrides {
+    static let defaultsKey = "agent.binaryOverrides"
+
+    static func load(defaults: UserDefaults = .standard) -> [String: String] {
+        (defaults.dictionary(forKey: defaultsKey) as? [String: String] ?? [:])
+            .reduce(into: [:]) { result, entry in
+                let value = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !value.isEmpty { result[entry.key] = value }
+            }
+    }
+
+    static func save(_ overrides: [String: String], defaults: UserDefaults = .standard) {
+        let trimmed = overrides.reduce(into: [String: String]()) { result, entry in
+            let value = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !value.isEmpty { result[entry.key] = value }
+        }
+        if trimmed.isEmpty {
+            defaults.removeObject(forKey: defaultsKey)
+        } else {
+            defaults.set(trimmed, forKey: defaultsKey)
+        }
+    }
 }
 
 @MainActor
@@ -300,6 +344,12 @@ final class AppModel: ObservableObject {
 
     func start() {
         NotificationManager.shared.setup(model: self)
+        // Finder-launched apps have launchd's PATH. Capture the login +
+        // interactive shell environment on a background thread once; New Agent
+        // lookup, herdr spawn, and terminal attach all read the same snapshot.
+        Task.detached(priority: .utility) {
+            _ = await ShellEnvironment.ensure()
+        }
         for device in devices {
             startSession(device)
             probeOSIfNeeded(device)
@@ -334,14 +384,7 @@ final class AppModel: ObservableObject {
                         self.probeOSIfNeeded(current)
                     }
                     await self.refresh(device.id)
-                    if let manifests = try? await service.agentManifests() {
-                        let kinds = manifests.map(\.agent)
-                        self.sessions[device.id]?.agentKinds = kinds
-                        self.sessions[device.id]?.attachmentCapabilities =
-                            AgentAttachmentCapabilityRegistry(manifests: manifests)
-                        self.sessions[device.id]?.installedAgentKinds =
-                            (try? await service.installedAgentKinds(from: kinds)) ?? []
-                    }
+                    await self.loadAgentCatalog(deviceID: device.id, using: service)
                     let stream = try await service.events()
                     for try await _ in stream {
                         self.scheduleRefresh(device.id)
@@ -361,6 +404,40 @@ final class AppModel: ObservableObject {
                 backoff = min(backoff * 2, 30)
             }
         }
+    }
+
+    /// Locally, keeps only advertised CLIs whose binaries are on the login-shell
+    /// search PATH (or a Settings override). SSH hosts keep their server-owned
+    /// catalog; `agent.start` validates in the target pane instead. Manifests
+    /// also feed the attachment-capability registry (paste path vs upload).
+    private func loadAgentCatalog(deviceID: UUID, using service: HerdrService) async {
+        sessions[deviceID]?.agentCatalog = .loading
+        do {
+            let manifests = try await service.agentManifests()
+            sessions[deviceID]?.attachmentCapabilities =
+                AgentAttachmentCapabilityRegistry(manifests: manifests)
+            let advertised = manifests.map(\.agent)
+            if device(deviceID)?.isLocal == true {
+                let found = await service.installedAgents(
+                    from: advertised,
+                    overrides: AgentBinaryOverrides.load()
+                )
+                sessions[deviceID]?.agentCatalog = .loaded(
+                    kinds: found.map(\.kind),
+                    paths: Dictionary(uniqueKeysWithValues: found.map { ($0.kind, $0.path) })
+                )
+            } else {
+                sessions[deviceID]?.agentCatalog = .loaded(kinds: advertised)
+            }
+        } catch {
+            sessions[deviceID]?.agentCatalog = .failed(error.localizedDescription)
+        }
+    }
+
+    func reloadAgentCatalog(deviceID: UUID) {
+        guard let device = device(deviceID) else { return }
+        let service = service(for: device)
+        Task { await loadAgentCatalog(deviceID: deviceID, using: service) }
     }
 
     /// Tears down every live tunnel. Awaited from the app's terminate hook — `stopSession`

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -873,7 +873,7 @@ struct NewAgentSheet: View {
     @ObservedObject var model: AppModel
     @Environment(\.dismiss) private var dismiss
     @State private var deviceID = Device.local.id
-    @State private var kind = "claude"
+    @State private var kind = ""
     @State private var workspaceID: String = ""
     @AppStorage("agent.bypassDefault") private var bypass = true
 
@@ -885,11 +885,8 @@ struct NewAgentSheet: View {
         model.session(deviceID)
     }
 
-    /// Only agents actually installed on the chosen device; falls back to the full
-    /// manifest list if sniffing failed.
     private var kinds: [String] {
-        if !session.installedAgentKinds.isEmpty { return session.installedAgentKinds }
-        return session.agentKinds.isEmpty ? ["claude", "codex", "gemini", "opencode", "grok"] : session.agentKinds
+        session.agentCatalog.kinds
     }
 
     private var bypassFlags: [String]? {
@@ -922,25 +919,57 @@ struct NewAgentSheet: View {
                     .fixedSize()
                     .onChange(of: deviceID) { _, _ in
                         workspaceID = ""
-                        if !kinds.contains(kind) { kind = kinds.first ?? "claude" }
+                        if !kinds.contains(kind) { kind = kinds.first ?? "" }
                     }
 
                     Spacer().frame(height: 8)
                 }
 
                 SheetSectionLabel("AGENT")
-                ScrollView {
-                    LazyVGrid(
-                        columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 4),
-                        spacing: 8
-                    ) {
-                        ForEach(kinds, id: \.self) { name in
-                            kindCell(name)
+                Group {
+                    switch session.agentCatalog {
+                    case .loading:
+                        HStack(spacing: 8) {
+                            ProgressView().controlSize(.small)
+                            Text("Checking agents on \(chosenDevice.name)…")
+                                .foregroundStyle(Theme.textSecondary)
                         }
+                        .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
+                    case .failed(let message):
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(chosenDevice.isLocal
+                                ? "Couldn’t check installed agent CLIs."
+                                : "Couldn’t load this server’s agent catalog.")
+                                .foregroundStyle(Theme.textSecondary)
+                            Text(message)
+                                .font(.system(size: 10.5))
+                                .foregroundStyle(Theme.textTertiary)
+                                .lineLimit(2)
+                            Button("Retry") { model.reloadAgentCatalog(deviceID: deviceID) }
+                                .controlSize(.small)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
+                    case .loaded(let loadedKinds, _) where loadedKinds.isEmpty:
+                        Text(chosenDevice.isLocal
+                            ? "No supported agent CLI was found on this Mac. Install one, or set a binary path in Settings → Agents."
+                            : "This server advertises no agent manifests.")
+                            .foregroundStyle(Theme.textSecondary)
+                            .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
+                    case .loaded(let loadedKinds, let paths):
+                        ScrollView {
+                            LazyVGrid(
+                                columns: Array(repeating: GridItem(.flexible(), spacing: 8), count: 4),
+                                spacing: 8
+                            ) {
+                                ForEach(loadedKinds, id: \.self) { name in
+                                    kindCell(name, path: paths[name])
+                                }
+                            }
+                            .padding(1)
+                        }
+                        .frame(maxHeight: 236)
                     }
-                    .padding(1)
                 }
-                .frame(maxHeight: 236)
 
                 Spacer().frame(height: 8)
 
@@ -993,6 +1022,7 @@ struct NewAgentSheet: View {
                 .buttonStyle(.borderedProminent)
                 .tint(Theme.accent)
                 .keyboardShortcut(.defaultAction)
+                .disabled(!kinds.contains(kind))
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
@@ -1006,11 +1036,14 @@ struct NewAgentSheet: View {
             workspaceID = model.selectedSpace?.deviceID == deviceID
                 ? (model.selectedSpace?.workspaceID ?? "")
                 : ""
-            if !kinds.contains(kind) { kind = kinds.first ?? "claude" }
+            if !kinds.contains(kind) { kind = kinds.first ?? "" }
+        }
+        .onChange(of: kinds) { _, newKinds in
+            if !newKinds.contains(kind) { kind = newKinds.first ?? "" }
         }
     }
 
-    private func kindCell(_ name: String) -> some View {
+    private func kindCell(_ name: String, path: String?) -> some View {
         let selected = kind == name
         return Button {
             kind = name
@@ -1030,6 +1063,7 @@ struct NewAgentSheet: View {
                     .foregroundStyle(selected ? Theme.text : Theme.textSecondary)
                     .lineLimit(1)
             }
+            .help(path ?? "")
             .frame(maxWidth: .infinity)
             .frame(height: 58)
             .background(

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -187,7 +187,7 @@ struct HerdrMApp: App {
         }
 
         Settings {
-            SettingsView()
+            SettingsView(model: appDelegate.model)
         }
     }
 
@@ -236,18 +236,73 @@ struct HerdrMApp: App {
 }
 
 struct SettingsView: View {
+    @ObservedObject var model: AppModel
+
     var body: some View {
         TabView {
             AppearanceSettingsView()
                 .tabItem { Label("Appearance", systemImage: "paintbrush") }
             TerminalSettingsView()
                 .tabItem { Label("Terminal", systemImage: "terminal") }
+            AgentsSettingsView(model: model)
+                .tabItem { Label("Agents", systemImage: "sparkles") }
             NotificationSettingsView()
                 .tabItem { Label("Notifications", systemImage: "bell") }
             AboutSettingsView()
                 .tabItem { Label("About", systemImage: "info.circle") }
         }
         .frame(width: 420)
+    }
+}
+
+struct AgentsSettingsView: View {
+    var model: AppModel
+    @State private var drafts: [String: String] = AgentBinaryOverrides.load()
+
+    /// Kinds the picker knows how to start. The lookup command is `kind`,
+    /// except Cursor which installs as `cursor-agent`.
+    private static let kinds: [(kind: String, label: String, hint: String)] = [
+        ("claude", "Claude", "claude"),
+        ("codex", "Codex", "codex"),
+        ("cursor", "Cursor", "cursor-agent"),
+        ("gemini", "Gemini", "gemini"),
+        ("grok", "Grok", "grok"),
+        ("kimi", "Kimi", "kimi"),
+        ("opencode", "OpenCode", "opencode"),
+        ("copilot", "Copilot", "copilot"),
+    ]
+
+    var body: some View {
+        Form {
+            Section {
+                ForEach(Self.kinds, id: \.kind) { row in
+                    TextField(row.label, text: binding(row.kind), prompt: Text("Automatic"))
+                        .font(.system(size: 12).monospaced())
+                        .help("Command or path for \(row.hint). Leave empty to detect.")
+                }
+            } footer: {
+                Text("Finder-launched apps don’t inherit your terminal PATH. herdrm captures it once from a login + interactive shell, then looks up these names. A path here is an escape hatch when detection picks the wrong binary.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(20)
+        .onAppear { drafts = AgentBinaryOverrides.load() }
+        .onChange(of: drafts) { _, _ in commit() }
+        .onDisappear(perform: commit)
+        .onSubmit(commit)
+    }
+
+    private func commit() {
+        AgentBinaryOverrides.save(drafts)
+        model.reloadAgentCatalog(deviceID: Device.local.id)
+    }
+
+    private func binding(_ kind: String) -> Binding<String> {
+        Binding(
+            get: { drafts[kind] ?? "" },
+            set: { drafts[kind] = $0 }
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Finder-launched herdrm inherits LaunchServices' PATH (`/usr/bin:/bin:/usr/sbin:/sbin`). Agent CLIs installed via Homebrew, mise, nvm/fnm, bun, or `~/.local/bin` are therefore invisible to New Agent, and a `#!/usr/bin/env node` shim that *is* found can still fail at exec.

This change captures the user's login + interactive shell environment once (`zsh -i -l`, then `-l` if the interactive rc hangs) and reuses that snapshot for lookup, `herdr server` spawn, and terminal attach.

- Probe with `env -0` into a private tempfile so rc banners cannot pollute the snapshot (`posix_spawn` + `SETSID`, 3s interactive / 5s round budget).
- Search order: captured PATH, then the GUI process PATH, then well-known prefixes (Homebrew, bun, cargo, mise, volta).
- `installedAgentKinds` + `command -v` is replaced by `installedAgents`, which returns kind + absolute path. Probe failure does not throw.
- Settings → Agents accepts a per-kind binary path or command name. An invalid override hides that kind; it never falls back to auto-detect.
- New Agent no longer falls back to a hardcoded kind list. It shows loading / retry / empty states, and Create stays disabled until a real kind is selected.

## Out of scope

SSH devices are unchanged: the picker still uses the remote server's manifest catalog, and attach still prepends `SSHTunnel.remotePathExport`. Porting the same interactive capture across SSH is a follow-up.

## Test plan

- [x] `cd Packages/HerdrKit && swift test`
- [x] New tests for NUL parsing, search order, override non-fallback, real `zsh -i -l` capture (isolated `HOME`), interactive hang → login-only fallback, and spawn PATH including wrapper vars (`NVM_DIR` / `FNM_*`)
- [x] Rebased onto current `upstream/main` (`f182c81`, v0.4.0 changelog)
- [ ] From a Finder-launched herdrm (not a terminal-spawned binary): New Agent lists CLIs that only exist on the login-shell PATH
- [ ] Settings → Agents override to a missing path hides that kind; clearing it restores detection
- [ ] Attach / spawn of a `#!/usr/bin/env node` shim still finds `node`