### PR TITLE
fix: prevent SIGPIPE from SocketRPC writes

### DIFF
--- a/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
@@ -106,6 +106,18 @@ public struct SocketRPC: Sendable {
         }
         let fd = socket(AF_UNIX, SOCK_STREAM, 0)
         guard fd >= 0 else { throw HerdrError.connectionFailed("socket(): \(String(cString: strerror(errno)))") }
+        var noSigPipe: Int32 = 1
+        guard setsockopt(
+            fd,
+            SOL_SOCKET,
+            SO_NOSIGPIPE,
+            &noSigPipe,
+            socklen_t(MemoryLayout.size(ofValue: noSigPipe))
+        ) == 0 else {
+            let reason = String(cString: strerror(errno))
+            close(fd)
+            throw HerdrError.connectionFailed("setsockopt(SO_NOSIGPIPE): \(reason)")
+        }
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
         let bytes = Array(path.utf8)

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
@@ -1,0 +1,46 @@
+import Darwin
+import Foundation
+import XCTest
+@testable import HerdrKit
+
+final class SocketRPCTests: XCTestCase {
+    func testConnectDisablesSIGPIPE() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdrm-sigpipe-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let path = directory.appendingPathComponent("server.sock").path
+        let listener = socket(AF_UNIX, SOCK_STREAM, 0)
+        XCTAssertGreaterThanOrEqual(listener, 0)
+        defer { close(listener) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let pathBytes = Array(path.utf8)
+        XCTAssertLessThan(pathBytes.count, MemoryLayout.size(ofValue: address.sun_path))
+        withUnsafeMutableBytes(of: &address.sun_path) { raw in
+            raw.copyBytes(from: pathBytes)
+        }
+        let addressLength = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketAddress in
+                Darwin.bind(listener, socketAddress, addressLength)
+            }
+        }
+        XCTAssertEqual(bindResult, 0, String(cString: strerror(errno)))
+        XCTAssertEqual(listen(listener, 1), 0, String(cString: strerror(errno)))
+
+        let client = try SocketRPC.connect(path: path)
+        defer { close(client) }
+
+        var noSigPipe: Int32 = 0
+        var optionLength = socklen_t(MemoryLayout.size(ofValue: noSigPipe))
+        XCTAssertEqual(
+            getsockopt(client, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, &optionLength),
+            0,
+            String(cString: strerror(errno))
+        )
+        XCTAssertEqual(noSigPipe, 1)
+    }
+}


### PR DESCRIPTION
## Summary

- set `SO_NOSIGPIPE` on every Unix socket created by `SocketRPC.connect`
- surface `setsockopt` failures as a connection error while closing the descriptor
- add a regression test that connects to a real Unix socket and verifies the returned descriptor has `SO_NOSIGPIPE` enabled

## Why

A write to a peer-closed Unix socket can otherwise terminate the whole HerdrM process with `SIGPIPE`, bypassing the reconnect path.

## Validation

- `xcrun swift build --package-path Packages/HerdrKit --jobs 2`
- `git diff --check`
- the XCTest target requires full Xcode; the local Command Line Tools installation compiled the production module but does not provide the `XCTest` module, so the regression test is delegated to this repository CI.