### PR TITLE
feat(terminal): improve IME and CJK input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Fixed
+- CJK IME composition in the embedded terminal keeps preedit visible, holds the candidate window at the caret, and does not forward edit shortcuts to the PTY. (#47)
+
 ## [0.4.5] - 2026-08-23
 
 ### Changed

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -136,10 +136,18 @@ private enum ClipboardFileError: LocalizedError {
 /// and `doCommand` are public, not open, so `interpretKeyEvents` is the only
 /// hook a subclass can take — and it only sees Return in legacy mode, leaving
 /// this inert when a TUI negotiates the kitty keyboard protocol.
+///
+/// IME composition is the same constraint. SwiftTerm 1.19 already implements
+/// `NSTextInputClient` and draws a marked-text overlay; this subclass only
+/// keeps edit shortcuts off the PTY while `hasMarkedText()`, commits CJK as
+/// UTF-8, and re-anchors `firstRect` when a TUI has hidden the hardware caret.
 final class LineBreakTerminalView: LocalProcessTerminalView {
     var usesLightColors = false
     var appliedDarkAppearance: Bool?
     private var lightColorAdapter = LightTerminalANSIAdapter()
+    /// Last non-empty caret frame, used when the TUI hides the hardware cursor
+    /// and SwiftTerm's `firstRect` would otherwise report `.zero`.
+    private var lastIMECaretFrame: NSRect = .zero
 
     override func dataReceived(slice: ArraySlice<UInt8>) {
         // SwiftTerm drops the selection on every chunk of output and on every
@@ -258,6 +266,17 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
     }
 
     override func interpretKeyEvents(_ eventArray: [NSEvent]) {
+        if hasMarkedText() {
+            // SwiftTerm's `doCommand` still emits PTY sequences for copy/select/
+            // emacs-style motion. Command/Control shortcuts must stay with the
+            // IME until composition ends; other keys still reach AppKit so
+            // preedit can update.
+            let forIME = eventArray.filter { !Self.isEditShortcutDuringComposition($0) }
+            if !forIME.isEmpty {
+                super.interpretKeyEvents(forIME)
+            }
+            return
+        }
         if eventArray.count == 1,
            let event = eventArray.first,
            event.type == .keyDown,
@@ -271,6 +290,110 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
             }
         }
         super.interpretKeyEvents(eventArray)
+    }
+
+    /// Command/Control combos become `doCommand` selectors that SwiftTerm
+    /// forwards to the process. IME composition needs those keys locally.
+    private static func isEditShortcutDuringComposition(_ event: NSEvent) -> Bool {
+        guard event.type == .keyDown else { return false }
+        let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        return mods.contains(.command) || mods.contains(.control)
+    }
+
+    override func setMarkedText(_ string: Any, selectedRange: NSRange, replacementRange: NSRange) {
+        rememberIMECaretFrame()
+        super.setMarkedText(string, selectedRange: selectedRange, replacementRange: replacementRange)
+    }
+
+    override func insertText(_ string: Any, replacementRange: NSRange) {
+        // IME commit must go as a complete UTF-8 string. With kitty keyboard
+        // flags on, SwiftTerm encodes a single scalar as CSI-u, which some
+        // TUIs then split. ASCII keystrokes still take the super path.
+        if hasMarkedText(), let text = Self.inputString(from: string) {
+            super.unmarkText()
+            if !text.isEmpty {
+                send(txt: text)
+            }
+            return
+        }
+        super.insertText(string, replacementRange: replacementRange)
+    }
+
+    override func showCursor(source: Terminal) {
+        super.showCursor(source: source)
+        rememberIMECaretFrame()
+    }
+
+    override func hideCursor(source: Terminal) {
+        rememberIMECaretFrame()
+        super.hideCursor(source: source)
+    }
+
+    override func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
+        let fromSuper = super.firstRect(forCharacterRange: range, actualRange: actualRange)
+        if fromSuper.width > 0.5, fromSuper.height > 0.5 {
+            rememberIMECaretFrame()
+            return fromSuper
+        }
+        let local = imeAnchorFrame()
+        guard let window else { return fromSuper }
+        return window.convertToScreen(convert(local, to: nil))
+    }
+
+    private func rememberIMECaretFrame() {
+        let frame = caretFrame
+        if frame.width > 0.5, frame.height > 0.5 {
+            lastIMECaretFrame = frame
+        }
+    }
+
+    /// Prefers the live caret, then the last frame from before the TUI hid it,
+    /// then a buffer-relative cell so IME candidates never fall back to 0,0.
+    private func imeAnchorFrame() -> NSRect {
+        let current = caretFrame
+        if current.width > 0.5, current.height > 0.5 {
+            lastIMECaretFrame = current
+            return current
+        }
+        if lastIMECaretFrame.width > 0.5, lastIMECaretFrame.height > 0.5 {
+            return lastIMECaretFrame
+        }
+        return estimatedCaretFrameFromBuffer()
+    }
+
+    private func estimatedCaretFrameFromBuffer() -> NSRect {
+        let cell = estimatedCellSize()
+        let col = min(max(0, terminal.buffer.x), max(0, terminal.cols - 1))
+        let row = min(max(0, terminal.buffer.y), max(0, terminal.rows - 1))
+        let origin = CGPoint(
+            x: CGFloat(col) * cell.width,
+            y: bounds.height - cell.height * CGFloat(row + 1)
+        )
+        return NSRect(origin: origin, size: cell)
+    }
+
+    private func estimatedCellSize() -> NSSize {
+        let rows = max(1, terminal.rows)
+        let cellHeight = max(1, getOptimalFrameSize().height / CGFloat(rows))
+        let glyph = font.glyph(withName: "W")
+        var cellWidth = font.advancement(forGlyph: glyph).width
+        if cellWidth < 1 {
+            cellWidth = ("W" as NSString).size(withAttributes: [.font: font]).width
+        }
+        return NSSize(width: max(1, cellWidth), height: cellHeight)
+    }
+
+    private static func inputString(from value: Any) -> String? {
+        switch value {
+        case let text as String:
+            return text
+        case let text as NSString:
+            return text as String
+        case let text as NSAttributedString:
+            return text.string
+        default:
+            return nil
+        }
     }
 
     var attachmentCapabilities: AgentAttachmentCapabilities?

