### PR TITLE
fix(sidebar): Spaces section header does not respond to clicks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Fixed
+- Sidebar section headers (Spaces, Agents, Terminals) now collapse on click, and chrome buttons no longer keep a focus ring after click (#48).
+
 ## [0.4.5] - 2026-08-23
 
 ### Changed

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -24,6 +24,9 @@ struct SidebarView: View {
     @State private var deviceButtonHovered = false
     @State private var draggingSpaceID: String?
     @State private var spaceDrop: (id: String, after: Bool)?
+    @State private var spacesExpanded = true
+    @State private var agentsExpanded = true
+    @State private var terminalsExpanded = true
 
     var body: some View {
         VStack(spacing: 0) {
@@ -58,14 +61,11 @@ struct SidebarView: View {
 
             ScrollView {
                 VStack(spacing: 1) {
-                    HStack(spacing: 5) {
-                        Text("Spaces")
-                            .font(.system(size: 12.5, weight: .medium))
-                            .foregroundStyle(Theme.textTertiary)
-                        Image(systemName: "chevron.down")
-                            .font(.system(size: 9, weight: .semibold))
-                            .foregroundStyle(Theme.textGhost)
-                        Spacer()
+                    // Title + chevron used to be a decorative HStack with no
+                    // tap target, so the chevron promised a disclosure that
+                    // never fired. Trailing New Space stays a sibling Button
+                    // so it does not toggle the section.
+                    groupHeader("Spaces", expanded: $spacesExpanded) {
                         Button {
                             model.showNewSpace = true
                         } label: {
@@ -77,48 +77,53 @@ struct SidebarView: View {
                         }
                         .buttonStyle(.plain)
                         .help("New Space")
+                        .focusEffectDisabled()
                     }
-                    .padding(.horizontal, 8)
-                    .frame(height: 28)
-                    allSpacesRow
-                    ForEach(model.visibleSpaces) { entry in
-                        SpaceRowView(
-                            entry: entry,
-                            model: model,
-                            draggingSpaceID: $draggingSpaceID,
-                            spaceDrop: $spaceDrop
-                        )
+                    if spacesExpanded {
+                        allSpacesRow
+                        ForEach(model.visibleSpaces) { entry in
+                            SpaceRowView(
+                                entry: entry,
+                                model: model,
+                                draggingSpaceID: $draggingSpaceID,
+                                spaceDrop: $spaceDrop
+                            )
+                        }
                     }
 
                     Spacer().frame(height: 10)
 
-                    groupHeader("Agents")
-                    if model.visibleAgents.isEmpty {
-                        Text(emptyAgentsHint)
-                            .font(.system(size: 11.5))
-                            .foregroundStyle(Theme.textGhost)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(8)
-                    }
-                    ForEach(model.visibleAgents) { entry in
-                        agentRow(entry)
-                            .contextMenu {
-                                Button("Close Agent…", role: .destructive) {
-                                    model.requestClosePane(entry.ref, name: entry.agent.title)
+                    groupHeader("Agents", expanded: $agentsExpanded)
+                    if agentsExpanded {
+                        if model.visibleAgents.isEmpty {
+                            Text(emptyAgentsHint)
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(Theme.textGhost)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(8)
+                        }
+                        ForEach(model.visibleAgents) { entry in
+                            agentRow(entry)
+                                .contextMenu {
+                                    Button("Close Agent…", role: .destructive) {
+                                        model.requestClosePane(entry.ref, name: entry.agent.title)
+                                    }
                                 }
-                            }
+                        }
                     }
 
                     if !model.shellSessions.isEmpty {
                         Spacer().frame(height: 10)
-                        groupHeader("Terminals")
-                        ForEach(model.shellSessions) { session in
-                            shellRow(session)
-                                .contextMenu {
-                                    Button("Close Terminal", role: .destructive) {
-                                        model.closeShellSession(session.id)
+                        groupHeader("Terminals", expanded: $terminalsExpanded)
+                        if terminalsExpanded {
+                            ForEach(model.shellSessions) { session in
+                                shellRow(session)
+                                    .contextMenu {
+                                        Button("Close Terminal", role: .destructive) {
+                                            model.closeShellSession(session.id)
+                                        }
                                     }
-                                }
+                            }
                         }
                     }
                 }
@@ -159,17 +164,44 @@ struct SidebarView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(SidebarRowButtonStyle())
+        // CSS `outline: none` is not a SwiftUI concept. This is the native
+        // equivalent for chrome (New Agent / New Terminal / Search). List
+        // rows keep their focus ring for keyboard access.
+        .focusEffectDisabled()
     }
 
-    private func groupHeader(_ title: String) -> some View {
+    private func groupHeader(_ title: String, expanded: Binding<Bool>) -> some View {
+        groupHeader(title, expanded: expanded) { EmptyView() }
+    }
+
+    private func groupHeader<Trailing: View>(
+        _ title: String,
+        expanded: Binding<Bool>,
+        @ViewBuilder trailing: () -> Trailing
+    ) -> some View {
         HStack(spacing: 5) {
-            Text(title)
-                .font(.system(size: 12.5, weight: .medium))
-                .foregroundStyle(Theme.textTertiary)
-            Image(systemName: "chevron.down")
-                .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(Theme.textGhost)
-            Spacer()
+            Button {
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    expanded.wrappedValue.toggle()
+                }
+            } label: {
+                HStack(spacing: 5) {
+                    Text(title)
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundStyle(Theme.textTertiary)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundStyle(Theme.textGhost)
+                        .rotationEffect(.degrees(expanded.wrappedValue ? 90 : 0))
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(title)
+            .disclosureAccessibility(expanded: expanded.wrappedValue)
+
+            trailing()
         }
         .padding(.horizontal, 8)
         .frame(height: 28)
@@ -336,6 +368,7 @@ struct SidebarView: View {
                     .frame(width: 26, height: 26)
             }
             .buttonStyle(.plain)
+            .focusEffectDisabled()
         }
         .padding(.horizontal, 10)
         .frame(height: 40)
@@ -371,6 +404,7 @@ struct TitlebarIconButton: View {
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .focusEffectDisabled()
         .onHover { hovered = $0 }
         .help(help)
     }
@@ -546,6 +580,16 @@ struct DevicePopoverRow: View {
                 .fill(hovered || isActive ? AnyShapeStyle(Theme.itemWashSelected) : AnyShapeStyle(.clear))
         )
         .onHover { hovered = $0 }
+    }
+}
+
+private extension View {
+    /// Button trait plus expanded/collapsed so VoiceOver matches the chevron.
+    /// macOS SwiftUI has no `accessibilityExpanded`; VoiceOver reads the value.
+    func disclosureAccessibility(expanded: Bool) -> some View {
+        self
+            .accessibilityAddTraits(.isButton)
+            .accessibilityValue(expanded ? "Expanded" : "Collapsed")
     }
 }
 

--- a/Sources/HerdrM/SpaceRowDrag.swift
+++ b/Sources/HerdrM/SpaceRowDrag.swift
@@ -17,7 +17,9 @@ struct SpaceRowDragHost: NSViewRepresentable {
     let onDrop: (String, Bool) -> Void
 
     func makeNSView(context: Context) -> SpaceRowDragNSView {
-        SpaceRowDragNSView()
+        // Non-zero seed frame: a SwiftUI overlay NSView that starts at .zero
+        // can stay 0-size, so clicks and drags never arrive (#42).
+        SpaceRowDragNSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
     }
 
     func updateNSView(_ view: SpaceRowDragNSView, context: Context) {
@@ -63,6 +65,11 @@ final class SpaceRowDragNSView: NSView, NSDraggingSource {
 
     override var isFlipped: Bool { true }
     override var acceptsFirstResponder: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        // Explicit hit-test so a 0-size overlay cannot silently drop clicks.
+        bounds.contains(point) ? self : nil
+    }
 
     override func mouseDown(with event: NSEvent) {
         downEvent = event


### PR DESCRIPTION
## Summary

Reproduced on macOS 27 beta 6 (Tahoe). Clicking the Spaces section header had no response.

The Spaces title and chevron were a decorative `HStack` — no tap handler, no `DisclosureGroup` — so the control looked like a disclosure and did nothing. This is a native SwiftUI app, not a WebView.

The whole header row is now the toggle (`contentShape` so the click target is the row). The trailing **New Space** button is a sibling, so it still opens the sheet and does not collapse the section. Agents and Terminals use the same header. The chevron points down when expanded and right when collapsed, with a 200ms `easeInOut` animation around the list.

A CSS `outline: none` cannot apply here — this repo has no CSS. The native equivalent is `.focusEffectDisabled()` on chrome buttons (New Agent, New Terminal, Search, New Space, plus the titlebar sidebar toggle and the settings gear). That is not applied globally, so Space / Agent rows keep a focus ring for keyboard access.

`SpaceRowDragNSView` now starts with a non-zero frame and an explicit `hitTest`, so the #42 overlay cannot collapse to 0-size and drop clicks.

Fixes #48

## Screenshots

Reproduced on macOS 27 beta 6 (Tahoe). Clicking the Spaces section header had no response.

![Spaces section header: clicking has no response](https://gist.githubusercontent.com/eachann1024/426ebf0bc66722fcd4a1ae4ba9045249/raw/bb5e3f91fa721fbfd0d7136bc4d523cfaa0fa6ba/spaces-header-no-response-1.png)

![Spaces section header: clicking has no response (2)](https://gist.githubusercontent.com/eachann1024/426ebf0bc66722fcd4a1ae4ba9045249/raw/bb5e3f91fa721fbfd0d7136bc4d523cfaa0fa6ba/spaces-header-no-response-2.png)

## Change graph

```mermaid
flowchart LR
    Header["Spaces / Agents / Terminals header"] -->|"click title + chevron"| Toggle["withAnimation toggle expanded"]
    Toggle --> Rows["show or hide section rows"]
    Header -->|"click New Space"| Sheet["New Space sheet, no toggle"]
    Chrome["New Agent / New Terminal / Search / New Space"] --> Focus["focusEffectDisabled"]
```

## Test plan

- [ ] Click the Spaces title or chevron: the list collapses and the chevron turns right
- [ ] Click again: the list expands and the chevron points down
- [ ] Click the trailing New Space control: the sheet opens and the section stays expanded
- [ ] Agents and Terminals headers behave the same way
- [ ] New Agent / New Terminal / Search / New Space do not keep a focus ring after click
- [ ] Keyboard focus on a Space or Agent row still shows a ring
- [ ] Drag-reordering a Space still works

## Verification

- `make kit-test`: 82 passed, 5 skipped (`HERDRM_E2E_SSH_TARGET` unset)
- `make build`: the Swift sources compile. This environment has no Developer ID certificate for team `NCFNX3LJ83`, so the Makefile's signed `xcodebuild` fails at signing. An unsigned `CODE_SIGNING_ALLOWED=NO` build succeeded.
