### PR TITLE
feat(terminal): support standalone SSH sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Added
+- Standalone terminals can now open a local login shell or connect to any
+  configured device over SSH.
+
 ## [0.5.1] - 2026-08-27
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -530,6 +530,33 @@ public actor HerdrService {
 
     // MARK: - Terminal attach
 
+    /// The command for a standalone interactive shell on this device.
+    public nonisolated func terminalCommand() -> TerminalCommand {
+        switch device.kind {
+        case .local:
+            return TerminalCommand(
+                executable: "/bin/sh",
+                args: ["-c", "cd \"$HOME\"; exec \"${SHELL:-/bin/zsh}\" -l"],
+                environment: [:],
+                authorizationID: nil
+            )
+        case .ssh(let target):
+            let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
+            return TerminalCommand(
+                executable: "/usr/bin/ssh",
+                args: ["-tt"] + authentication.arguments + [
+                    "-o", "StrictHostKeyChecking=accept-new",
+                    "-o", "ConnectTimeout=10",
+                    "-o", "ServerAliveInterval=15",
+                    "-o", "ServerAliveCountMax=3",
+                    SSHTunnel.sshDestination(target),
+                ],
+                environment: authentication.environment,
+                authorizationID: authentication.authorizationID
+            )
+        }
+    }
+
     /// Shell fragment that picks the herdr binary to attach with. herdr's attach
     /// stream requires the CLI and server protocol versions to match exactly, so
     /// when several herdr binaries share the PATH (a stale copy in ~/.local/bin
@@ -552,7 +579,7 @@ public actor HerdrService {
     /// `serverVersion` (from the device's last successful ping) lets the attach
     /// pick a herdr binary whose protocol matches the server's — see
     /// `attachBinarySelection`.
-    public nonisolated func attachCommand(paneID: String, serverVersion: String? = nil) -> AttachCommand {
+    public nonisolated func attachCommand(paneID: String, serverVersion: String? = nil) -> TerminalCommand {
         switch device.kind {
         case .local:
             // Same PATH we used to discover `herdr`: login-shell snapshot, GUI
@@ -565,7 +592,7 @@ public actor HerdrService {
             environment.removeValue(forKey: "LINES")
             let script = "\(Self.attachBinarySelection(serverVersion: serverVersion)); "
                 + "exec \"$hb\" agent attach '\(paneID)' --takeover"
-            return AttachCommand(
+            return TerminalCommand(
                 executable: "/bin/sh",
                 args: ["-c", script],
                 environment: environment,
@@ -580,7 +607,7 @@ public actor HerdrService {
                 + "exec \"$hb\" agent attach '\(paneID)' --takeover"
             let remote = "exec /bin/sh -c \(Self.shellQuoted(script))"
             let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
-            return AttachCommand(
+            return TerminalCommand(
                 executable: "/usr/bin/ssh",
                 args: ["-tt"] + authentication.arguments + [
                     "-o", "StrictHostKeyChecking=accept-new",
@@ -599,10 +626,12 @@ public actor HerdrService {
     }
 }
 
-public struct AttachCommand: Sendable {
+public struct TerminalCommand: Sendable {
     public let executable: String
     public let args: [String]
     public let environment: [String: String]
     /// Single-use askpass grant; the caller must discard it once the process exits.
     public let authorizationID: UUID?
 }
+
+public typealias AttachCommand = TerminalCommand

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
@@ -106,6 +106,30 @@ final class SSHDestinationTests: XCTestCase {
 }
 
 final class AttachBinarySelectionTests: XCTestCase {
+    func testStandaloneTerminalCommandsMatchDeviceTransport() {
+        let local = HerdrService(
+            device: Device(name: "L", kind: .local),
+            autoStartLocalServer: false
+        ).terminalCommand()
+        XCTAssertEqual(local.executable, "/bin/sh")
+        XCTAssertTrue(local.args.last?.contains("exec \"${SHELL:-/bin/zsh}\" -l") == true)
+        XCTAssertNil(local.authorizationID)
+
+        let remote = HerdrService(
+            device: Device(
+                id: UUID(),
+                name: "R",
+                kind: .ssh(target: "user@example.test:2222")
+            ),
+            autoStartLocalServer: false
+        ).terminalCommand()
+        XCTAssertEqual(remote.executable, "/usr/bin/ssh")
+        XCTAssertTrue(remote.args.contains("-tt"))
+        XCTAssertTrue(remote.args.contains("StrictHostKeyChecking=accept-new"))
+        XCTAssertTrue(remote.args.contains("ServerAliveInterval=15"))
+        XCTAssertEqual(remote.args.last, "ssh://user@example.test:2222")
+    }
+
     func testKnownServerVersionProbesForAnExactMatch() {
         let fragment = HerdrService.attachBinarySelection(serverVersion: "0.8.2")
         XCTAssertTrue(fragment.contains("for d in $PATH"))

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ macOS window on top of it, and it's grown well past "attach to a terminal":
 ### A real terminal, not a chat wrapper
 - **Live terminal** — attaches directly to the agent's PTY (`herdr agent attach`); grabs
   keyboard focus the moment you jump in from ⌘K, the sidebar, or a notification.
+- **Standalone terminals** — open a local login shell or choose any configured SSH device;
+  remote shells reuse the same OpenSSH config, agent, host-key, and Keychain password flow.
 - **Native text selection** — drag to select, no Shift needed; right-click for Copy/Paste/Select
   All plus link actions (⌘-click opens a URL).
 - **Legibility controls** — Thin strokes, font Weight, and Line spacing settings.

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -63,11 +63,12 @@ enum SplitAxis { case vertical, horizontal }
 /// keyboard-driven resize; standalone `ShellSession`s are not part of this.
 enum SplitSide { case agent, shell }
 
-/// A standalone local shell shown as its own sidebar entry — not a herdr pane
+/// A standalone local or SSH shell shown as its own sidebar entry — not a herdr pane
 /// (herdr refuses to attach agent-less panes) and not the ⌘D split.
 struct ShellSession: Identifiable, Equatable {
     let id: UUID
     var title: String
+    let device: Device
 }
 
 /// Per-kind CLI path overrides persisted in user defaults. Empty means automatic
@@ -117,6 +118,7 @@ final class AppModel: ObservableObject {
 
     @Published var showAddDevice = false
     @Published var showNewAgent = false
+    @Published var showNewTerminal = false
     @Published var showNewSpace = false
     @Published var showSearch = false
     @Published var shellSplitAxis: SplitAxis?
@@ -136,7 +138,7 @@ final class AppModel: ObservableObject {
     /// Held weakly so the views are not kept alive by the model.
     weak var splitAgentView: LocalProcessTerminalView?
     weak var splitShellView: LocalProcessTerminalView?
-    /// Standalone local terminals. Their views stay alive while deselected —
+    /// Standalone terminals. Their views stay alive while deselected —
     /// unlike agents, a local shell has no server side to reattach to.
     @Published var shellSessions: [ShellSession] = []
     @Published var selectedShellID: UUID?
@@ -348,9 +350,13 @@ final class AppModel: ObservableObject {
     }
 
     /// Every click opens another terminal, like New Agent opens another agent.
-    func newShellSession() {
+    func newShellSession(on device: Device) {
         let n = shellSessions.count + 1
-        let session = ShellSession(id: UUID(), title: String(localized: "Terminal \(n)"))
+        let session = ShellSession(
+            id: UUID(),
+            title: String(localized: "Terminal \(n)"),
+            device: device
+        )
         shellSessions.append(session)
         selectShell(session.id)
     }

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -56,6 +56,7 @@ struct RootView: View {
         .onAppear { model.start() }
         .sheet(isPresented: $model.showAddDevice) { AddDeviceSheet(model: model) }
         .sheet(isPresented: $model.showNewAgent) { NewAgentSheet(model: model) }
+        .sheet(isPresented: $model.showNewTerminal) { NewTerminalSheet(model: model) }
         .sheet(isPresented: $model.showNewSpace) { NewSpaceSheet(model: model) }
         .sheet(item: $model.spaceToRename) { entry in RenameSpaceSheet(model: model, entry: entry) }
         .sheet(item: $model.agentToRename) { entry in RenameAgentSheet(model: model, entry: entry) }
@@ -144,7 +145,7 @@ struct DetailView: View {
                 Text(shell.title)
                     .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(Theme.text)
-                Text("Local")
+                Text(shell.device.name)
                     .font(.system(size: 11.5))
                     .foregroundStyle(Theme.textTertiary)
                 Spacer()
@@ -247,6 +248,7 @@ struct DetailView: View {
             ForEach(model.shellSessions) { session in
                 ShellTerminalView(
                     sessionID: session.id,
+                    device: session.device,
                     fontName: terminalFontName,
                     fontSize: terminalFontSize,
                     thinStrokes: terminalThinStrokes,
@@ -602,6 +604,71 @@ struct SheetSectionLabel: View {
             .font(.system(size: 10.5, weight: .medium))
             .kerning(0.4)
             .foregroundStyle(Theme.textTertiary)
+    }
+}
+
+struct NewTerminalSheet: View {
+    @ObservedObject var model: AppModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var deviceID = Device.local.id
+
+    private var chosenDevice: Device {
+        model.device(deviceID) ?? .local
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SheetHeader(
+                systemImage: "terminal",
+                title: String(localized: "New Terminal"),
+                subtitle: chosenDevice.isLocal
+                    ? String(localized: "Start a login shell on this Mac")
+                    : String(localized: "Connect to \(chosenDevice.name) over SSH")
+            )
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            VStack(alignment: .leading, spacing: 8) {
+                SheetSectionLabel("DEVICE")
+                Picker("", selection: $deviceID) {
+                    ForEach(model.devices) { device in
+                        Text(device.name).tag(device.id)
+                    }
+                }
+                .labelsHidden()
+                .fixedSize()
+
+                if let target = chosenDevice.sshTarget {
+                    Text(target)
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+            .padding(16)
+
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Open Terminal") {
+                    model.newShellSession(on: chosenDevice)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accent)
+                .keyboardShortcut(.defaultAction)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .frame(width: 400)
+        .onAppear {
+            deviceID = model.deviceFilter
+                ?? model.selectedEntry?.device.id
+                ?? model.devices.first?.id
+                ?? Device.local.id
+        }
     }
 }
 

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -104,6 +104,12 @@ struct HerdrMApp: App {
             }
 
             CommandMenu("Terminal") {
+                Button("New Terminal…") { focusedModel?.showNewTerminal = true }
+                    .keyboardShortcut("t", modifiers: .command)
+                    .disabled(focusedModel == nil)
+
+                Divider()
+
                 // Guarded on selectedEntry, not just on the model: with the placeholder
                 // on screen there is no SplitContainer to render into, so a split would
                 // be invisible yet leave shellSplitAxis non-nil — and the next ⌘W would

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -46,10 +46,10 @@ struct SidebarView: View {
                 actionRow(icon: "square.and.pencil", label: "New Agent") {
                     model.showNewAgent = true
                 }
-                // Every click opens another standalone local shell, listed under
-                // TERMINALS below — the ⌘D split beside an agent is separate.
+                // Standalone terminals are listed under TERMINALS below; the
+                // ⌘D split beside an agent remains a local shell.
                 actionRow(icon: "terminal", label: "New Terminal") {
-                    model.newShellSession()
+                    model.showNewTerminal = true
                 }
                 actionRow(icon: "magnifyingglass", label: "Search") {
                     model.showSearch = true
@@ -292,7 +292,7 @@ struct SidebarView: View {
                     .foregroundStyle(Theme.text)
                     .lineLimit(1)
                 Spacer(minLength: 0)
-                Text("Local")
+                Text(session.device.name)
                     .font(.system(size: 11))
                     .foregroundStyle(Theme.textGhost)
             }

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -880,12 +880,9 @@ func applyTerminalAppearance(
     view.needsDisplay = true
 }
 
-/// A local login shell, side by side with the agent attach — no herdr pane and no
-/// attachment paste. It does take first responder when it appears, so splitting hands the
-/// keyboard to the new shell; closing the split gives it back via `focusRemainingTerminal`.
-/// Standalone shell views stay in the hierarchy while deselected (a local shell
-/// has no server side to reattach to), so re-selecting one needs a way to hand
-/// it the keyboard again — the registry maps session ids to their live views.
+/// A standalone local or SSH login shell, or the local login shell beside an
+/// agent attach. Standalone views stay alive while deselected, so re-selecting
+/// one uses the registry to restore keyboard focus.
 @MainActor
 enum ShellViewRegistry {
     private struct WeakView { weak var view: LocalProcessTerminalView? }
@@ -910,6 +907,7 @@ enum ShellViewRegistry {
 struct ShellTerminalView: NSViewRepresentable {
     /// Session identity for the registry; nil for the ⌘D split shell.
     var sessionID: UUID?
+    var device: Device = .local
     var fontName: String = ""
     var fontSize: Double = TerminalDefaults.defaultFontSize
     var thinStrokes: Bool = true
@@ -940,11 +938,19 @@ struct ShellTerminalView: NSViewRepresentable {
             mouseReporting: mouseReporting
         )
 
+        let command = HerdrService(device: device, autoStartLocalServer: false)
+            .terminalCommand()
         var environment = Terminal.getEnvironmentVariables(termName: "xterm-256color")
         environment.append("LANG=en_US.UTF-8")
+        for (key, value) in command.environment {
+            environment.removeAll { $0.hasPrefix("\(key)=") }
+            environment.append("\(key)=\(value)")
+        }
+        context.coordinator.authorizationID = command.authorizationID
+        context.coordinator.scheduleAuthorizationCleanup()
         view.startProcess(
-            executable: "/bin/sh",
-            args: ["-c", "cd \"$HOME\"; exec \"${SHELL:-/bin/zsh}\" -l"],
+            executable: command.executable,
+            args: command.args,
             environment: environment
         )
         if let sessionID {
@@ -978,6 +984,7 @@ struct ShellTerminalView: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: LocalProcessTerminalView, coordinator: Coordinator) {
         coordinator.onExit = nil
+        coordinator.discardAuthorization()
         if let sessionID = coordinator.sessionID {
             ShellViewRegistry.unregister(sessionID)
         }
@@ -1003,11 +1010,29 @@ struct ShellTerminalView: NSViewRepresentable {
     final class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
         var onExit: ((Int32?) -> Void)?
         var sessionID: UUID?
+        var authorizationID: UUID?
+
+        deinit {
+            discardAuthorization()
+        }
+
+        func scheduleAuthorizationCleanup() {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 30) { [weak self] in
+                self?.discardAuthorization()
+            }
+        }
+
+        func discardAuthorization() {
+            guard let authorizationID else { return }
+            try? SSHCredentialStore.removeAuthorization(authorizationID)
+            self.authorizationID = nil
+        }
 
         func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
         func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}
         func hostCurrentDirectoryUpdate(source: TerminalView, directory: String?) {}
         func processTerminated(source: TerminalView, exitCode: Int32?) {
+            discardAuthorization()
             let callback = onExit
             onExit = nil  // report once
             DispatchQueue.main.async { callback?(exitCode) }


### PR DESCRIPTION
## Summary
- choose Local or any configured SSH device when opening a standalone terminal
- reuse the existing OpenSSH, known-hosts, keepalive, and Keychain askpass flow
- keep remote terminals alive when switching sidebar entries and label them by device

## Tests
- `swift test --filter 'AttachBinarySelectionTests|SSHDestinationTests|SSHAuthenticationTests'`