--- a/project.yml
+++ b/project.yml
@@ -9,7 +9,8 @@ packages:
     path: Packages/HerdrKit
   SwiftTerm:
     url: https://github.com/migueldeicaza/SwiftTerm
-    from: "1.2.0"
+    # 1.19 ships the marked-text overlay used for IME preedit; do not reimplement it.
+    from: "1.19.0"
   Sparkle:
     url: https://github.com/sparkle-project/Sparkle
     from: "2.9.6"


### PR DESCRIPTION
Fixes #47

Chinese and other CJK IMEs were hard to use in the embedded SwiftTerm pane. While composing, Command/Control edit shortcuts were interpreted into PTY sequences, and when a TUI hid the hardware cursor SwiftTerm's `firstRect` reported an empty rect so the candidate window jumped to the origin.

SwiftTerm 1.19 already draws a marked-text overlay for preedit, so this PR pins that floor in `project.yml` (`from: "1.19.0"`, resolved 1.20.0 here) and only fills the gaps in `LineBreakTerminalView`:

- While `hasMarkedText()`, Command/Control shortcuts are not sent through `interpretKeyEvents` / `doCommand`
- IME commits are written as a complete UTF-8 string instead of a kitty CSI-u scalar
- `firstRect` falls back to the last caret cell, then the buffer cursor, so candidates stay on the insertion point

`LANG=en_US.UTF-8` is unchanged. Upstream SwiftTerm wide-character rendering bugs are not forked here.

## Change graph

```mermaid
flowchart LR
    IME["macOS IME"] --> Keys["interpretKeyEvents"]
    Keys -->|"hasMarkedText + edit shortcut"| Drop["keep off PTY"]
    Keys -->|"composition keys"| Overlay["SwiftTerm marked-text overlay"]
    Overlay --> Anchor["firstRect caret anchor"]
    Anchor --> Candidates["IME candidate window"]
    Overlay -->|"insertText commit"| UTF8["UTF-8 to PTY"]
```

## Test plan

- [x] `make kit-test` — 82 tests, 0 failures, 5 SSH E2E skipped without `HERDRM_E2E_SSH_TARGET`
- [x] `HerdrM` compiles; `make build` fails on this machine because the Developer ID identity is missing, and the same signing error reproduces on `main`
- [ ] Type CJK in an agent pane: preedit visible, candidates near the caret, Cmd/Ctrl shortcuts do not interrupt composition
