### PR TITLE
fix(sidebar): Space drag uses AppKit because Button swallowed mouseDown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Fixed
+- Dragging a Space in the sidebar actually reorders it. The 0.4.0 rows were
+  SwiftUI `Button`s, and on macOS that swallows mouseDown so `.onDrag` never
+  started (click-to-select still worked). Space rows now use an AppKit drag
+  session after a few points of movement.
+
 ## [0.4.0] - 2026-08-22
 
 ### Added

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -1,7 +1,6 @@
 import AppKit
 import HerdrKit
 import SwiftUI
-import UniformTypeIdentifiers
 
 struct VisualEffectView: NSViewRepresentable {
     var material: NSVisualEffectView.Material = .sidebar
@@ -83,37 +82,12 @@ struct SidebarView: View {
                     .frame(height: 28)
                     allSpacesRow
                     ForEach(model.visibleSpaces) { entry in
-                        spaceRow(entry)
-                            .opacity(draggingSpaceID == entry.id ? 0.4 : 1)
-                            .overlay(alignment: (spaceDrop?.after ?? false) ? .bottom : .top) {
-                                if spaceDrop?.id == entry.id {
-                                    Rectangle()
-                                        .fill(Theme.accent)
-                                        .frame(height: 2)
-                                }
-                            }
-                            .onDrag {
-                                draggingSpaceID = entry.id
-                                return NSItemProvider(object: entry.id as NSString)
-                            }
-                            .onDrop(
-                                of: [.utf8PlainText, .text],
-                                delegate: SpaceRowDropDelegate(
-                                    entry: entry,
-                                    model: model,
-                                    draggingSpaceID: $draggingSpaceID,
-                                    spaceDrop: $spaceDrop
-                                )
-                            )
-                            .contextMenu {
-                                Button("Rename Space…") {
-                                    model.spaceToRename = entry
-                                }
-                                Divider()
-                                Button("Close Space \"\(entry.workspace.label)\"…", role: .destructive) {
-                                    model.requestCloseSpace(entry)
-                                }
-                            }
+                        SpaceRowView(
+                            entry: entry,
+                            model: model,
+                            draggingSpaceID: $draggingSpaceID,
+                            spaceDrop: $spaceDrop
+                        )
                     }
 
                     Spacer().frame(height: 10)
@@ -215,34 +189,6 @@ struct SidebarView: View {
                     .foregroundStyle(selected ? Theme.text : Theme.textSecondary)
                 Spacer()
                 Text("\(model.scopeAgentCount)")
-                    .font(.system(size: 11))
-                    .foregroundStyle(Theme.textGhost)
-            }
-            .padding(.horizontal, 8)
-            .frame(height: 30)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(SidebarRowButtonStyle(selected: selected))
-    }
-
-    private func spaceRow(_ entry: AppModel.SpaceEntry) -> some View {
-        let selected = model.selectedSpace == entry.ref
-        return Button {
-            model.selectSpace(entry.ref)
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "folder")
-                    .font(.system(size: 11.5))
-                    .foregroundStyle(selected ? Theme.textSecondary : Theme.textTertiary)
-                Text(entry.workspace.label)
-                    .font(.system(size: 13))
-                    .foregroundStyle(selected ? Theme.text : Theme.textSecondary)
-                    .lineLimit(1)
-                Spacer()
-                if model.showsDeviceBadges {
-                    deviceBadge(entry.device)
-                }
-                Text("\(model.agentCount(in: entry))")
                     .font(.system(size: 11))
                     .foregroundStyle(Theme.textGhost)
             }
@@ -615,43 +561,76 @@ struct SidebarRowButtonStyle: ButtonStyle {
     }
 }
 
