### PR TITLE
feat: add Simplified Chinese localization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ the Sparkle update description — a release without a section here fails CI.
 
 ## [Unreleased]
 
+### Added
+- Simplified Chinese localization via an Apple String Catalog, with Settings →
+  Appearance offering Follow System / English / Simplified Chinese (restart to apply).
+
 ## [0.4.5] - 2026-08-23
 
 ### Changed

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,0 +1,2678 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "language.name.en" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "English"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "English"
+          }
+        }
+      }
+    },
+    "language.name.zh-Hans" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "简体中文"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "简体中文"
+          }
+        }
+      }
+    },
+    "Hide Sidebar (⌘B)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide Sidebar (⌘B)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏侧边栏 (⌘B)"
+          }
+        }
+      }
+    },
+    "Show Sidebar (⌘B)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show Sidebar (⌘B)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示侧边栏 (⌘B)"
+          }
+        }
+      }
+    },
+    "New Agent" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Agent"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建 Agent"
+          }
+        }
+      }
+    },
+    "New Agent…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Agent…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建 Agent…"
+          }
+        }
+      }
+    },
+    "New Terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Terminal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建终端"
+          }
+        }
+      }
+    },
+    "Search" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索"
+          }
+        }
+      }
+    },
+    "Spaces" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Spaces"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空间"
+          }
+        }
+      }
+    },
+    "New Space" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Space"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建空间"
+          }
+        }
+      }
+    },
+    "New Space…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "New Space…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "新建空间…"
+          }
+        }
+      }
+    },
+    "Agents" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agents"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent"
+          }
+        }
+      }
+    },
+    "Close Agent…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Agent…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭 Agent…"
+          }
+        }
+      }
+    },
+    "Terminals" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminals"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端"
+          }
+        }
+      }
+    },
+    "Close Terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Terminal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭终端"
+          }
+        }
+      }
+    },
+    "Connecting…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connecting…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在连接…"
+          }
+        }
+      }
+    },
+    "No agents" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No agents"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "暂无 Agent"
+          }
+        }
+      }
+    },
+    "All Spaces" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All Spaces"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部空间"
+          }
+        }
+      }
+    },
+    "Local" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本机"
+          }
+        }
+      }
+    },
+    "needs input" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "needs input"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待输入"
+          }
+        }
+      }
+    },
+    "All Devices" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All Devices"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全部设备"
+          }
+        }
+      }
+    },
+    "DEVICES" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEVICES"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备"
+          }
+        }
+      }
+    },
+    "%lld devices · %lld connected" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld devices · %lld connected"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%lld 台设备 · %lld 台已连接"
+          }
+        }
+      }
+    },
+    "Edit %@…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit %@…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑 %@…"
+          }
+        }
+      }
+    },
+    "Remove %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remove %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移除 %@"
+          }
+        }
+      }
+    },
+    "Add Device…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Device…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加设备…"
+          }
+        }
+      }
+    },
+    "This Mac · herdr.sock" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This Mac · herdr.sock"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "这台 Mac · herdr.sock"
+          }
+        }
+      }
+    },
+    "%@ · SSH" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · SSH"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ · SSH"
+          }
+        }
+      }
+    },
+    "Check for Updates…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check for Updates…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "检查更新…"
+          }
+        }
+      }
+    },
+    "Terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端"
+          }
+        }
+      }
+    },
+    "Split Vertically" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Split Vertically"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "垂直分屏"
+          }
+        }
+      }
+    },
+    "Split Horizontally" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Split Horizontally"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "水平分屏"
+          }
+        }
+      }
+    },
+    "Focus Left Pane" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Focus Left Pane"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦左侧面板"
+          }
+        }
+      }
+    },
+    "Focus Right Pane" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Focus Right Pane"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦右侧面板"
+          }
+        }
+      }
+    },
+    "Focus Top Pane" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Focus Top Pane"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦上方面板"
+          }
+        }
+      }
+    },
+    "Focus Bottom Pane" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Focus Bottom Pane"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦下方面板"
+          }
+        }
+      }
+    },
+    "Widen Active Pane" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Widen Active Pane"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加宽当前面板"
+          }
+        }
+      }
+    },
+    "Narrow Active Pane" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Narrow Active Pane"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "收窄当前面板"
+          }
+        }
+      }
+    },
+    "Grow Active Pane" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Grow Active Pane"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "增高当前面板"
+          }
+        }
+      }
+    },
+    "Shrink Active Pane" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Shrink Active Pane"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "缩短当前面板"
+          }
+        }
+      }
+    },
+    "Close Split" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Split"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭分屏"
+          }
+        }
+      }
+    },
+    "Close" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭"
+          }
+        }
+      }
+    },
+    "Appearance" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appearance"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外观"
+          }
+        }
+      }
+    },
+    "Notifications" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知"
+          }
+        }
+      }
+    },
+    "About" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "About"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关于"
+          }
+        }
+      }
+    },
+    "Automatic" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Automatic"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "自动检测"
+          }
+        }
+      }
+    },
+    "Command or path for %@. Leave empty to detect." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Command or path for %@. Leave empty to detect."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "用于 %@ 的命令或路径。留空则自动检测。"
+          }
+        }
+      }
+    },
+    "Finder-launched apps don’t inherit your terminal PATH. herdrm captures it once from a login + interactive shell, then looks up these names. A path here is an escape hatch when detection picks the wrong binary." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finder-launched apps don’t inherit your terminal PATH. herdrm captures it once from a login + interactive shell, then looks up these names. A path here is an escape hatch when detection picks the wrong binary."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通过 Finder 启动的应用不会继承终端 PATH。herdrm 会从登录 + 交互式 shell 捕获一次，再按这些名称查找。检测结果不对时，可在此填写路径作为兜底。"
+          }
+        }
+      }
+    },
+    "Font" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Font"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字体"
+          }
+        }
+      }
+    },
+    "System Mono (SF Mono)" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System Mono (SF Mono)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统等宽字体 (SF Mono)"
+          }
+        }
+      }
+    },
+    "Size" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Size"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "大小"
+          }
+        }
+      }
+    },
+    "Weight" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Weight"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "字重"
+          }
+        }
+      }
+    },
+    "theme.system" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "System"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "系统"
+          }
+        }
+      }
+    },
+    "theme.light" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浅色"
+          }
+        }
+      }
+    },
+    "theme.dark" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dark"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "深色"
+          }
+        }
+      }
+    },
+    "font.weight.light" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Light"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "细"
+          }
+        }
+      }
+    },
+    "font.weight.regular" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Regular"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "常规"
+          }
+        }
+      }
+    },
+    "font.weight.medium" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Medium"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "中等"
+          }
+        }
+      }
+    },
+    "Only the system monospaced font has selectable weights." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Only the system monospaced font has selectable weights."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅系统等宽字体可选择字重。"
+          }
+        }
+      }
+    },
+    "Line spacing" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line spacing"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行距"
+          }
+        }
+      }
+    },
+    "Thin strokes" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Thin strokes"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "细笔画"
+          }
+        }
+      }
+    },
+    "Turns off macOS font smoothing, which thickens glyph stems and makes agent output — Claude Code's bold text especially — look heavy and smudged." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Turns off macOS font smoothing, which thickens glyph stems and makes agent output — Claude Code's bold text especially — look heavy and smudged."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭 macOS 字体平滑。字干被加粗后，Agent 输出——尤其是 Claude Code 的粗体——会显得又重又糊。"
+          }
+        }
+      }
+    },
+    "Mouse reporting" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mouse reporting"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "鼠标上报"
+          }
+        }
+      }
+    },
+    "Forwards clicks and drags to TUI apps that ask for them. Turn off to always select text with the mouse — Shift-drag selects either way." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forwards clicks and drags to TUI apps that ask for them. Turn off to always select text with the mouse — Shift-drag selects either way."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "将点击和拖动转发给需要鼠标的 TUI 应用。关闭后鼠标始终用于选中文本；按住 Shift 拖动则两种模式都能选中。"
+          }
+        }
+      }
+    },
+    "Reset to Defaults" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset to Defaults"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "恢复默认"
+          }
+        }
+      }
+    },
+    "Preview" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Preview"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "预览"
+          }
+        }
+      }
+    },
+    "Theme" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Theme"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "主题"
+          }
+        }
+      }
+    },
+    "The terminal follows the app theme." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The terminal follows the app theme."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端外观跟随应用主题。"
+          }
+        }
+      }
+    },
+    "Language" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Language"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "语言"
+          }
+        }
+      }
+    },
+    "Follow System" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Follow System"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "跟随系统"
+          }
+        }
+      }
+    },
+    "Changing language takes effect after you quit and reopen herdrm." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changing language takes effect after you quit and reopen herdrm."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改语言后，退出并重新打开 herdrm 才会生效。"
+          }
+        }
+      }
+    },
+    "Notify when an agent finishes or needs input" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notify when an agent finishes or needs input"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当 Agent 完成或需要输入时通知"
+          }
+        }
+      }
+    },
+    "Play a sound" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Play a sound"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "播放提示音"
+          }
+        }
+      }
+    },
+    "Finished agents only notify while you're not watching them — herdr reports panes you have open as idle, not done." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finished agents only notify while you're not watching them — herdr reports panes you have open as idle, not done."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "只有你没在看的 Agent 完成时才会通知——herdr 会把你打开的面板报成 idle，而不是 done。"
+          }
+        }
+      }
+    },
+    "Notifications are disabled in System Settings." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications are disabled in System Settings."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知已在系统设置中关闭。"
+          }
+        }
+      }
+    },
+    "Open System Settings…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open System Settings…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开系统设置…"
+          }
+        }
+      }
+    },
+    "Notification permission hasn't been granted yet." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notification permission hasn't been granted yet."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未授予通知权限。"
+          }
+        }
+      }
+    },
+    "Request Permission" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Request Permission"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请求权限"
+          }
+        }
+      }
+    },
+    "Notification permission granted." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notification permission granted."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已授予通知权限。"
+          }
+        }
+      }
+    },
+    "herdrm — a native macOS console for herdr." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "herdrm — a native macOS console for herdr."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "herdrm — 面向 herdr 的原生 macOS 控制台。"
+          }
+        }
+      }
+    },
+    "Devices are managed from the switcher in the sidebar footer." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Devices are managed from the switcher in the sidebar footer."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备可在侧边栏底部的切换器中管理。"
+          }
+        }
+      }
+    },
+    "Something went wrong" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Something went wrong"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "出了点问题"
+          }
+        }
+      }
+    },
+    "OK" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好"
+          }
+        }
+      }
+    },
+    "Cancel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "No agent selected" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No agent selected"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择 Agent"
+          }
+        }
+      }
+    },
+    "Working" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Working"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "运行中"
+          }
+        }
+      }
+    },
+    "Needs input" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Needs input"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "等待输入"
+          }
+        }
+      }
+    },
+    "Done" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Done"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已完成"
+          }
+        }
+      }
+    },
+    "Reconnect" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reconnect"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重新连接"
+          }
+        }
+      }
+    },
+    "Connection to %@ dropped" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connection to %@ dropped"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "与 %@ 的连接已断开"
+          }
+        }
+      }
+    },
+    "Terminal session ended" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal session ended"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端会话已结束"
+          }
+        }
+      }
+    },
+    "The SSH connection behind this terminal went away." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The SSH connection behind this terminal went away."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此终端背后的 SSH 连接已断开。"
+          }
+        }
+      }
+    },
+    "Another client took this pane over, or the attach closed." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Another client took this pane over, or the attach closed."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "其他客户端接管了此面板，或附加会话已关闭。"
+          }
+        }
+      }
+    },
+    "Uploading…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uploading…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在上传…"
+          }
+        }
+      }
+    },
+    "No agents in this space yet" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No agents in this space yet"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此空间还没有 Agent"
+          }
+        }
+      }
+    },
+    "Select an agent, or start a new one" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select an agent, or start a new one"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择一个 Agent，或新建一个"
+          }
+        }
+      }
+    },
+    "Add Device" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add Device"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "添加设备"
+          }
+        }
+      }
+    },
+    "Uses OpenSSH config, agent, Tailscale SSH, or password" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uses OpenSSH config, agent, Tailscale SSH, or password"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "支持 OpenSSH 配置、agent、Tailscale SSH 或密码"
+          }
+        }
+      }
+    },
+    "NAME" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NAME"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名称"
+          }
+        }
+      }
+    },
+    "SSH TARGET" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH TARGET"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 目标"
+          }
+        }
+      }
+    },
+    "user@host, a ~/.ssh/config alias, or user@host:port for a custom port." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "user@host, a ~/.ssh/config alias, or user@host:port for a custom port."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "可用 user@host、~/.ssh/config 别名，或 user@host:port 指定端口。"
+          }
+        }
+      }
+    },
+    "SSH Authentication" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH Authentication"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 认证"
+          }
+        }
+      }
+    },
+    "PASSWORD" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "PASSWORD"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "密码"
+          }
+        }
+      }
+    },
+    "SSH password" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH password"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 密码"
+          }
+        }
+      }
+    },
+    "Saved in your macOS login Keychain" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saved in your macOS login Keychain"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "已保存在 macOS 登录钥匙串"
+          }
+        }
+      }
+    },
+    "Connect" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connect"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "连接"
+          }
+        }
+      }
+    },
+    "A herdr workspace rooted at a project directory on %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A herdr workspace rooted at a project directory on %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 %@ 上以项目目录为根的 herdr 工作区"
+          }
+        }
+      }
+    },
+    "DEVICE" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEVICE"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "设备"
+          }
+        }
+      }
+    },
+    "DIRECTORY" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DIRECTORY"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "目录"
+          }
+        }
+      }
+    },
+    "Path on %@; ~ expands to its home directory" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Path on %@; ~ expands to its home directory"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "路径位于 %@；~ 会展开为该设备的主目录"
+          }
+        }
+      }
+    },
+    "Defaults to the folder name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Defaults to the folder name"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "默认为文件夹名称"
+          }
+        }
+      }
+    },
+    "Create Space" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create Space"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "创建空间"
+          }
+        }
+      }
+    },
+    "Up to the parent folder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Up to the parent folder"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "返回上级文件夹"
+          }
+        }
+      }
+    },
+    "Browse…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Browse…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "浏览…"
+          }
+        }
+      }
+    },
+    "No subfolders" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No subfolders"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有子文件夹"
+          }
+        }
+      }
+    },
+    "No folders match \"%@\"" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No folders match \"%@\""
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有匹配“%@”的文件夹"
+          }
+        }
+      }
+    },
+    "the focused space" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "the focused space"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "当前聚焦的空间"
+          }
+        }
+      }
+    },
+    "Starts in %@, attached to its live terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Starts in %@, attached to its live terminal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 %@ 中启动，并附加到其实时终端"
+          }
+        }
+      }
+    },
+    "AGENT" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AGENT"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Agent"
+          }
+        }
+      }
+    },
+    "Checking agents on %@…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checking agents on %@…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在检查 %@ 上的 Agent…"
+          }
+        }
+      }
+    },
+    "Couldn’t check installed agent CLIs." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn’t check installed agent CLIs."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法检查本机已安装的 Agent CLI。"
+          }
+        }
+      }
+    },
+    "Couldn’t load this server’s agent catalog." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Couldn’t load this server’s agent catalog."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无法加载此服务器的 Agent 目录。"
+          }
+        }
+      }
+    },
+    "Retry" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重试"
+          }
+        }
+      }
+    },
+    "No supported agent CLI was found on this Mac. Install one, or set a binary path in Settings → Agents." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No supported agent CLI was found on this Mac. Install one, or set a binary path in Settings → Agents."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "本机未找到受支持的 Agent CLI。请先安装，或在设置 → Agent 中指定二进制路径。"
+          }
+        }
+      }
+    },
+    "This server advertises no agent manifests." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This server advertises no agent manifests."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此服务器未声明任何 Agent manifest。"
+          }
+        }
+      }
+    },
+    "SPACE" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SPACE"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空间"
+          }
+        }
+      }
+    },
+    "Focused space" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Focused space"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "聚焦的空间"
+          }
+        }
+      }
+    },
+    "OPTIONS" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OPTIONS"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选项"
+          }
+        }
+      }
+    },
+    "Bypass permissions" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bypass permissions"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "绕过权限"
+          }
+        }
+      }
+    },
+    "Start Agent" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Start Agent"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启动 Agent"
+          }
+        }
+      }
+    },
+    "Rename Space" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename Space"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名空间"
+          }
+        }
+      }
+    },
+    "Rename Space…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename Space…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名空间…"
+          }
+        }
+      }
+    },
+    "Rename %@ on %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename %@ on %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名 %@（位于 %@）"
+          }
+        }
+      }
+    },
+    "Space name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Space name"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空间名称"
+          }
+        }
+      }
+    },
+    "Rename" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名"
+          }
+        }
+      }
+    },
+    "Edit Device" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Device"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "编辑设备"
+          }
+        }
+      }
+    },
+    "Changing the SSH target reconnects the device" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Changing the SSH target reconnects the device"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "更改 SSH 目标会重新连接该设备"
+          }
+        }
+      }
+    },
+    "Name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Name"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "名称"
+          }
+        }
+      }
+    },
+    "SSH target" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH target"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "SSH 目标"
+          }
+        }
+      }
+    },
+    "Save" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        }
+      }
+    },
+    "Close Space \"%@\"…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Space \"%@\"…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭空间“%@”…"
+          }
+        }
+      }
+    },
+    "Search agents and spaces…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search agents and spaces…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索 Agent 和空间…"
+          }
+        }
+      }
+    },
+    "No matches" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No matches"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "无匹配结果"
+          }
+        }
+      }
+    },
+    "navigate" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "navigate"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "导航"
+          }
+        }
+      }
+    },
+    "open" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "open"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开"
+          }
+        }
+      }
+    },
+    "cancel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cancel"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
+    },
+    "Space · %lld agents" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Space · %lld agents"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "空间 · %lld 个 Agent"
+          }
+        }
+      }
+    },
+    "%@ needs your input · %@ · %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ needs your input · %@ · %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 需要你的输入 · %@ · %@"
+          }
+        }
+      }
+    },
+    "%@ finished · %@ · %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ finished · %@ · %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 已完成 · %@ · %@"
+          }
+        }
+      }
+    },
+    "Terminal %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal %lld"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端 %lld"
+          }
+        }
+      }
+    },
+    "Authentication cancelled — choose Reconnect to try again" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Authentication cancelled — choose Reconnect to try again"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "认证已取消 — 请选择“重新连接”再试"
+          }
+        }
+      }
+    },
+    "Still connecting to %@ — try again in a moment." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Still connecting to %@ — try again in a moment."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仍在连接 %@ — 请稍后再试。"
+          }
+        }
+      }
+    },
+    "%@ is unreachable: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ is unreachable: %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 无法访问：%@"
+          }
+        }
+      }
+    },
+    "%@ isn't connected." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ isn't connected."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 尚未连接。"
+          }
+        }
+      }
+    },
+    "%@ just reconnected — try again." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ just reconnected — try again."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 刚刚重新连上 — 请再试一次。"
+          }
+        }
+      }
+    },
+    "Close space \"%@\" on %@?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close space \"%@\" on %@?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭空间“%@”（位于 %@）？"
+          }
+        }
+      }
+    },
+    "All terminals and agents in this space will be closed." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All terminals and agents in this space will be closed."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此空间中的所有终端和 Agent 都将被关闭。"
+          }
+        }
+      }
+    },
+    "Close \"%@\"?" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close \"%@\"?"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭“%@”？"
+          }
+        }
+      }
+    },
+    "The pane and whatever is running inside it will be terminated." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The pane and whatever is running inside it will be terminated."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "该面板及其内部正在运行的内容将被终止。"
+          }
+        }
+      }
+    },
+    "Copy" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拷贝"
+          }
+        }
+      }
+    },
+    "Open Link" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Link"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开链接"
+          }
+        }
+      }
+    },
+    "Copy Link Address" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Copy Link Address"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "拷贝链接地址"
+          }
+        }
+      }
+    },
+    "Paste" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Paste"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "粘贴"
+          }
+        }
+      }
+    },
+    "Select All" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select All"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "全选"
+          }
+        }
+      }
+    },
+    "Remote paste supports regular files, not folders or special files." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Remote paste supports regular files, not folders or special files."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "远程粘贴仅支持普通文件，不支持文件夹或特殊文件。"
+          }
+        }
+      }
+    },
+    "The clipboard image could not be encoded as PNG." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The clipboard image could not be encoded as PNG."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "剪贴板中的图片无法编码为 PNG。"
+          }
+        }
+      }
+    },
+    "The remote file transfer service is unavailable." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The remote file transfer service is unavailable."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "远程文件传输服务不可用。"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/Sources/HerdrM/AppLanguage.swift
+++ b/Sources/HerdrM/AppLanguage.swift
@@ -1,0 +1,59 @@
+import Foundation
+import HerdrKit
+
+/// In-app language override. `AppleLanguages` is read at process start, so a
+/// change here only takes effect after the user quits and reopens herdrm.
+enum AppLanguage: String, CaseIterable, Identifiable {
+    case system
+    case english = "en"
+    case simplifiedChinese = "zh-Hans"
+
+    static let defaultsKey = "app.language"
+
+    var id: String { rawValue }
+
+    /// Native names for concrete languages; "Follow System" is the only
+    /// option that is translated. English and Simplified Chinese keep their
+    /// endonym from the catalog in every locale.
+    var displayName: String {
+        switch self {
+        case .system:
+            return String(localized: "Follow System")
+        case .english:
+            return String(localized: "language.name.en", defaultValue: "English")
+        case .simplifiedChinese:
+            return String(localized: "language.name.zh-Hans", defaultValue: "Chinese")
+        }
+    }
+
+    static func current(defaults: UserDefaults = .standard) -> AppLanguage {
+        AppLanguage(rawValue: defaults.string(forKey: defaultsKey) ?? "") ?? .system
+    }
+
+    static func apply(_ language: AppLanguage, defaults: UserDefaults = .standard) {
+        defaults.set(language.rawValue, forKey: defaultsKey)
+        switch language {
+        case .system:
+            defaults.removeObject(forKey: "AppleLanguages")
+        case .english:
+            defaults.set(["en"], forKey: "AppleLanguages")
+        case .simplifiedChinese:
+            defaults.set(["zh-Hans"], forKey: "AppleLanguages")
+        }
+    }
+
+    static func synchronize(defaults: UserDefaults = .standard) {
+        apply(current(defaults: defaults), defaults: defaults)
+    }
+}
+
+extension Device {
+    var localizedSubtitle: String {
+        switch kind {
+        case .local:
+            return String(localized: "This Mac · herdr.sock")
+        case .ssh(let target):
+            return String(localized: "\(target) · SSH")
+        }
+    }
+}

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -348,7 +348,8 @@ final class AppModel: ObservableObject {
 
     /// Every click opens another terminal, like New Agent opens another agent.
     func newShellSession() {
-        let session = ShellSession(id: UUID(), title: "Terminal \(shellSessions.count + 1)")
+        let n = shellSessions.count + 1
+        let session = ShellSession(id: UUID(), title: String(localized: "Terminal \(n)"))
         shellSessions.append(session)
         selectShell(session.id)
     }
@@ -519,7 +520,7 @@ final class AppModel: ObservableObject {
     func cancelSSHAuthentication(for request: SSHAuthenticationRequest) {
         sshAuthenticationRequest = nil
         sessions[request.deviceID]?.connection =
-            .failed("Authentication cancelled — choose Reconnect to try again")
+            .failed(String(localized: "Authentication cancelled — choose Reconnect to try again"))
     }
 
     var hasReconnectableDevice: Bool {
@@ -678,13 +679,13 @@ final class AppModel: ObservableObject {
         else { return error.localizedDescription }
         switch session(device.id).connection {
         case .connecting:
-            return "Still connecting to \(device.name) — try again in a moment."
+            return String(localized: "Still connecting to \(device.name) — try again in a moment.")
         case .failed(let reason):
-            return "\(device.name) is unreachable: \(reason)"
+            return String(localized: "\(device.name) is unreachable: \(reason)")
         case .idle:
-            return "\(device.name) isn't connected."
+            return String(localized: "\(device.name) isn't connected.")
         case .connected:
-            return "\(device.name) just reconnected — try again."
+            return String(localized: "\(device.name) just reconnected — try again.")
         }
     }
 
@@ -692,8 +693,8 @@ final class AppModel: ObservableObject {
 
     func requestCloseSpace(_ entry: SpaceEntry) {
         closeRequest = CloseRequest(
-            title: "Close space \"\(entry.workspace.label)\" on \(entry.device.name)?",
-            message: "All terminals and agents in this space will be closed."
+            title: String(localized: "Close space \"\(entry.workspace.label)\" on \(entry.device.name)?"),
+            message: String(localized: "All terminals and agents in this space will be closed.")
         ) { [weak self] in
             guard let self else { return }
             Task {
@@ -712,8 +713,8 @@ final class AppModel: ObservableObject {
     func requestClosePane(_ ref: PaneRef, name: String) {
         guard let device = device(ref.deviceID) else { return }
         closeRequest = CloseRequest(
-            title: "Close \"\(name)\"?",
-            message: "The pane and whatever is running inside it will be terminated."
+            title: String(localized: "Close \"\(name)\"?"),
+            message: String(localized: "The pane and whatever is running inside it will be terminated.")
         ) { [weak self] in
             guard let self else { return }
             Task {

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -203,9 +203,9 @@ struct DetailView: View {
     private func statusPill(_ status: AgentStatus) -> some View {
         let label: String? = {
             switch status {
-            case .working: return "Working"
-            case .blocked: return "Needs input"
-            case .done: return "Done"
+            case .working: return String(localized: "Working")
+            case .blocked: return String(localized: "Needs input")
+            case .done: return String(localized: "Done")
             case .idle, .unknown: return nil
             }
         }()
@@ -406,12 +406,12 @@ struct DetailView: View {
             Image(systemName: dropped ? "bolt.horizontal.circle" : "rectangle.slash")
                 .font(.system(size: 28, weight: .light))
                 .foregroundStyle(Theme.textGhost)
-            Text(dropped ? "Connection to \(entry.device.name) dropped" : "Terminal session ended")
+            Text(dropped ? String(localized: "Connection to \(entry.device.name) dropped") : String(localized: "Terminal session ended"))
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(Theme.text)
             Text(dropped
-                ? "The SSH connection behind this terminal went away."
-                : "Another client took this pane over, or the attach closed.")
+                ? String(localized: "The SSH connection behind this terminal went away.")
+                : String(localized: "Another client took this pane over, or the attach closed."))
                 .font(.system(size: 11.5))
                 .foregroundStyle(Theme.textTertiary)
             Button("Reconnect") {
@@ -446,13 +446,13 @@ struct DetailView: View {
 
     private var placeholderText: String {
         switch model.connection {
-        case .connecting: return "Connecting…"
+        case .connecting: return String(localized: "Connecting…")
         case .failed(let reason): return reason
         default:
             if model.selectedSpace != nil && model.visibleAgents.isEmpty {
-                return "No agents in this space yet"
+                return String(localized: "No agents in this space yet")
             }
-            return "Select an agent, or start a new one"
+            return String(localized: "Select an agent, or start a new one")
         }
     }
 
@@ -468,8 +468,8 @@ struct AddDeviceSheet: View {
         VStack(alignment: .leading, spacing: 0) {
             SheetHeader(
                 systemImage: "desktopcomputer",
-                title: "Add Device",
-                subtitle: "Uses OpenSSH config, agent, Tailscale SSH, or password"
+                title: String(localized: "Add Device"),
+                subtitle: String(localized: "Uses OpenSSH config, agent, Tailscale SSH, or password")
             )
             Rectangle().fill(Theme.hairline).frame(height: 1)
 
@@ -524,7 +524,7 @@ struct SSHAuthenticationSheet: View {
         VStack(alignment: .leading, spacing: 0) {
             SheetHeader(
                 systemImage: "key.fill",
-                title: "SSH Authentication",
+                title: String(localized: "SSH Authentication"),
                 subtitle: request.target
             )
             Rectangle().fill(Theme.hairline).frame(height: 1)
@@ -534,7 +534,7 @@ struct SSHAuthenticationSheet: View {
                 SecureField("SSH password", text: $password)
                     .textFieldStyle(.roundedBorder)
                     .focused($passwordFocused)
-                Label(SSHCredentialStore.persistenceDescription, systemImage: "lock.fill")
+                Label(String(localized: "Saved in your macOS login Keychain"), systemImage: "lock.fill")
                     .font(.system(size: 11))
                     .foregroundStyle(Theme.textTertiary)
             }
@@ -592,9 +592,9 @@ struct SheetHeader: View {
 }
 
 struct SheetSectionLabel: View {
-    let text: String
+    let text: LocalizedStringKey
 
-    init(_ text: String) { self.text = text }
+    init(_ text: LocalizedStringKey) { self.text = text }
 
     var body: some View {
         Text(text)
@@ -620,8 +620,8 @@ struct NewSpaceSheet: View {
         VStack(alignment: .leading, spacing: 0) {
             SheetHeader(
                 systemImage: "folder.badge.plus",
-                title: "New Space",
-                subtitle: "A herdr workspace rooted at a project directory on \(chosenDevice.name)"
+                title: String(localized: "New Space"),
+                subtitle: String(localized: "A herdr workspace rooted at a project directory on \(chosenDevice.name)")
             )
             Rectangle().fill(Theme.hairline).frame(height: 1)
 
@@ -642,7 +642,7 @@ struct NewSpaceSheet: View {
                 SheetSectionLabel("DIRECTORY")
                 DirectoryPickerField(model: model, device: chosenDevice, path: $directory)
                 if !chosenDevice.isLocal {
-                    Text("Path on \(chosenDevice.name); ~ expands to its home directory")
+                    Text(String(localized: "Path on \(chosenDevice.name); ~ expands to its home directory"))
                         .font(.system(size: 10.5))
                         .foregroundStyle(Theme.textTertiary)
                 }
@@ -780,7 +780,7 @@ struct DirectoryPickerField: View {
                     }
                 }
                 if visibleEntries.isEmpty && !isListing {
-                    Text(entries.isEmpty ? "No subfolders" : "No folders match \"\(filter)\"")
+                    Text(entries.isEmpty ? String(localized: "No subfolders") : String(localized: "No folders match \"\(filter)\""))
                         .font(.system(size: 11.5))
                         .foregroundStyle(Theme.textGhost)
                         .padding(8)
@@ -894,7 +894,7 @@ struct NewAgentSheet: View {
     }
 
     private var spaceLabel: String {
-        if workspaceID.isEmpty { return "the focused space" }
+        if workspaceID.isEmpty { return String(localized: "the focused space") }
         return session.workspaces.first { $0.workspaceID == workspaceID }?.label ?? workspaceID
     }
 
@@ -902,8 +902,8 @@ struct NewAgentSheet: View {
         VStack(alignment: .leading, spacing: 0) {
             SheetHeader(
                 systemImage: "sparkles",
-                title: "New Agent",
-                subtitle: "Starts in \(spaceLabel), attached to its live terminal"
+                title: String(localized: "New Agent"),
+                subtitle: String(localized: "Starts in \(spaceLabel), attached to its live terminal")
             )
             Rectangle().fill(Theme.hairline).frame(height: 1)
 
@@ -931,15 +931,15 @@ struct NewAgentSheet: View {
                     case .loading:
                         HStack(spacing: 8) {
                             ProgressView().controlSize(.small)
-                            Text("Checking agents on \(chosenDevice.name)…")
+                            Text(String(localized: "Checking agents on \(chosenDevice.name)…"))
                                 .foregroundStyle(Theme.textSecondary)
                         }
                         .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
                     case .failed(let message):
                         VStack(alignment: .leading, spacing: 8) {
                             Text(chosenDevice.isLocal
-                                ? "Couldn’t check installed agent CLIs."
-                                : "Couldn’t load this server’s agent catalog.")
+                                ? String(localized: "Couldn’t check installed agent CLIs.")
+                                : String(localized: "Couldn’t load this server’s agent catalog."))
                                 .foregroundStyle(Theme.textSecondary)
                             Text(message)
                                 .font(.system(size: 10.5))
@@ -951,8 +951,8 @@ struct NewAgentSheet: View {
                         .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
                     case .loaded(let loadedKinds, _) where loadedKinds.isEmpty:
                         Text(chosenDevice.isLocal
-                            ? "No supported agent CLI was found on this Mac. Install one, or set a binary path in Settings → Agents."
-                            : "This server advertises no agent manifests.")
+                            ? String(localized: "No supported agent CLI was found on this Mac. Install one, or set a binary path in Settings → Agents.")
+                            : String(localized: "This server advertises no agent manifests."))
                             .foregroundStyle(Theme.textSecondary)
                             .frame(maxWidth: .infinity, minHeight: 58, alignment: .leading)
                     case .loaded(let loadedKinds, let paths):
@@ -1094,8 +1094,8 @@ struct RenameSpaceSheet: View {
         VStack(alignment: .leading, spacing: 0) {
             SheetHeader(
                 systemImage: "pencil",
-                title: "Rename Space",
-                subtitle: "Rename \(entry.workspace.label) on \(entry.device.name)"
+                title: String(localized: "Rename Space"),
+                subtitle: String(localized: "Rename \(entry.workspace.label) on \(entry.device.name)")
             )
             Rectangle().fill(Theme.hairline).frame(height: 1)
 
@@ -1140,8 +1140,8 @@ struct EditDeviceSheet: View {
         VStack(alignment: .leading, spacing: 0) {
             SheetHeader(
                 systemImage: "pencil",
-                title: "Edit Device",
-                subtitle: "Changing the SSH target reconnects the device"
+                title: String(localized: "Edit Device"),
+                subtitle: String(localized: "Changing the SSH target reconnects the device")
             )
             Rectangle().fill(Theme.hairline).frame(height: 1)
 

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -65,6 +65,7 @@ struct HerdrMApp: App {
         if ProcessInfo.processInfo.environment[SSHCredentialStore.askPassModeEnvironmentKey] == "1" {
             Self.runSSHAskPass()
         }
+        AppLanguage.synchronize()
         SSHCredentialStore.purgeAuthorizations()
         TerminalDefaults.registerBundledFonts()
         updaterController = SPUStandardUpdaterController(
@@ -192,9 +193,9 @@ struct HerdrMApp: App {
     }
 
     private var closeButtonTitle: String {
-        if focusedModel?.shellSplitAxis != nil { return "Close Split" }
-        if focusedModel?.selectedShell != nil { return "Close Terminal" }
-        return "Close"
+        if focusedModel?.shellSplitAxis != nil { return String(localized: "Close Split") }
+        if focusedModel?.selectedShell != nil { return String(localized: "Close Terminal") }
+        return String(localized: "Close")
     }
 
     static func applyTheme(_ preference: String) {
@@ -278,7 +279,7 @@ struct AgentsSettingsView: View {
                 ForEach(Self.kinds, id: \.kind) { row in
                     TextField(row.label, text: binding(row.kind), prompt: Text("Automatic"))
                         .font(.system(size: 12).monospaced())
-                        .help("Command or path for \(row.hint). Leave empty to detect.")
+                        .help(String(localized: "Command or path for \(row.hint). Leave empty to detect."))
                 }
             } footer: {
                 Text("Finder-launched apps don’t inherit your terminal PATH. herdrm captures it once from a login + interactive shell, then looks up these names. A path here is an escape hatch when detection picks the wrong binary.")
@@ -340,9 +341,12 @@ struct TerminalSettingsView: View {
                 }
 
                 Picker("Weight", selection: $fontWeight) {
-                    Text("Light").tag(Double(NSFont.Weight.light.rawValue))
-                    Text("Regular").tag(TerminalDefaults.defaultFontWeight)
-                    Text("Medium").tag(Double(NSFont.Weight.medium.rawValue))
+                    Text(String(localized: "font.weight.light", defaultValue: "Light"))
+                        .tag(Double(NSFont.Weight.light.rawValue))
+                    Text(String(localized: "font.weight.regular", defaultValue: "Regular"))
+                        .tag(TerminalDefaults.defaultFontWeight)
+                    Text(String(localized: "font.weight.medium", defaultValue: "Medium"))
+                        .tag(Double(NSFont.Weight.medium.rawValue))
                 }
                 .pickerStyle(.segmented)
                 .disabled(!fontName.isEmpty)
@@ -408,16 +412,30 @@ struct TerminalSettingsView: View {
 
 struct AppearanceSettingsView: View {
     @AppStorage("app.theme") private var themePreference = "system"
+    @AppStorage(AppLanguage.defaultsKey) private var language = AppLanguage.system.rawValue
 
     var body: some View {
         Form {
             Picker("Theme", selection: $themePreference) {
-                Text("System").tag("system")
-                Text("Light").tag("light")
-                Text("Dark").tag("dark")
+                Text(String(localized: "theme.system", defaultValue: "System")).tag("system")
+                Text(String(localized: "theme.light", defaultValue: "Light")).tag("light")
+                Text(String(localized: "theme.dark", defaultValue: "Dark")).tag("dark")
             }
             .pickerStyle(.segmented)
             Text("The terminal follows the app theme.")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+            Picker("Language", selection: $language) {
+                ForEach(AppLanguage.allCases) { option in
+                    Text(verbatim: option.displayName).tag(option.rawValue)
+                }
+            }
+            .onChange(of: language) { _, newValue in
+                AppLanguage.apply(AppLanguage(rawValue: newValue) ?? .system)
+            }
+            // Changing AppleLanguages only takes effect on the next process start.
+            Text("Changing language takes effect after you quit and reopen herdrm.")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
         }

--- a/Sources/HerdrM/NotificationManager.swift
+++ b/Sources/HerdrM/NotificationManager.swift
@@ -39,9 +39,9 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
         content.title = agent.title
         switch status {
         case .blocked:
-            content.body = "\(agent.agent) needs your input · \(spaceName) · \(deviceName)"
+            content.body = String(localized: "\(agent.agent) needs your input · \(spaceName) · \(deviceName)")
         case .done:
-            content.body = "\(agent.agent) finished · \(spaceName) · \(deviceName)"
+            content.body = String(localized: "\(agent.agent) finished · \(spaceName) · \(deviceName)")
         default:
             return
         }

--- a/Sources/HerdrM/SearchView.swift
+++ b/Sources/HerdrM/SearchView.swift
@@ -129,7 +129,7 @@ struct SearchSheet: View {
         .onChange(of: query) { _, _ in highlighted = 0 }
     }
 
-    private func hint(_ key: String, _ label: String) -> some View {
+    private func hint(_ key: String, _ label: LocalizedStringKey) -> some View {
         HStack(spacing: 4) {
             Text(key)
                 .font(.system(size: 10, weight: .medium))
@@ -183,7 +183,7 @@ struct SearchSheet: View {
                     .foregroundStyle(Theme.text)
                     .lineLimit(1)
                 Spacer(minLength: 8)
-                trailing("Space · \(model.agentCount(in: entry)) agents", device: entry.device)
+                trailing(String(localized: "Space · \(model.agentCount(in: entry)) agents"), device: entry.device)
             }
         }
         .padding(.horizontal, 10)

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -134,15 +134,15 @@ struct SidebarView: View {
 
     private var emptyAgentsHint: String {
         switch model.connection {
-        case .connecting: return "Connecting…"
+        case .connecting: return String(localized: "Connecting…")
         case .failed(let reason): return reason
-        default: return "No agents"
+        default: return String(localized: "No agents")
         }
     }
 
     // MARK: - Rows
 
-    private func actionRow(icon: String, label: String, action: @escaping () -> Void) -> some View {
+    private func actionRow(icon: String, label: LocalizedStringKey, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             HStack(spacing: 10) {
                 Image(systemName: icon)
@@ -161,7 +161,7 @@ struct SidebarView: View {
         .buttonStyle(SidebarRowButtonStyle())
     }
 
-    private func groupHeader(_ title: String) -> some View {
+    private func groupHeader(_ title: LocalizedStringKey) -> some View {
         HStack(spacing: 5) {
             Text(title)
                 .font(.system(size: 12.5, weight: .medium))
@@ -354,7 +354,7 @@ struct SidebarView: View {
 /// Small icon button that sits in the 28pt titlebar strip.
 struct TitlebarIconButton: View {
     let systemName: String
-    let help: String
+    let help: LocalizedStringKey
     let action: () -> Void
     @State private var hovered = false
 
@@ -405,7 +405,7 @@ struct DevicePopover: View {
                         Text("All Devices")
                             .font(.system(size: 13))
                             .foregroundStyle(Theme.text)
-                        Text("\(model.devices.count) devices · \(connectedCount) connected")
+                        Text(String(localized: "\(model.devices.count) devices · \(connectedCount) connected"))
                             .font(.system(size: 11))
                             .foregroundStyle(Theme.textTertiary)
                     }
@@ -433,11 +433,11 @@ struct DevicePopover: View {
                 }
                 .contextMenu {
                     if !device.isLocal {
-                        Button("Edit \(device.name)…") {
+                        Button(String(localized: "Edit \(device.name)…")) {
                             isPresented = false
                             model.deviceToEdit = device
                         }
-                        Button("Remove \(device.name)", role: .destructive) {
+                        Button(String(localized: "Remove \(device.name)"), role: .destructive) {
                             isPresented = false
                             model.removeDevice(device)
                         }
@@ -473,7 +473,7 @@ struct DevicePopover: View {
         }.count
     }
 
-    private func actionRow(icon: String, label: String, action: @escaping () -> Void) -> some View {
+    private func actionRow(icon: String, label: LocalizedStringKey, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             HStack(spacing: 9) {
                 Image(systemName: icon)
@@ -524,7 +524,7 @@ struct DevicePopoverRow: View {
                             .fill(dotColor)
                             .frame(width: 6, height: 6)
                     }
-                    Text(device.subtitle)
+                    Text(device.localizedSubtitle)
                         .font(.system(size: 11))
                         .foregroundStyle(Theme.textTertiary)
                         .lineLimit(1)

--- a/Sources/HerdrM/SpaceRowDrag.swift
+++ b/Sources/HerdrM/SpaceRowDrag.swift
@@ -92,14 +92,14 @@ final class SpaceRowDragNSView: NSView, NSDraggingSource {
     override func menu(for event: NSEvent) -> NSMenu? {
         let menu = NSMenu()
         let rename = menu.addItem(
-            withTitle: "Rename Space…",
+            withTitle: String(localized: "Rename Space…"),
             action: #selector(renameSpace),
             keyEquivalent: ""
         )
         rename.target = self
         menu.addItem(.separator())
         let close = menu.addItem(
-            withTitle: "Close Space \"\(label)\"…",
+            withTitle: String(localized: "Close Space \"\(label)\"…"),
             action: #selector(closeSpace),
             keyEquivalent: ""
         )

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -123,9 +123,9 @@ private enum ClipboardFileError: LocalizedError {
 
     var errorDescription: String? {
         switch self {
-        case .unsupportedItem: return "Remote paste supports regular files, not folders or special files."
-        case .imageEncodingFailed: return "The clipboard image could not be encoded as PNG."
-        case .transferUnavailable: return "The remote file transfer service is unavailable."
+        case .unsupportedItem: return String(localized: "Remote paste supports regular files, not folders or special files.")
+        case .imageEncodingFailed: return String(localized: "The clipboard image could not be encoded as PNG.")
+        case .transferUnavailable: return String(localized: "The remote file transfer service is unavailable.")
         }
     }
 }
@@ -213,20 +213,20 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
     override func menu(for event: NSEvent) -> NSMenu? {
         let menu = NSMenu()
         if selection.active {
-            menu.addItem(makeItem("Copy", #selector(NSText.copy(_:))))
+            menu.addItem(makeItem(String(localized: "Copy"), #selector(NSText.copy(_:))))
             if let url = Self.firstURL(in: selection.getSelectedText()) {
                 menu.addItem(.separator())
-                let open = makeItem("Open Link", #selector(openLinkFromMenu(_:)))
+                let open = makeItem(String(localized: "Open Link"), #selector(openLinkFromMenu(_:)))
                 open.representedObject = url
                 menu.addItem(open)
-                let copyLink = makeItem("Copy Link Address", #selector(copyLinkFromMenu(_:)))
+                let copyLink = makeItem(String(localized: "Copy Link Address"), #selector(copyLinkFromMenu(_:)))
                 copyLink.representedObject = url
                 menu.addItem(copyLink)
             }
             menu.addItem(.separator())
         }
-        menu.addItem(makeItem("Paste", #selector(NSText.paste(_:))))
-        menu.addItem(makeItem("Select All", #selector(NSText.selectAll(_:))))
+        menu.addItem(makeItem(String(localized: "Paste"), #selector(NSText.paste(_:))))
+        menu.addItem(makeItem(String(localized: "Select All"), #selector(NSText.selectAll(_:))))
         return menu
     }
 

--- a/project.yml
+++ b/project.yml
@@ -4,6 +4,10 @@ options:
   deploymentTarget:
     macOS: "14.0"
   xcodeVersion: "16.0"
+  developmentRegion: en
+  knownRegions:
+    - en
+    - zh-Hans
 packages:
   HerdrKit:
     path: Packages/HerdrKit
@@ -21,6 +25,9 @@ targets:
       - Sources/HerdrM
       - path: Resources
         buildPhase: resources
+        excludes:
+          - Localizable.xcstrings
+      - path: Resources/Localizable.xcstrings
     dependencies:
       - package: HerdrKit
       - package: SwiftTerm
@@ -37,6 +44,10 @@ targets:
         LSMinimumSystemVersion: "$(MACOSX_DEPLOYMENT_TARGET)"
         NSPrincipalClass: NSApplication
         NSHumanReadableCopyright: "© 2026 MOE AI LLC"
+        CFBundleDevelopmentRegion: en
+        CFBundleLocalizations:
+          - en
+          - zh-Hans
         SUFeedURL: https://github.com/missuo/herdrm/releases/latest/download/appcast.xml
         SUPublicEDKey: RHEhllstUuuVrVDCPGrbhg/8LivSzpuZB9X3u3xdV5o=
         SUEnableAutomaticChecks: true
@@ -54,6 +65,7 @@ targets:
         COMBINE_HIDPI_IMAGES: YES
         CODE_SIGN_STYLE: Manual
         DEVELOPMENT_TEAM: NCFNX3LJ83
+        LOCALIZATION_PREFERS_STRING_CATALOGS: YES
       configs:
         Debug:
           # real identity so UserNotifications & friends work in dev builds


### PR DESCRIPTION
## Summary

Adds Simplified Chinese product localization for herdrm using an Apple String Catalog (`en` + `zh-Hans`). Settings → Appearance now offers Follow System / English / Simplified Chinese (native names, no flags). Follow System is the default; changing the override requires quitting and reopening the app.

Fixes #46

## Why

The product UI was hardcoded English. A catalog plus `String(localized:)` / SwiftUI `Text` keeps English as the source language, ships both locales in one file, and avoids a JS i18n library in this native SwiftUI + AppKit app.

## Change graph

```mermaid
flowchart LR
  Pref["Settings language picker"] --> Store["app.language + AppleLanguages"]
  Store --> Restart["Quit and reopen"]
  Restart --> Bundle["Bundle preferredLocalizations"]
  Catalog["Localizable.xcstrings"] --> Bundle
  Bundle --> UI["Menus, sidebar, sheets, alerts, notifications"]
```

## Validation

- `make kit-test`: 82 tests, 5 skipped (`HERDRM_E2E_SSH_TARGET` unset), 0 failures
- `make build`: failed with missing Developer ID certificate `NCFNX3LJ83` on this machine; the same `make build` failure reproduces on a clean `main` checkout, so it is an environment/upstream signing baseline, not caused by this change
- Ad-hoc `xcodebuild` (same scheme, `CODE_SIGN_IDENTITY=-`) succeeded; the app bundle contains `en.lproj/Localizable.strings` and `zh-Hans.lproj/Localizable.strings`, and `CFBundleLocalizations` is `en`, `zh-Hans`

## Notes

- RPC/protocol fields, agent binary names, and the Nerd Font preview sample are left untranslated
- HerdrKit `HerdrError` copy stays English (tests assert those strings); wrapped action errors and UI chrome are localized
- In-app language switching writes `AppleLanguages` and shows a restart hint; Bundle lookups do not change in the current process


## Screenshot

<img width="1092" height="764" alt="Screenshot 2026-08-25 at 04 24 04 PM" src="https://github.com/user-attachments/assets/29a9b0bc-8cd3-435c-8b9e-130e9f60b72a" />


<img width="532" height="330" alt="Screenshot 2026-08-25 at 04 23 04 PM" src="https://github.com/user-attachments/assets/98579ae4-676b-4471-8899-2b9f099d7726" />

<img width="532" height="549" alt="Screenshot 2026-08-25 at 04 23 08 PM" src="https://github.com/user-attachments/assets/21fb53ea-b205-44b5-b19f-1ce1cab87c96" />

