### PR TITLE
feat(terminal): Cmd+Backspace deletes to start of line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Fixed
+- ⌘⌫ in the terminal now deletes to the start of the line (^U). ⌘← / ⌘→ jump to start / end (^A / ^E) and ⌘⌦ deletes to the end (^K); the same chords still send those readline bytes when a TUI has negotiated the kitty keyboard protocol. zsh's default ^U is kill-whole-line — that binding lives in the shell, not the terminal.
+
 ## [0.4.5] - 2026-08-23
 
 ### Changed

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -135,7 +135,13 @@ private enum ClipboardFileError: LocalizedError {
 /// Shift+Enter, so the modifier never reaches the TUI. SwiftTerm's `keyDown`
 /// and `doCommand` are public, not open, so `interpretKeyEvents` is the only
 /// hook a subclass can take — and it only sees Return in legacy mode, leaving
-/// this inert when a TUI negotiates the kitty keyboard protocol.
+/// Shift+Enter inert when a TUI negotiates the kitty keyboard protocol.
+///
+/// ⌘ text-editing chords are different. SwiftTerm hands ⌘ to AppKit
+/// `interpretKeyEvents`, and `doCommand` has no `deleteToBeginningOfLine:`, so
+/// ⌘⌫ used to send nothing. Those chords (and the matching ⌥ word-editing
+/// ones) send readline bytes here, before `super`, even under kitty — Ghostty
+/// / VS Code / iTerm Natural Text Editing, not the Shift+Enter kitty skip.
 final class LineBreakTerminalView: LocalProcessTerminalView {
     var usesLightColors = false
     var appliedDarkAppearance: Bool?
@@ -261,16 +267,48 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
         if eventArray.count == 1,
            let event = eventArray.first,
            event.type == .keyDown,
-           event.keyCode == 36 || event.keyCode == 76,  // Return, keypad Enter
-           !hasMarkedText() {
-            let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            if modifiers.contains(.shift),
-               modifiers.isDisjoint(with: [.command, .control, .option]) {
-                send(txt: "\u{1b}\r")
-                return
-            }
+           !hasMarkedText(),
+           let payload = ptyBytes(forMacEditingKey: event) {
+            send(txt: payload)
+            return
         }
         super.interpretKeyEvents(eventArray)
+    }
+
+    /// Mac Delete is Backspace (keyCode 51). ⌥⌘ arrows move split focus and
+    /// are left alone; ⌘A/⌘E/⌘W and the other app chords never match here.
+    private func ptyBytes(forMacEditingKey event: NSEvent) -> String? {
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let commandOnly = modifiers.contains(.command)
+            && modifiers.isDisjoint(with: [.option, .control])
+        let optionOnly = optionAsMetaKey
+            && modifiers.contains(.option)
+            && modifiers.isDisjoint(with: [.command, .control])
+
+        if commandOnly {
+            switch event.keyCode {
+            case 51:  return "\u{15}"  // ⌘⌫ → ^U
+            case 123: return "\u{01}"  // ⌘← → ^A
+            case 124: return "\u{05}"  // ⌘→ → ^E
+            case 117: return "\u{0b}"  // ⌘⌦ → ^K
+            default: break
+            }
+        }
+        if optionOnly {
+            switch event.keyCode {
+            case 51:  return "\u{1b}\u{7f}"  // ⌥⌫ → ESC DEL
+            case 123: return "\u{1b}b"       // ⌥← → ESC b
+            case 124: return "\u{1b}f"       // ⌥→ → ESC f
+            case 117: return "\u{1b}d"       // ⌥⌦ → ESC d
+            default: break
+            }
+        }
+        if event.keyCode == 36 || event.keyCode == 76,  // Return, keypad Enter
+           modifiers.contains(.shift),
+           modifiers.isDisjoint(with: [.command, .control, .option]) {
+            return "\u{1b}\r"
+        }
+        return nil
     }
 
     var attachmentCapabilities: AgentAttachmentCapabilities?


### PR DESCRIPTION
## Summary

Cmd+Backspace in the embedded terminal did nothing. SwiftTerm forwards ⌘ to AppKit `interpretKeyEvents`, and `doCommand` has no `deleteToBeginningOfLine:`, so the PTY never received a byte.

`LineBreakTerminalView.interpretKeyEvents` now sends readline bytes before `super`, when IME is not composing (`hasMarkedText() == false`):

| Chord | Bytes |
| --- | --- |
| ⌘⌫ (keyCode 51) | `0x15` (^U) |
| ⌘← | `0x01` (^A) |
| ⌘→ | `0x05` (^E) |
| ⌘⌦ (keyCode 117) | `0x0b` (^K) |
| ⌥⌫ | ESC DEL |
| ⌥← / ⌥→ | ESC b / ESC f |
| ⌥⌦ | ESC d |

This matches Ghostty / VS Code / iTerm Natural Text Editing. Unlike Shift+Enter (which stays inert under kitty; see #14), these eight chords still send the legacy bytes when a TUI has negotiated the kitty keyboard protocol.

Not mapped: ⌘W / ⌘Q / ⌘K / ⌘N / ⌘D / ⌘B / ⌘C / ⌘V, ⌘A, ⌘E, and ⌥⌘ arrows (split focus).

zsh's default ^U is `kill-whole-line`, not delete-to-start-of-line. That is a shell keymap, not something the terminal should rewrite; we send ^U and leave the binding to the shell.

## Change graph

```mermaid
flowchart LR
    KeyDown["NSEvent keyDown"] --> IKE["LineBreakTerminalView.interpretKeyEvents"]
    IKE -->|"IME composing"| Super["super.interpretKeyEvents"]
    IKE -->|"⌘⌫ ⌘← ⌘→ ⌘⌦ / ⌥ word chords"| PTY["PTY readline bytes"]
    Super --> AppKit["AppKit doCommand"]
```

## Validation

- `make build` — failed in this environment (no Developer ID certificate for team NCFNX3LJ83). Same failure on `main` at d8ec416.
- `xcodebuild … CODE_SIGNING_ALLOWED=NO` — **BUILD SUCCEEDED** (compile check for this change).
- `make kit-test` — 82 tests, 5 skipped (`HERDRM_E2E_SSH_TARGET` unset), 0 failures.