-private struct SpaceRowDropDelegate: DropDelegate {
+/// Not a `Button`: on macOS, `Button` consumes mouseDown so SwiftUI `.onDrag`
+/// never starts. Click and reorder go through `SpaceRowDragHost`.
+private struct SpaceRowView: View {
     let entry: AppModel.SpaceEntry
-    let model: AppModel
+    @ObservedObject var model: AppModel
     @Binding var draggingSpaceID: String?
     @Binding var spaceDrop: (id: String, after: Bool)?
+    @State private var hovered = false
 
-    func validateDrop(info: DropInfo) -> Bool {
-        info.hasItemsConforming(to: [.utf8PlainText, .text])
-    }
-
-    func dropUpdated(info: DropInfo) -> DropProposal? {
-        let after = info.location.y > 15
-        DispatchQueue.main.async {
-            spaceDrop = (entry.id, after)
+    var body: some View {
+        let selected = model.selectedSpace == entry.ref
+        HStack(spacing: 8) {
+            Image(systemName: "folder")
+                .font(.system(size: 11.5))
+                .foregroundStyle(selected ? Theme.textSecondary : Theme.textTertiary)
+            Text(entry.workspace.label)
+                .font(.system(size: 13))
+                .foregroundStyle(selected ? Theme.text : Theme.textSecondary)
+                .lineLimit(1)
+            Spacer()
+            if model.showsDeviceBadges {
+                DeviceChip(device: entry.device)
+            }
+            Text("\(model.agentCount(in: entry))")
+                .font(.system(size: 11))
+                .foregroundStyle(Theme.textGhost)
         }
-        return DropProposal(operation: .move)
-    }
-
-    func dropExited(info: DropInfo) {
-        DispatchQueue.main.async {
-            if spaceDrop?.id == entry.id { spaceDrop = nil }
+        .padding(.horizontal, 8)
+        .frame(height: 30)
+        .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(selected || hovered ? AnyShapeStyle(Theme.itemWashSelected) : AnyShapeStyle(.clear))
+        )
+        .onHover { hovered = $0 }
+        .opacity(draggingSpaceID == entry.id ? 0.4 : 1)
+        .overlay(alignment: (spaceDrop?.after ?? false) ? .bottom : .top) {
+            if spaceDrop?.id == entry.id {
+                Rectangle()
+                    .fill(Theme.accent)
+                    .frame(height: 2)
+            }
         }
-    }
-
-    func performDrop(info: DropInfo) -> Bool {
-        let after = info.location.y > 15
-        let target = entry
-        let sourceID = draggingSpaceID
-        Task { @MainActor in
-            draggingSpaceID = nil
-            spaceDrop = nil
-            guard let sourceID,
-                  let source = model.visibleSpaces.first(where: { $0.id == sourceID })
-            else { return }
-            model.moveSpace(source, onto: target, placeAfter: after)
+        .overlay {
+            SpaceRowDragHost(
+                entryID: entry.id,
+                label: entry.workspace.label,
+                onClick: { model.selectSpace(entry.ref) },
+                onRename: { model.spaceToRename = entry },
+                onClose: { model.requestCloseSpace(entry) },
+                onDragStart: { draggingSpaceID = $0 },
+                onDragEnd: {
+                    draggingSpaceID = nil
+                    spaceDrop = nil
+                },
+                onDropHover: { after in spaceDrop = (entry.id, after) },
+                onHoverExit: {
+                    if spaceDrop?.id == entry.id { spaceDrop = nil }
+                },
+                onDrop: { sourceID, after in
+                    draggingSpaceID = nil
+                    spaceDrop = nil
+                    guard let source = model.visibleSpaces.first(where: { $0.id == sourceID })
+                    else { return }
+                    model.moveSpace(source, onto: entry, placeAfter: after)
+                }
+            )
         }
-        return true
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(entry.workspace.label)
     }
 }
 

--- a/Sources/HerdrM/SpaceRowDrag.swift
+++ b/Sources/HerdrM/SpaceRowDrag.swift
@@ -1,0 +1,162 @@
+import AppKit
+import SwiftUI
+
+/// AppKit drag/drop host. SwiftUI `.onDrag` on macOS does not start when a
+/// `Button` (or even `onTapGesture`) owns mouseDown; a few points of movement
+/// here begin an `NSDraggingSession` instead.
+struct SpaceRowDragHost: NSViewRepresentable {
+    let entryID: String
+    let label: String
+    let onClick: () -> Void
+    let onRename: () -> Void
+    let onClose: () -> Void
+    let onDragStart: (String) -> Void
+    let onDragEnd: () -> Void
+    let onDropHover: (Bool) -> Void
+    let onHoverExit: () -> Void
+    let onDrop: (String, Bool) -> Void
+
+    func makeNSView(context: Context) -> SpaceRowDragNSView {
+        SpaceRowDragNSView()
+    }
+
+    func updateNSView(_ view: SpaceRowDragNSView, context: Context) {
+        view.entryID = entryID
+        view.label = label
+        view.onClick = onClick
+        view.onRename = onRename
+        view.onClose = onClose
+        view.onDragStart = onDragStart
+        view.onDragEnd = onDragEnd
+        view.onDropHover = onDropHover
+        view.onHoverExit = onHoverExit
+        view.onDrop = onDrop
+    }
+}
+
+final class SpaceRowDragNSView: NSView, NSDraggingSource {
+    static let pasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.space-id")
+
+    var entryID = ""
+    var label = ""
+    var onClick: (() -> Void)?
+    var onRename: (() -> Void)?
+    var onClose: (() -> Void)?
+    var onDragStart: ((String) -> Void)?
+    var onDragEnd: (() -> Void)?
+    var onDropHover: ((Bool) -> Void)?
+    var onHoverExit: (() -> Void)?
+    var onDrop: ((String, Bool) -> Void)?
+
+    private var downEvent: NSEvent?
+    private var didDrag = false
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        registerForDraggedTypes([Self.pasteboardType])
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        registerForDraggedTypes([Self.pasteboardType])
+    }
+
+    override var isFlipped: Bool { true }
+    override var acceptsFirstResponder: Bool { false }
+
+    override func mouseDown(with event: NSEvent) {
+        downEvent = event
+        didDrag = false
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let down = downEvent, !didDrag else { return }
+        let start = convert(down.locationInWindow, from: nil)
+        let now = convert(event.locationInWindow, from: nil)
+        guard hypot(now.x - start.x, now.y - start.y) >= 4 else { return }
+        didDrag = true
+        onDragStart?(entryID)
+        let pbItem = NSPasteboardItem()
+        pbItem.setString(entryID, forType: Self.pasteboardType)
+        let item = NSDraggingItem(pasteboardWriter: pbItem)
+        item.setDraggingFrame(bounds, contents: nil)
+        beginDraggingSession(with: [item], event: down, source: self)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        if !didDrag { onClick?() }
+        downEvent = nil
+        didDrag = false
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = NSMenu()
+        let rename = menu.addItem(
+            withTitle: "Rename Space…",
+            action: #selector(renameSpace),
+            keyEquivalent: ""
+        )
+        rename.target = self
+        menu.addItem(.separator())
+        let close = menu.addItem(
+            withTitle: "Close Space \"\(label)\"…",
+            action: #selector(closeSpace),
+            keyEquivalent: ""
+        )
+        close.target = self
+        return menu
+    }
+
+    @objc private func renameSpace() { onRename?() }
+    @objc private func closeSpace() { onClose?() }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        sourceOperationMaskFor context: NSDraggingContext
+    ) -> NSDragOperation {
+        .move
+    }
+
+    func draggingSession(
+        _ session: NSDraggingSession,
+        endedAt screenPoint: NSPoint,
+        operation: NSDragOperation
+    ) {
+        onDragEnd?()
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard draggedID(from: sender) != nil else { return [] }
+        onDropHover?(placeAfter(sender))
+        return .move
+    }
+
+    override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
+        guard draggedID(from: sender) != nil else { return [] }
+        onDropHover?(placeAfter(sender))
+        return .move
+    }
+
+    override func draggingExited(_ sender: NSDraggingInfo?) {
+        onHoverExit?()
+    }
+
+    override func prepareForDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        draggedID(from: sender) != nil
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let sourceID = draggedID(from: sender) else { return false }
+        let after = placeAfter(sender)
+        onDrop?(sourceID, after)
+        return true
+    }
+
+    private func placeAfter(_ sender: NSDraggingInfo) -> Bool {
+        convert(sender.draggingLocation, from: nil).y > bounds.midY
+    }
+
+    private func draggedID(from sender: NSDraggingInfo) -> String? {
+        sender.draggingPasteboard.string(forType: Self.pasteboardType)
+    }
+}


### PR DESCRIPTION
0.4.0 shipped #39, but dragging a Space in the sidebar still only selects the row. The rows were SwiftUI `Button`s; on macOS that consumes `mouseDown`, so `.onDrag` never starts. I reproduced it on a signed 0.4.0 build: click works, `workspace.move_block` never fires.

This replaces the Space row `Button` + `.onDrag` with an AppKit host: click still selects, a few points of movement begin `NSDraggingSession`, drop still calls `workspace.move_block`. Rename / Close stay on the row context menu.

## Test plan
- [ ] Drag Space A onto Space B; order matches `herdr workspace list` (`number`) and survives snapshot refresh
- [ ] Click a Space still selects it (no accidental reorder)
- [ ] Rename / Close from the context menu still work
- [ ] A worktree-grouped Space still moves as a block via `workspace.move_block`

Fixes the 0.4.0 regression of #38.