### PR TITLE
feat(files): add local and SSH file manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Added
+- A two-pane Files workspace browses local and SSH-device files and copies
+  regular files in either direction with progress, cancellation, atomic
+  staging, and Replace / Keep Both conflict handling.
+
 ## [0.5.1] - 2026-08-27
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/DeviceFileService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/DeviceFileService.swift
@@ -1,0 +1,925 @@
+import Foundation
+
+public struct DeviceFileEntry: Identifiable, Hashable, Sendable {
+    public enum Kind: String, Hashable, Sendable {
+        case directory
+        case regularFile
+        case symbolicLink
+        case other
+    }
+
+    public let name: String
+    public let path: String
+    public let kind: Kind
+    public let size: Int64?
+    public let modificationDate: Date?
+    public let isHidden: Bool
+    public let isPackage: Bool
+
+    public var id: String { path }
+
+    public init(
+        name: String,
+        path: String,
+        kind: Kind,
+        size: Int64? = nil,
+        modificationDate: Date? = nil,
+        isHidden: Bool = false,
+        isPackage: Bool = false
+    ) {
+        self.name = name
+        self.path = path
+        self.kind = kind
+        self.size = size
+        self.modificationDate = modificationDate
+        self.isHidden = isHidden
+        self.isPackage = isPackage
+    }
+}
+
+public struct DeviceDirectoryListing: Sendable {
+    public let path: String
+    public let entries: [DeviceFileEntry]
+
+    public init(path: String, entries: [DeviceFileEntry]) {
+        self.path = path
+        self.entries = entries
+    }
+}
+
+public enum FileConflictPolicy: Sendable {
+    case fail
+    case replace
+    case keepBoth
+}
+
+public struct FileTransferProgress: Sendable {
+    public let completedBytes: Int64
+    public let totalBytes: Int64
+
+    public var fractionCompleted: Double {
+        guard totalBytes > 0 else { return 0 }
+        return min(1, Double(completedBytes) / Double(totalBytes))
+    }
+
+    public init(completedBytes: Int64, totalBytes: Int64) {
+        self.completedBytes = completedBytes
+        self.totalBytes = totalBytes
+    }
+}
+
+/// Filesystem operations for one configured device. Remote operations use the
+/// same system OpenSSH, known_hosts, config, agent, and Keychain askpass path as
+/// terminal attach and socket forwarding.
+public actor DeviceFileService {
+    public typealias ProgressHandler = @Sendable (FileTransferProgress) -> Void
+
+    public let device: Device
+    private let sshExecutableURL: URL
+    private var cachedRemoteHome: String?
+
+    public init(device: Device) {
+        self.device = device
+        self.sshExecutableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+    }
+
+    init(device: Device, sshExecutableURL: URL) {
+        self.device = device
+        self.sshExecutableURL = sshExecutableURL
+    }
+
+    public func listDirectory(
+        at requestedPath: String,
+        includingHidden: Bool = false
+    ) async throws -> DeviceDirectoryListing {
+        let path = try await absolutePath(requestedPath)
+        let entries: [DeviceFileEntry]
+        switch device.kind {
+        case .local:
+            entries = try Self.listLocalDirectory(at: path)
+        case .ssh:
+            let output = try await runSSHData(
+                command: Self.remoteListingCommand(path: path),
+                timeout: 30
+            )
+            entries = try Self.parseRemoteListing(output, directory: path)
+        }
+        return DeviceDirectoryListing(
+            path: path,
+            entries: Self.sorted(
+                includingHidden ? entries : entries.filter { !$0.isHidden }
+            )
+        )
+    }
+
+    public func uploadFile(
+        from localURL: URL,
+        toDirectory requestedDirectory: String,
+        conflictPolicy: FileConflictPolicy = .fail,
+        progress: @escaping ProgressHandler = { _ in }
+    ) async throws -> String {
+        let values = try localURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        guard localURL.isFileURL, values.isRegularFile == true else {
+            throw HerdrError.fileTransferFailed("only regular local files can be uploaded")
+        }
+        let directory = try await absolutePath(requestedDirectory)
+        let destination = try await resolvedDestination(
+            name: localURL.lastPathComponent,
+            directory: directory,
+            conflictPolicy: conflictPolicy
+        )
+
+        switch device.kind {
+        case .local:
+            let result = try await Self.copyLocalFile(
+                from: localURL,
+                to: URL(fileURLWithPath: destination),
+                replace: conflictPolicy == .replace,
+                progress: progress
+            )
+            return result.path
+        case .ssh:
+            let totalBytes = Int64(values.fileSize ?? 0)
+            let temporary = destination + ".herdrm-\(UUID().uuidString.lowercased()).part"
+            let installCommand = conflictPolicy == .replace
+                ? "mv -f \"$tmp\" \"$dest\""
+                : "ln \"$tmp\" \"$dest\" && rm -f \"$tmp\""
+            let command = """
+            umask 077
+            tmp=\(HerdrService.shellQuoted(temporary))
+            dest=\(HerdrService.shellQuoted(destination))
+            trap 'rm -f "$tmp"' EXIT HUP INT TERM
+            cat > "$tmp" && chmod 600 "$tmp" && \(installCommand)
+            status=$?
+            [ "$status" -eq 0 ] && trap - EXIT HUP INT TERM
+            exit "$status"
+            """
+            try await runSSHUpload(
+                localURL: localURL,
+                command: command,
+                totalBytes: totalBytes,
+                progress: progress
+            )
+            return destination
+        }
+    }
+
+    public func downloadFile(
+        at sourcePath: String,
+        toLocalDirectory localDirectory: URL,
+        conflictPolicy: FileConflictPolicy = .fail,
+        progress: @escaping ProgressHandler = { _ in }
+    ) async throws -> URL {
+        guard localDirectory.isFileURL else {
+            throw HerdrError.fileTransferFailed("a local destination directory is required")
+        }
+        let source = try await absolutePath(sourcePath)
+        let name = (source as NSString).lastPathComponent
+        let destination = try Self.resolvedLocalDestination(
+            name: name,
+            directory: localDirectory,
+            conflictPolicy: conflictPolicy
+        )
+
+        switch device.kind {
+        case .local:
+            return try await Self.copyLocalFile(
+                from: URL(fileURLWithPath: source),
+                to: destination,
+                replace: conflictPolicy == .replace,
+                progress: progress
+            )
+        case .ssh:
+            let totalOutput = try await runSSHData(
+                command: "wc -c < \(HerdrService.shellQuoted(source))",
+                timeout: 15
+            )
+            guard let totalBytes = Int64(
+                String(decoding: totalOutput, as: UTF8.self)
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            ) else {
+                throw HerdrError.fileTransferFailed("the remote host returned an invalid file size")
+            }
+            let temporary = destination
+                .deletingLastPathComponent()
+                .appendingPathComponent(
+                    ".\(destination.lastPathComponent).herdrm-\(UUID().uuidString.lowercased()).part"
+                )
+            defer { try? FileManager.default.removeItem(at: temporary) }
+            try await runSSHDownload(
+                command: "cat \(HerdrService.shellQuoted(source))",
+                temporaryURL: temporary,
+                totalBytes: totalBytes,
+                progress: progress
+            )
+            try Self.installDownloadedFile(
+                temporary,
+                at: destination,
+                replace: conflictPolicy == .replace
+            )
+            return destination
+        }
+    }
+
+    private func absolutePath(_ requestedPath: String) async throws -> String {
+        let trimmed = requestedPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        let path = trimmed.isEmpty ? "~" : trimmed
+        let expanded: String
+        if path == "~" || path.hasPrefix("~/") {
+            let home = try await homeDirectory()
+            expanded = path == "~" ? home : home + "/" + path.dropFirst(2)
+        } else {
+            expanded = path
+        }
+        guard expanded.hasPrefix("/") else {
+            throw HerdrError.fileOperationFailed("path must be absolute or start with ~")
+        }
+        return (expanded as NSString).standardizingPath
+    }
+
+    private func homeDirectory() async throws -> String {
+        switch device.kind {
+        case .local:
+            return NSHomeDirectory()
+        case .ssh:
+            if let cachedRemoteHome { return cachedRemoteHome }
+            let output = try await runSSHData(command: "printf '%s' \"$HOME\"", timeout: 15)
+            let home = String(decoding: output, as: UTF8.self)
+            guard home.hasPrefix("/") else {
+                throw HerdrError.fileOperationFailed("could not resolve the remote home directory")
+            }
+            cachedRemoteHome = home
+            return home
+        }
+    }
+
+    private func resolvedDestination(
+        name: String,
+        directory: String,
+        conflictPolicy: FileConflictPolicy
+    ) async throws -> String {
+        let original = Self.join(directory: directory, name: name)
+        let exists = try await pathExists(original)
+        switch conflictPolicy {
+        case .replace:
+            return original
+        case .fail:
+            guard !exists else {
+                throw HerdrError.fileTransferFailed("“\(name)” already exists")
+            }
+            return original
+        case .keepBoth:
+            guard exists else { return original }
+            for index in 2...10_000 {
+                let candidate = Self.keepBothName(name, index: index)
+                let path = Self.join(directory: directory, name: candidate)
+                if try await !pathExists(path) { return path }
+            }
+            throw HerdrError.fileTransferFailed("could not find an available name for “\(name)”")
+        }
+    }
+
+    private func pathExists(_ path: String) async throws -> Bool {
+        switch device.kind {
+        case .local:
+            return FileManager.default.fileExists(atPath: path)
+        case .ssh:
+            let command = """
+            if [ -e \(HerdrService.shellQuoted(path)) ] || [ -L \(HerdrService.shellQuoted(path)) ]; then
+                printf 1
+            else
+                printf 0
+            fi
+            """
+            let output = try await runSSHData(command: command, timeout: 15)
+            return output.first == UInt8(ascii: "1")
+        }
+    }
+
+    private func runSSHData(command: String, timeout: TimeInterval) async throws -> Data {
+        guard case .ssh(let target) = device.kind else {
+            throw HerdrError.fileOperationFailed("SSH is unavailable for a local device")
+        }
+        let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
+        defer { authentication.discardAuthorization() }
+        let arguments = authentication.arguments + [
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "ConnectTimeout=10",
+            "-o", "ServerAliveInterval=15",
+            "-o", "ServerAliveCountMax=3",
+            SSHTunnel.sshDestination(target),
+            command,
+        ]
+        return try await SSHFileProcess.capture(
+            executableURL: sshExecutableURL,
+            arguments: arguments,
+            environment: authentication.environment,
+            timeout: timeout
+        )
+    }
+
+    private func runSSHUpload(
+        localURL: URL,
+        command: String,
+        totalBytes: Int64,
+        progress: @escaping ProgressHandler
+    ) async throws {
+        guard case .ssh(let target) = device.kind else {
+            throw HerdrError.fileTransferFailed("SSH is unavailable for a local device")
+        }
+        let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
+        defer { authentication.discardAuthorization() }
+        let arguments = authentication.arguments + [
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "ConnectTimeout=10",
+            "-o", "ServerAliveInterval=15",
+            "-o", "ServerAliveCountMax=3",
+            SSHTunnel.sshDestination(target),
+            "exec /bin/sh -c \(HerdrService.shellQuoted(command))",
+        ]
+        try await SSHFileProcess.upload(
+            executableURL: sshExecutableURL,
+            arguments: arguments,
+            environment: authentication.environment,
+            localURL: localURL,
+            totalBytes: totalBytes,
+            progress: progress
+        )
+    }
+
+    private func runSSHDownload(
+        command: String,
+        temporaryURL: URL,
+        totalBytes: Int64,
+        progress: @escaping ProgressHandler
+    ) async throws {
+        guard case .ssh(let target) = device.kind else {
+            throw HerdrError.fileTransferFailed("SSH is unavailable for a local device")
+        }
+        let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
+        defer { authentication.discardAuthorization() }
+        let arguments = authentication.arguments + [
+            "-o", "StrictHostKeyChecking=accept-new",
+            "-o", "ConnectTimeout=10",
+            "-o", "ServerAliveInterval=15",
+            "-o", "ServerAliveCountMax=3",
+            SSHTunnel.sshDestination(target),
+            command,
+        ]
+        try await SSHFileProcess.download(
+            executableURL: sshExecutableURL,
+            arguments: arguments,
+            environment: authentication.environment,
+            temporaryURL: temporaryURL,
+            totalBytes: totalBytes,
+            progress: progress
+        )
+    }
+
+    static func parseRemoteListing(_ data: Data, directory: String) throws -> [DeviceFileEntry] {
+        let fields = data.split(separator: 0, omittingEmptySubsequences: false)
+        let payload = fields.last?.isEmpty == true ? fields.dropLast() : fields[...]
+        guard payload.count.isMultiple(of: 4) else {
+            throw HerdrError.fileOperationFailed("the remote host returned malformed directory data")
+        }
+        var entries: [DeviceFileEntry] = []
+        entries.reserveCapacity(payload.count / 4)
+        for offset in stride(from: 0, to: payload.count, by: 4) {
+            guard let name = String(data: Data(payload[offset]), encoding: .utf8),
+                  let type = String(data: Data(payload[offset + 1]), encoding: .utf8),
+                  let size = Int64(String(decoding: payload[offset + 2], as: UTF8.self)),
+                  let modified = TimeInterval(String(decoding: payload[offset + 3], as: UTF8.self))
+            else { continue }
+            let kind: DeviceFileEntry.Kind
+            switch type.lowercased() {
+            case "directory": kind = .directory
+            case "regular file": kind = .regularFile
+            case "symbolic link": kind = .symbolicLink
+            default: kind = .other
+            }
+            entries.append(
+                DeviceFileEntry(
+                    name: name,
+                    path: join(directory: directory, name: name),
+                    kind: kind,
+                    size: kind == .regularFile ? size : nil,
+                    modificationDate: Date(timeIntervalSince1970: modified),
+                    isHidden: name.hasPrefix(".")
+                )
+            )
+        }
+        return entries
+    }
+
+    static func remoteListingCommand(path: String) -> String {
+        """
+        cd \(HerdrService.shellQuoted(path)) || exit 1
+        if stat -f '%HT' . >/dev/null 2>&1; then
+            find . ! -name . -prune -exec /bin/sh -c 'for item do
+                type=$(stat -f "%HT" "$item") || continue
+                size=$(stat -f "%z" "$item") || continue
+                modified=$(stat -f "%m" "$item") || continue
+                name=${item#./}
+                printf "%s\\0%s\\0%s\\0%s\\0" "$name" "$type" "$size" "$modified"
+            done' sh {} +
+        else
+            find . ! -name . -prune -exec /bin/sh -c 'for item do
+                type=$(stat -c "%F" -- "$item") || continue
+                size=$(stat -c "%s" -- "$item") || continue
+                modified=$(stat -c "%Y" -- "$item") || continue
+                name=${item#./}
+                printf "%s\\0%s\\0%s\\0%s\\0" "$name" "$type" "$size" "$modified"
+            done' sh {} +
+        fi
+        """
+    }
+
+    static func keepBothName(_ name: String, index: Int) -> String {
+        let value = name as NSString
+        let ext = value.pathExtension
+        let stem = value.deletingPathExtension
+        return ext.isEmpty ? "\(name) \(index)" : "\(stem) \(index).\(ext)"
+    }
+
+    private static func listLocalDirectory(at path: String) throws -> [DeviceFileEntry] {
+        let keys: Set<URLResourceKey> = [
+            .isDirectoryKey,
+            .isRegularFileKey,
+            .isSymbolicLinkKey,
+            .isHiddenKey,
+            .isPackageKey,
+            .fileSizeKey,
+            .contentModificationDateKey,
+        ]
+        return try FileManager.default.contentsOfDirectory(
+            at: URL(fileURLWithPath: path, isDirectory: true),
+            includingPropertiesForKeys: Array(keys),
+            options: []
+        ).map { url in
+            let values = try url.resourceValues(forKeys: keys)
+            let kind: DeviceFileEntry.Kind
+            if values.isSymbolicLink == true {
+                kind = .symbolicLink
+            } else if values.isDirectory == true {
+                kind = .directory
+            } else if values.isRegularFile == true {
+                kind = .regularFile
+            } else {
+                kind = .other
+            }
+            return DeviceFileEntry(
+                name: url.lastPathComponent,
+                path: url.path,
+                kind: kind,
+                size: kind == .regularFile ? Int64(values.fileSize ?? 0) : nil,
+                modificationDate: values.contentModificationDate,
+                isHidden: values.isHidden == true || url.lastPathComponent.hasPrefix("."),
+                isPackage: values.isPackage == true
+            )
+        }
+    }
+
+    private static func sorted(_ entries: [DeviceFileEntry]) -> [DeviceFileEntry] {
+        entries.sorted { lhs, rhs in
+            if lhs.kind == .directory, rhs.kind != .directory { return true }
+            if lhs.kind != .directory, rhs.kind == .directory { return false }
+            return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+        }
+    }
+
+    private static func join(directory: String, name: String) -> String {
+        directory == "/" ? "/\(name)" : "\(directory)/\(name)"
+    }
+
+    private static func resolvedLocalDestination(
+        name: String,
+        directory: URL,
+        conflictPolicy: FileConflictPolicy
+    ) throws -> URL {
+        let manager = FileManager.default
+        var destination = directory.appendingPathComponent(name)
+        let exists = manager.fileExists(atPath: destination.path)
+        switch conflictPolicy {
+        case .replace:
+            return destination
+        case .fail:
+            guard !exists else {
+                throw HerdrError.fileTransferFailed("“\(name)” already exists")
+            }
+            return destination
+        case .keepBoth:
+            guard exists else { return destination }
+            for index in 2...10_000 {
+                destination = directory.appendingPathComponent(keepBothName(name, index: index))
+                if !manager.fileExists(atPath: destination.path) { return destination }
+            }
+            throw HerdrError.fileTransferFailed("could not find an available name for “\(name)”")
+        }
+    }
+
+    private static func copyLocalFile(
+        from source: URL,
+        to destination: URL,
+        replace: Bool,
+        progress: @escaping ProgressHandler
+    ) async throws -> URL {
+        let values = try source.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+        guard values.isRegularFile == true else {
+            throw HerdrError.fileTransferFailed("only regular files can be transferred")
+        }
+        let totalBytes = Int64(values.fileSize ?? 0)
+        let temporary = destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                ".\(destination.lastPathComponent).herdrm-\(UUID().uuidString.lowercased()).part"
+            )
+        defer { try? FileManager.default.removeItem(at: temporary) }
+
+        FileManager.default.createFile(atPath: temporary.path, contents: nil)
+        let input = try FileHandle(forReadingFrom: source)
+        let output = try FileHandle(forWritingTo: temporary)
+        defer {
+            try? input.close()
+            try? output.close()
+        }
+        var completed: Int64 = 0
+        while let data = try input.read(upToCount: 256 * 1024), !data.isEmpty {
+            try Task.checkCancellation()
+            try output.write(contentsOf: data)
+            completed += Int64(data.count)
+            progress(FileTransferProgress(completedBytes: completed, totalBytes: totalBytes))
+        }
+        try output.synchronize()
+        try installDownloadedFile(temporary, at: destination, replace: replace)
+        progress(FileTransferProgress(completedBytes: totalBytes, totalBytes: totalBytes))
+        return destination
+    }
+
+    private static func installDownloadedFile(
+        _ temporary: URL,
+        at destination: URL,
+        replace: Bool
+    ) throws {
+        let manager = FileManager.default
+        if manager.fileExists(atPath: destination.path) {
+            guard replace else {
+                throw HerdrError.fileTransferFailed("“\(destination.lastPathComponent)” already exists")
+            }
+            _ = try manager.replaceItemAt(destination, withItemAt: temporary)
+        } else {
+            try manager.moveItem(at: temporary, to: destination)
+        }
+    }
+}
+
+private enum SSHFileProcess {
+    static func capture(
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) async throws -> Data {
+        let processBox = CancellableProcess()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Data, Error>) in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let process = configuredProcess(
+                        executableURL: executableURL,
+                        arguments: arguments,
+                        environment: environment
+                    )
+                    let output = Pipe()
+                    let errorOutput = Pipe()
+                    process.standardOutput = output
+                    process.standardError = errorOutput
+                    do {
+                        try process.run()
+                        processBox.install(process)
+                    } catch {
+                        continuation.resume(
+                            throwing: HerdrError.fileOperationFailed(
+                                "could not start SSH: \(error.localizedDescription)"
+                            )
+                        )
+                        return
+                    }
+                    scheduleTimeout(processBox, after: timeout)
+                    let streams = readStreams(output: output, error: errorOutput)
+                    process.waitUntilExit()
+                    let (data, errorData) = streams()
+                    if processBox.didTimeOut {
+                        continuation.resume(
+                            throwing: HerdrError.fileOperationFailed("SSH timed out")
+                        )
+                    } else if processBox.wasCancelled {
+                        continuation.resume(throwing: CancellationError())
+                    } else if process.terminationStatus != 0 {
+                        continuation.resume(
+                            throwing: HerdrError.fileOperationFailed(
+                                failureReason(status: process.terminationStatus, stderr: errorData)
+                            )
+                        )
+                    } else {
+                        continuation.resume(returning: data)
+                    }
+                }
+            }
+        } onCancel: {
+            processBox.cancel()
+        }
+    }
+
+    static func upload(
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        localURL: URL,
+        totalBytes: Int64,
+        progress: @escaping DeviceFileService.ProgressHandler
+    ) async throws {
+        let processBox = CancellableProcess()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    let process = configuredProcess(
+                        executableURL: executableURL,
+                        arguments: arguments,
+                        environment: environment
+                    )
+                    let errorOutput = Pipe()
+                    let source: FileHandle
+                    do {
+                        source = try FileHandle(forReadingFrom: localURL)
+                    } catch {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    defer { try? source.close() }
+                    process.standardInput = source
+                    process.standardOutput = FileHandle.nullDevice
+                    process.standardError = errorOutput
+                    do {
+                        try process.run()
+                        processBox.install(process)
+                    } catch {
+                        continuation.resume(
+                            throwing: HerdrError.fileTransferFailed(
+                                "could not start SSH: \(error.localizedDescription)"
+                            )
+                        )
+                        return
+                    }
+                    let errorReader = readError(errorOutput)
+                    while process.isRunning {
+                        if processBox.wasCancelled {
+                            process.terminate()
+                            break
+                        }
+                        let offset = lseek(source.fileDescriptor, 0, SEEK_CUR)
+                        if offset >= 0 {
+                            progress(
+                                FileTransferProgress(
+                                    completedBytes: Int64(offset),
+                                    totalBytes: totalBytes
+                                )
+                            )
+                        }
+                        usleep(100_000)
+                    }
+                    process.waitUntilExit()
+                    let errorData = errorReader()
+                    if processBox.wasCancelled {
+                        continuation.resume(throwing: CancellationError())
+                    } else if process.terminationStatus != 0 {
+                        continuation.resume(
+                            throwing: HerdrError.fileTransferFailed(
+                                failureReason(status: process.terminationStatus, stderr: errorData)
+                            )
+                        )
+                    } else {
+                        progress(
+                            FileTransferProgress(
+                                completedBytes: totalBytes,
+                                totalBytes: totalBytes
+                            )
+                        )
+                        continuation.resume()
+                    }
+                }
+            }
+        } onCancel: {
+            processBox.cancel()
+        }
+    }
+
+    static func download(
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String],
+        temporaryURL: URL,
+        totalBytes: Int64,
+        progress: @escaping DeviceFileService.ProgressHandler
+    ) async throws {
+        let processBox = CancellableProcess()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    FileManager.default.createFile(atPath: temporaryURL.path, contents: nil)
+                    let destination: FileHandle
+                    do {
+                        destination = try FileHandle(forWritingTo: temporaryURL)
+                    } catch {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    defer { try? destination.close() }
+
+                    let process = configuredProcess(
+                        executableURL: executableURL,
+                        arguments: arguments,
+                        environment: environment
+                    )
+                    let output = Pipe()
+                    let errorOutput = Pipe()
+                    process.standardOutput = output
+                    process.standardError = errorOutput
+                    do {
+                        try process.run()
+                        processBox.install(process)
+                    } catch {
+                        continuation.resume(
+                            throwing: HerdrError.fileTransferFailed(
+                                "could not start SSH: \(error.localizedDescription)"
+                            )
+                        )
+                        return
+                    }
+                    let errorReader = readError(errorOutput)
+                    var completed: Int64 = 0
+                    do {
+                        while let data = try output.fileHandleForReading.read(
+                            upToCount: 256 * 1024
+                        ), !data.isEmpty {
+                            if processBox.wasCancelled { throw CancellationError() }
+                            try destination.write(contentsOf: data)
+                            completed += Int64(data.count)
+                            progress(
+                                FileTransferProgress(
+                                    completedBytes: completed,
+                                    totalBytes: totalBytes
+                                )
+                            )
+                        }
+                        process.waitUntilExit()
+                        let errorData = errorReader()
+                        if processBox.wasCancelled {
+                            continuation.resume(throwing: CancellationError())
+                        } else if process.terminationStatus != 0 {
+                            continuation.resume(
+                                throwing: HerdrError.fileTransferFailed(
+                                    failureReason(
+                                        status: process.terminationStatus,
+                                        stderr: errorData
+                                    )
+                                )
+                            )
+                        } else {
+                            try destination.synchronize()
+                            progress(
+                                FileTransferProgress(
+                                    completedBytes: totalBytes,
+                                    totalBytes: totalBytes
+                                )
+                            )
+                            continuation.resume()
+                        }
+                    } catch {
+                        processBox.cancel()
+                        process.waitUntilExit()
+                        _ = errorReader()
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+        } onCancel: {
+            processBox.cancel()
+        }
+    }
+
+    private static func configuredProcess(
+        executableURL: URL,
+        arguments: [String],
+        environment: [String: String]
+    ) -> Process {
+        let process = Process()
+        process.executableURL = executableURL
+        process.arguments = arguments
+        process.environment = ProcessInfo.processInfo.environment.merging(environment) { _, new in new }
+        return process
+    }
+
+    private static func scheduleTimeout(_ process: CancellableProcess, after timeout: TimeInterval) {
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + timeout) {
+            process.timeout()
+        }
+    }
+
+    private static func readStreams(
+        output: Pipe,
+        error: Pipe
+    ) -> () -> (Data, Data) {
+        let group = DispatchGroup()
+        let data = LockedData()
+        let errorData = LockedData()
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            data.set(output.fileHandleForReading.readDataToEndOfFile())
+            group.leave()
+        }
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            errorData.set(error.fileHandleForReading.readDataToEndOfFile())
+            group.leave()
+        }
+        return {
+            group.wait()
+            return (data.value, errorData.value)
+        }
+    }
+
+    private static func readError(_ pipe: Pipe) -> () -> Data {
+        let group = DispatchGroup()
+        let data = LockedData()
+        group.enter()
+        DispatchQueue.global(qos: .utility).async {
+            data.set(pipe.fileHandleForReading.readDataToEndOfFile())
+            group.leave()
+        }
+        return {
+            group.wait()
+            return data.value
+        }
+    }
+
+    private static func failureReason(status: Int32, stderr: Data) -> String {
+        let detail = String(data: stderr, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return detail.isEmpty ? "SSH exited \(status)" : String(detail.suffix(2_000))
+    }
+}
+
+private final class CancellableProcess: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+    private var cancelled = false
+    private var timedOut = false
+
+    var wasCancelled: Bool {
+        lock.withLock { cancelled }
+    }
+
+    var didTimeOut: Bool {
+        lock.withLock { timedOut }
+    }
+
+    func install(_ process: Process) {
+        let shouldCancel = lock.withLock {
+            self.process = process
+            return cancelled
+        }
+        if shouldCancel, process.isRunning { process.terminate() }
+    }
+
+    func cancel() {
+        terminate(cancelled: true, timedOut: false)
+    }
+
+    func timeout() {
+        terminate(cancelled: false, timedOut: true)
+    }
+
+    private func terminate(cancelled: Bool, timedOut: Bool) {
+        let runningProcess = lock.withLock {
+            self.cancelled = self.cancelled || cancelled
+            self.timedOut = self.timedOut || timedOut
+            return process
+        }
+        if runningProcess?.isRunning == true { runningProcess?.terminate() }
+    }
+}
+
+private final class LockedData: @unchecked Sendable {
+    private let lock = NSLock()
+    private var data = Data()
+
+    var value: Data {
+        lock.withLock { data }
+    }
+
+    func set(_ data: Data) {
+        lock.withLock { self.data = data }
+    }
+}

--- a/Packages/HerdrKit/Sources/HerdrKit/Models.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/Models.swift
@@ -236,6 +236,7 @@ public enum HerdrError: Error, LocalizedError, Sendable {
     case malformedResponse(String)
     case incompatibleProtocol(Int)
     case tunnelFailed(String)
+    case fileOperationFailed(String)
     case fileTransferFailed(String)
 
     public var errorDescription: String? {
@@ -249,6 +250,7 @@ public enum HerdrError: Error, LocalizedError, Sendable {
         case .malformedResponse(let reason): return "malformed response: \(reason)"
         case .incompatibleProtocol(let version): return "herdr protocol \(version) is too old (need >= 17)"
         case .tunnelFailed(let reason): return "SSH tunnel failed: \(reason)"
+        case .fileOperationFailed(let reason): return "file operation failed: \(reason)"
         case .fileTransferFailed(let reason): return "file transfer failed: \(reason)"
         }
     }

--- a/Packages/HerdrKit/Tests/HerdrKitTests/DeviceFileServiceTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/DeviceFileServiceTests.swift
@@ -1,0 +1,263 @@
+import XCTest
+@testable import HerdrKit
+
+final class DeviceFileServiceTests: XCTestCase {
+    func testLocalListingClassifiesSortsAndFiltersEntries() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let folder = root.appendingPathComponent("Folder", isDirectory: true)
+        let file = root.appendingPathComponent("notes.txt")
+        let hidden = root.appendingPathComponent(".secret")
+        let link = root.appendingPathComponent("shortcut")
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: false)
+        try Data("notes".utf8).write(to: file)
+        try Data("hidden".utf8).write(to: hidden)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: file)
+
+        let service = DeviceFileService(device: .local)
+        let visible = try await service.listDirectory(at: root.path)
+        XCTAssertEqual(visible.entries.map(\.name), ["Folder", "notes.txt", "shortcut"])
+        XCTAssertEqual(visible.entries[0].kind, .directory)
+        XCTAssertEqual(visible.entries[1].kind, .regularFile)
+        XCTAssertEqual(visible.entries[1].size, 5)
+        XCTAssertEqual(visible.entries[2].kind, .symbolicLink)
+
+        let all = try await service.listDirectory(at: root.path, includingHidden: true)
+        XCTAssertTrue(all.entries.contains(where: { $0.name == ".secret" && $0.isHidden }))
+    }
+
+    func testLocalCopySupportsReplaceAndFinderStyleKeepBoth() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let sourceDirectory = root.appendingPathComponent("source", isDirectory: true)
+        let destinationDirectory = root.appendingPathComponent("destination", isDirectory: true)
+        try FileManager.default.createDirectory(at: sourceDirectory, withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: destinationDirectory, withIntermediateDirectories: false)
+        let source = sourceDirectory.appendingPathComponent("report.txt")
+        try Data("new".utf8).write(to: source)
+        try Data("old".utf8).write(to: destinationDirectory.appendingPathComponent("report.txt"))
+
+        let service = DeviceFileService(device: .local)
+        let kept = try await service.uploadFile(
+            from: source,
+            toDirectory: destinationDirectory.path,
+            conflictPolicy: .keepBoth
+        )
+        XCTAssertEqual((kept as NSString).lastPathComponent, "report 2.txt")
+        XCTAssertEqual(try String(contentsOfFile: kept, encoding: .utf8), "new")
+
+        let replaced = try await service.uploadFile(
+            from: source,
+            toDirectory: destinationDirectory.path,
+            conflictPolicy: .replace
+        )
+        XCTAssertEqual((replaced as NSString).lastPathComponent, "report.txt")
+        XCTAssertEqual(try String(contentsOfFile: replaced, encoding: .utf8), "new")
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: destinationDirectory.path)
+                .contains(where: { $0.contains(".herdrm-") })
+        )
+    }
+
+    func testRemoteListingUsesNullDelimitedNames() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let executable = root.appendingPathComponent("fake-ssh")
+        let arguments = root.appendingPathComponent("arguments")
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' "$@" > \(HerdrService.shellQuoted(arguments.path))
+        printf '%s\\0%s\\0%s\\0%s\\0' Folder directory 0 1770000000
+        printf '%s\\0%s\\0%s\\0%s\\0' 'line
+        break.txt' 'regular file' 12 1770000001
+        """
+        try makeExecutable(script, at: executable)
+
+        let device = Device(name: "Remote", kind: .ssh(target: "user@example.test"))
+        let service = DeviceFileService(device: device, sshExecutableURL: executable)
+        let listing = try await service.listDirectory(at: "/srv/project")
+
+        XCTAssertEqual(listing.entries.map(\.name), ["Folder", "line\nbreak.txt"])
+        XCTAssertEqual(listing.entries[0].kind, .directory)
+        XCTAssertEqual(listing.entries[1].kind, .regularFile)
+        XCTAssertEqual(listing.entries[1].size, 12)
+        let captured = try String(contentsOf: arguments, encoding: .utf8)
+        XCTAssertTrue(captured.contains("StrictHostKeyChecking=accept-new"))
+        XCTAssertTrue(captured.contains("find . ! -name . -prune"))
+    }
+
+    func testRemoteListingCommandHandlesMacOSAndUnusualNames() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let folder = root.appendingPathComponent("Folder", isDirectory: true)
+        let unusual = root.appendingPathComponent("quote's\nnotes.txt")
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: false)
+        try Data("notes".utf8).write(to: unusual)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            DeviceFileService.remoteListingCommand(path: root.path),
+        ]
+        let output = Pipe()
+        let errorOutput = Pipe()
+        process.standardOutput = output
+        process.standardError = errorOutput
+        try process.run()
+        process.waitUntilExit()
+
+        XCTAssertEqual(
+            process.terminationStatus,
+            0,
+            String(
+                data: errorOutput.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? ""
+        )
+        let entries = try DeviceFileService.parseRemoteListing(
+            output.fileHandleForReading.readDataToEndOfFile(),
+            directory: root.path
+        )
+        XCTAssertEqual(
+            entries.map(\.name).sorted(),
+            ["Folder", "quote's\nnotes.txt"].sorted()
+        )
+        XCTAssertEqual(entries.first(where: { $0.name == "Folder" })?.kind, .directory)
+        XCTAssertEqual(
+            entries.first(where: { $0.name == "quote's\nnotes.txt" })?.kind,
+            .regularFile
+        )
+    }
+
+    func testRemoteUploadStreamsBytesToAtomicTemporaryDestination() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let executable = root.appendingPathComponent("fake-ssh")
+        let captured = root.appendingPathComponent("captured")
+        let arguments = root.appendingPathComponent("arguments")
+        let script = """
+        #!/bin/sh
+        printf '%s\\n' "$@" > \(HerdrService.shellQuoted(arguments.path))
+        case "$*" in
+          *"if [ -e "*) printf 0 ;;
+          *) cat > \(HerdrService.shellQuoted(captured.path)) ;;
+        esac
+        """
+        try makeExecutable(script, at: executable)
+        let source = root.appendingPathComponent("design's notes.txt")
+        let payload = Data([0x00, 0x0A, 0x42, 0xFF])
+        try payload.write(to: source)
+
+        let device = Device(name: "Remote", kind: .ssh(target: "user@example.test"))
+        let service = DeviceFileService(device: device, sshExecutableURL: executable)
+        let destination = try await service.uploadFile(
+            from: source,
+            toDirectory: "/srv/project"
+        )
+
+        XCTAssertEqual(destination, "/srv/project/design's notes.txt")
+        XCTAssertEqual(try Data(contentsOf: captured), payload)
+        let capturedArguments = try String(contentsOf: arguments, encoding: .utf8)
+        XCTAssertTrue(capturedArguments.contains(".part"))
+        XCTAssertTrue(capturedArguments.contains("trap"))
+        XCTAssertTrue(capturedArguments.contains("ln"))
+        XCTAssertTrue(capturedArguments.contains("design"))
+        XCTAssertTrue(capturedArguments.contains("notes.txt"))
+    }
+
+    func testRemoteDownloadStagesThenAtomicallyInstallsFile() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let executable = root.appendingPathComponent("fake-ssh")
+        let payload = "remote payload"
+        let script = """
+        #!/bin/sh
+        case "$*" in
+          *"wc -c"*) printf \(payload.utf8.count) ;;
+          *) printf '%s' \(HerdrService.shellQuoted(payload)) ;;
+        esac
+        """
+        try makeExecutable(script, at: executable)
+        let destinationDirectory = root.appendingPathComponent("downloads", isDirectory: true)
+        try FileManager.default.createDirectory(at: destinationDirectory, withIntermediateDirectories: false)
+
+        let device = Device(name: "Remote", kind: .ssh(target: "user@example.test"))
+        let service = DeviceFileService(device: device, sshExecutableURL: executable)
+        let result = try await service.downloadFile(
+            at: "/srv/project/result.txt",
+            toLocalDirectory: destinationDirectory
+        )
+
+        XCTAssertEqual(result.lastPathComponent, "result.txt")
+        XCTAssertEqual(try String(contentsOf: result, encoding: .utf8), payload)
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: destinationDirectory.path)
+                .contains(where: { $0.contains(".herdrm-") })
+        )
+    }
+
+    func testCancellingRemoteDownloadRemovesPartialFile() async throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let executable = root.appendingPathComponent("fake-ssh")
+        let script = """
+        #!/bin/sh
+        case "$*" in
+          *"wc -c"*) printf 100 ;;
+          *) exec sleep 10 ;;
+        esac
+        """
+        try makeExecutable(script, at: executable)
+        let destinationDirectory = root.appendingPathComponent("downloads", isDirectory: true)
+        try FileManager.default.createDirectory(at: destinationDirectory, withIntermediateDirectories: false)
+
+        let device = Device(name: "Remote", kind: .ssh(target: "user@example.test"))
+        let service = DeviceFileService(device: device, sshExecutableURL: executable)
+        let transfer = Task {
+            try await service.downloadFile(
+                at: "/srv/project/result.txt",
+                toLocalDirectory: destinationDirectory
+            )
+        }
+        try await Task.sleep(nanoseconds: 150_000_000)
+        transfer.cancel()
+
+        do {
+            _ = try await transfer.value
+            XCTFail("expected cancellation")
+        } catch is CancellationError {
+            // Expected.
+        }
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: destinationDirectory.appendingPathComponent("result.txt").path
+            )
+        )
+        XCTAssertFalse(
+            try FileManager.default.contentsOfDirectory(atPath: destinationDirectory.path)
+                .contains(where: { $0.contains(".herdrm-") })
+        )
+    }
+
+    func testKeepBothNamePreservesExtension() {
+        XCTAssertEqual(DeviceFileService.keepBothName("archive.tar.gz", index: 2), "archive.tar 2.gz")
+        XCTAssertEqual(DeviceFileService.keepBothName("README", index: 3), "README 3")
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herdrm-files-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func makeExecutable(_ script: String, at url: URL) throws {
+        try script.write(to: url, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: url.path
+        )
+    }
+}

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ macOS window on top of it, and it's grown well past "attach to a terminal":
 | 🧭 **Live status** | Spaces & Agents sorted by urgency: blocked → done → working → idle |
 | ⌨️ **Real terminal** | Full PTY attach, not a chat wrapper — native selection, legible fonts, resilient sessions |
 | 📎 **Paste anything** | Files and images land straight in the agent's pane, locally or over SSH |
+| 📁 **Move files** | Browse Local + SSH files side by side and copy in either direction |
 | 🔔 **Notifications** | A system alert the moment an agent needs you — click it to jump right there |
 | 🔍 **⌘K search** | Every agent, on every device, one keystroke away |
 
@@ -86,6 +87,10 @@ macOS window on top of it, and it's grown well past "attach to a terminal":
   of freezing on the last frame; mixed-version `herdr` binaries no longer break attach.
 
 ### Files, search, and staying in the loop
+- **Two-pane file manager** — browse Local and any configured SSH device side by side, then
+  upload or download regular files with progress, cancellation, and explicit Replace / Keep
+  Both conflict handling. Transfers use the same OpenSSH config, agent, host-key, and Keychain
+  password flow as terminals.
 - **Paste files and images** into Claude Code, Codex, or Copilot. Local pastes forward as
   Ctrl+V; remote pastes stream over SSH into a self-pruning cache (7-day retention, 50 MB cap).
 - **Search** — ⌘K across every device, ordered by urgency, scrolling to follow your selection.

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -119,6 +119,7 @@ final class AppModel: ObservableObject {
     @Published var showNewAgent = false
     @Published var showNewSpace = false
     @Published var showSearch = false
+    @Published var isFileManagerActive = false
     @Published var shellSplitAxis: SplitAxis?
     /// The pane that currently holds the keyboard within the ⌘D split. Reset to
     /// the agent side whenever the split closes so reopening it is predictable.
@@ -297,6 +298,7 @@ final class AppModel: ObservableObject {
     // MARK: - Selection
 
     func selectSpace(_ ref: SpaceRef?) {
+        isFileManagerActive = false
         selectedSpace = ref
         selectedShellID = nil
         if let entry = selectedEntry {
@@ -323,6 +325,7 @@ final class AppModel: ObservableObject {
 
     /// Jump target used by the search sheet and by notification clicks.
     func reveal(_ ref: PaneRef) {
+        isFileManagerActive = false
         if let filter = deviceFilter, filter != ref.deviceID {
             deviceFilter = nil
         }
@@ -343,6 +346,17 @@ final class AppModel: ObservableObject {
 
     // MARK: - Shell terminals
 
+    func openFileManager() {
+        isFileManagerActive = true
+        selectedShellID = nil
+    }
+
+    func selectAgent(_ ref: PaneRef) {
+        isFileManagerActive = false
+        selectedPane = ref
+        selectedShellID = nil
+    }
+
     var selectedShell: ShellSession? {
         selectedShellID.flatMap { id in shellSessions.first { $0.id == id } }
     }
@@ -356,6 +370,7 @@ final class AppModel: ObservableObject {
     }
 
     func selectShell(_ id: UUID) {
+        isFileManagerActive = false
         selectedShellID = id
         ShellViewRegistry.focus(id)
     }
@@ -858,6 +873,7 @@ final class AppModel: ObservableObject {
                     )
                 }
                 await refresh(device.id)
+                isFileManagerActive = false
                 selectedPane = PaneRef(deviceID: device.id, paneID: pane)
             } catch {
                 if let createdPane {

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -101,6 +101,7 @@ enum TitlebarMetrics {
 struct DetailView: View {
     @ObservedObject var model: AppModel
     @Binding var sidebarCollapsed: Bool
+    @State private var hasOpenedFileManager = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -108,8 +109,7 @@ struct DetailView: View {
                 .background(Theme.contentBackground)
                 .zIndex(1)
             Rectangle().fill(Theme.hairline).frame(height: 1)
-            terminal
-                .clipped()
+            detailContent
                 // Losing the selected agent tears the SplitContainer down without
                 // resetting the axis, which would leave the same phantom split.
                 //
@@ -122,9 +122,29 @@ struct DetailView: View {
                 .onChange(of: model.selectedEntry?.id) { _, id in
                     if id == nil { model.shellSplitAxis = nil }
                 }
+                .onChange(of: model.isFileManagerActive) { _, active in
+                    if active { hasOpenedFileManager = true }
+                }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Theme.contentBackground.ignoresSafeArea())
+    }
+
+    private var detailContent: some View {
+        ZStack {
+            terminal
+                .clipped()
+                .opacity(model.isFileManagerActive ? 0 : 1)
+                .allowsHitTesting(!model.isFileManagerActive)
+            if hasOpenedFileManager {
+                DeviceFilesView(model: model)
+                    .opacity(model.isFileManagerActive ? 1 : 0)
+                    .allowsHitTesting(model.isFileManagerActive)
+            }
+        }
+        .onAppear {
+            if model.isFileManagerActive { hasOpenedFileManager = true }
+        }
     }
 
     // MARK: - Titlebar strip (28pt, traditional)
@@ -137,7 +157,15 @@ struct DetailView: View {
                     sidebarCollapsed = false
                 }
             }
-            if let shell = model.selectedShell {
+            if model.isFileManagerActive {
+                Image(systemName: "folder")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Theme.textTertiary)
+                Text("Files")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Theme.text)
+                Spacer()
+            } else if let shell = model.selectedShell {
                 Image(systemName: "terminal")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(Theme.textTertiary)

--- a/Sources/HerdrM/DeviceFilesView.swift
+++ b/Sources/HerdrM/DeviceFilesView.swift
@@ -1,0 +1,613 @@
+import AppKit
+import HerdrKit
+import SwiftUI
+
+@MainActor
+private final class DeviceFileBrowserModel: ObservableObject {
+    @Published private(set) var device: Device = .local
+    @Published private(set) var currentPath = "~"
+    @Published var pathText = "~"
+    @Published private(set) var entries: [DeviceFileEntry] = []
+    @Published var selectedPath: String?
+    @Published var includesHidden = false
+    @Published private(set) var isLoading = false
+    @Published private(set) var error: String?
+
+    private var service = DeviceFileService(device: .local)
+    private var generation = 0
+
+    var selectedEntry: DeviceFileEntry? {
+        selectedPath.flatMap { path in entries.first { $0.path == path } }
+    }
+
+    func configure(for device: Device) async {
+        guard self.device.id != device.id || entries.isEmpty else { return }
+        generation += 1
+        self.device = device
+        service = DeviceFileService(device: device)
+        currentPath = "~"
+        pathText = "~"
+        entries = []
+        selectedPath = nil
+        error = nil
+        await refresh()
+    }
+
+    func refresh() async {
+        await load(pathText)
+    }
+
+    func navigate(to path: String) async {
+        await load(path)
+    }
+
+    func open(_ entry: DeviceFileEntry) async {
+        if entry.kind == .directory {
+            await load(entry.path)
+        } else {
+            selectedPath = entry.path
+        }
+    }
+
+    func goUp() async {
+        guard currentPath != "/" else { return }
+        let parent = (currentPath as NSString).deletingLastPathComponent
+        await load(parent.isEmpty ? "/" : parent)
+    }
+
+    func goHome() async {
+        await load("~")
+    }
+
+    func toggleHidden() async {
+        includesHidden.toggle()
+        await load(currentPath)
+    }
+
+    private func load(_ requestedPath: String) async {
+        generation += 1
+        let requestGeneration = generation
+        isLoading = true
+        error = nil
+        defer {
+            if requestGeneration == generation { isLoading = false }
+        }
+        do {
+            let listing = try await service.listDirectory(
+                at: requestedPath,
+                includingHidden: includesHidden
+            )
+            guard requestGeneration == generation, !Task.isCancelled else { return }
+            currentPath = listing.path
+            pathText = (listing.path as NSString).abbreviatingWithTildeInPath
+            entries = listing.entries
+            if let selectedPath, !entries.contains(where: { $0.path == selectedPath }) {
+                self.selectedPath = nil
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            guard requestGeneration == generation else { return }
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+@MainActor
+private final class DeviceFileTransferModel: ObservableObject {
+    enum Direction {
+        case upload
+        case download
+    }
+
+    @Published private(set) var isTransferring = false
+    @Published private(set) var progress: FileTransferProgress?
+    @Published private(set) var label = ""
+    @Published var error: String?
+
+    private var task: Task<Void, Never>?
+
+    func start(
+        direction: Direction,
+        entry: DeviceFileEntry,
+        targetDevice: Device,
+        localDirectory: String,
+        targetDirectory: String,
+        conflictPolicy: FileConflictPolicy,
+        onFinished: @escaping @MainActor () async -> Void
+    ) {
+        guard !isTransferring else { return }
+        isTransferring = true
+        progress = nil
+        error = nil
+        label = direction == .upload
+            ? String(localized: "Uploading \(entry.name)")
+            : String(localized: "Downloading \(entry.name)")
+
+        let progressHandler: DeviceFileService.ProgressHandler = { [weak self] value in
+            Task { @MainActor in self?.progress = value }
+        }
+        task = Task { [weak self] in
+            do {
+                let service = DeviceFileService(device: targetDevice)
+                switch direction {
+                case .upload:
+                    _ = try await service.uploadFile(
+                        from: URL(fileURLWithPath: entry.path),
+                        toDirectory: targetDirectory,
+                        conflictPolicy: conflictPolicy,
+                        progress: progressHandler
+                    )
+                case .download:
+                    _ = try await service.downloadFile(
+                        at: entry.path,
+                        toLocalDirectory: URL(
+                            fileURLWithPath: localDirectory,
+                            isDirectory: true
+                        ),
+                        conflictPolicy: conflictPolicy,
+                        progress: progressHandler
+                    )
+                }
+                await onFinished()
+            } catch is CancellationError {
+                // Explicit cancellation should not produce a failure alert.
+            } catch {
+                self?.error = error.localizedDescription
+            }
+            self?.isTransferring = false
+            self?.progress = nil
+            self?.task = nil
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+    }
+
+    deinit {
+        task?.cancel()
+    }
+}
+
+struct DeviceFilesView: View {
+    @ObservedObject var model: AppModel
+    @StateObject private var local = DeviceFileBrowserModel()
+    @StateObject private var target = DeviceFileBrowserModel()
+    @StateObject private var transfer = DeviceFileTransferModel()
+    @State private var targetDeviceID = Device.local.id
+    @State private var pendingConflict: PendingFileTransfer?
+
+    private var targetDevice: Device {
+        model.device(targetDeviceID) ?? .local
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            deviceBar
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+            HStack(spacing: 0) {
+                DeviceFilePane(title: String(localized: "Local"), device: .local, browser: local)
+                transferButtons
+                DeviceFilePane(title: targetDevice.name, device: targetDevice, browser: target)
+            }
+            if transfer.isTransferring {
+                Rectangle().fill(Theme.hairline).frame(height: 1)
+                transferBar
+            }
+        }
+        .background(Theme.contentBackground)
+        .task {
+            targetDeviceID = preferredTargetDeviceID()
+        }
+        .onChange(of: model.deviceFilter) { _, deviceID in
+            if let deviceID { targetDeviceID = deviceID }
+        }
+        .onChange(of: model.devices.map(\.id)) { _, ids in
+            if !ids.contains(targetDeviceID) {
+                targetDeviceID = preferredTargetDeviceID()
+            }
+        }
+        .confirmationDialog(
+            "File Already Exists",
+            isPresented: Binding(
+                get: { pendingConflict != nil },
+                set: { if !$0 { pendingConflict = nil } }
+            ),
+            presenting: pendingConflict
+        ) { pending in
+            Button("Replace", role: .destructive) {
+                begin(pending, policy: .replace)
+                pendingConflict = nil
+            }
+            Button("Keep Both") {
+                begin(pending, policy: .keepBoth)
+                pendingConflict = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingConflict = nil
+            }
+        } message: { pending in
+            Text("“\(pending.entry.name)” already exists in the destination.")
+        }
+        .alert(
+            "Transfer Failed",
+            isPresented: Binding(
+                get: { transfer.error != nil },
+                set: { if !$0 { transfer.error = nil } }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(transfer.error ?? "")
+        }
+    }
+
+    private var deviceBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "laptopcomputer")
+                .foregroundStyle(Theme.textTertiary)
+            Text("Local")
+                .font(.system(size: 12.5, weight: .medium))
+                .foregroundStyle(Theme.textSecondary)
+            Spacer()
+            Text("Transfer with")
+                .font(.system(size: 11.5))
+                .foregroundStyle(Theme.textTertiary)
+            Picker("", selection: $targetDeviceID) {
+                ForEach(model.devices) { device in
+                    Text(device.name).tag(device.id)
+                }
+            }
+            .labelsHidden()
+            .frame(maxWidth: 220)
+            .disabled(transfer.isTransferring)
+            Spacer()
+            Image(systemName: targetDevice.isLocal ? "laptopcomputer" : "network")
+                .foregroundStyle(Theme.deviceTint(targetDevice))
+            Text(targetDevice.name)
+                .font(.system(size: 12.5, weight: .medium))
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 42)
+    }
+
+    private var transferButtons: some View {
+        VStack(spacing: 10) {
+            Spacer()
+            Button {
+                prepare(.upload)
+            } label: {
+                Image(systemName: "arrow.right")
+                    .frame(width: 28, height: 24)
+            }
+            .buttonStyle(.bordered)
+            .help("Copy the selected local file to \(targetDevice.name)")
+            .disabled(!canUpload)
+
+            Button {
+                prepare(.download)
+            } label: {
+                Image(systemName: "arrow.left")
+                    .frame(width: 28, height: 24)
+            }
+            .buttonStyle(.bordered)
+            .help("Copy the selected file from \(targetDevice.name) to Local")
+            .disabled(!canDownload)
+            Spacer()
+        }
+        .padding(.horizontal, 8)
+        .frame(width: 58)
+        .background(Theme.statusBarBackground.opacity(0.55))
+        .overlay(
+            HStack {
+                Rectangle().fill(Theme.hairline).frame(width: 1)
+                Spacer()
+                Rectangle().fill(Theme.hairline).frame(width: 1)
+            }
+        )
+    }
+
+    private var transferBar: some View {
+        HStack(spacing: 10) {
+            ProgressView(value: transfer.progress?.fractionCompleted ?? 0)
+                .frame(maxWidth: 180)
+            Text(transfer.label)
+                .font(.system(size: 11.5))
+                .foregroundStyle(Theme.textSecondary)
+                .lineLimit(1)
+            Spacer()
+            if let progress = transfer.progress {
+                Text(
+                    ByteCountFormatter.string(
+                        fromByteCount: progress.completedBytes,
+                        countStyle: .file
+                    )
+                )
+                .font(.system(size: 11, design: .monospaced))
+                .foregroundStyle(Theme.textTertiary)
+            }
+            Button("Cancel") { transfer.cancel() }
+                .controlSize(.small)
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 36)
+        .background(Theme.statusBarBackground)
+    }
+
+    private var canUpload: Bool {
+        !transfer.isTransferring && local.selectedEntry?.kind == .regularFile
+    }
+
+    private var canDownload: Bool {
+        !transfer.isTransferring && target.selectedEntry?.kind == .regularFile
+    }
+
+    private func preferredTargetDeviceID() -> UUID {
+        if let filtered = model.deviceFilter, model.device(filtered) != nil { return filtered }
+        return model.devices.first(where: { !$0.isLocal })?.id
+            ?? model.devices.first?.id
+            ?? Device.local.id
+    }
+
+    private func prepare(_ direction: DeviceFileTransferModel.Direction) {
+        let entry = direction == .upload ? local.selectedEntry : target.selectedEntry
+        guard let entry else { return }
+        let destinationEntries = direction == .upload ? target.entries : local.entries
+        let pending = PendingFileTransfer(direction: direction, entry: entry)
+        if destinationEntries.contains(where: { $0.name == entry.name }) {
+            pendingConflict = pending
+        } else {
+            begin(pending, policy: .fail)
+        }
+    }
+
+    private func begin(_ pending: PendingFileTransfer, policy: FileConflictPolicy) {
+        transfer.start(
+            direction: pending.direction,
+            entry: pending.entry,
+            targetDevice: targetDevice,
+            localDirectory: local.currentPath,
+            targetDirectory: target.currentPath,
+            conflictPolicy: policy
+        ) {
+            switch pending.direction {
+            case .upload:
+                await target.refresh()
+            case .download:
+                await local.refresh()
+            }
+        }
+    }
+}
+
+private struct PendingFileTransfer: Identifiable {
+    let id = UUID()
+    let direction: DeviceFileTransferModel.Direction
+    let entry: DeviceFileEntry
+}
+
+private struct DeviceFilePane: View {
+    let title: String
+    let device: Device
+    @ObservedObject var browser: DeviceFileBrowserModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            paneHeader
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+            pathBar
+            columnHeader
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+            listing
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+            footer
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Theme.contentBackground)
+        .task(id: device.id) {
+            await browser.configure(for: device)
+        }
+    }
+
+    private var paneHeader: some View {
+        HStack(spacing: 7) {
+            Image(systemName: device.isLocal ? "laptopcomputer" : "network")
+                .font(.system(size: 11.5, weight: .semibold))
+                .foregroundStyle(Theme.deviceTint(device))
+            Text(title)
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundStyle(Theme.text)
+                .lineLimit(1)
+            Spacer()
+            if browser.isLoading {
+                ProgressView().controlSize(.small)
+            }
+            Button {
+                Task { await browser.toggleHidden() }
+            } label: {
+                Image(systemName: browser.includesHidden ? "eye" : "eye.slash")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Theme.textTertiary)
+            .help(browser.includesHidden ? "Hide hidden files" : "Show hidden files")
+            Button {
+                Task { await browser.refresh() }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(Theme.textTertiary)
+            .help("Refresh")
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 36)
+    }
+
+    private var pathBar: some View {
+        HStack(spacing: 6) {
+            Button {
+                Task { await browser.goUp() }
+            } label: {
+                Image(systemName: "chevron.up")
+            }
+            .buttonStyle(.plain)
+            .disabled(browser.currentPath == "/")
+            .help("Parent folder")
+
+            Button {
+                Task { await browser.goHome() }
+            } label: {
+                Image(systemName: "house")
+            }
+            .buttonStyle(.plain)
+            .help("Home folder")
+
+            TextField("Path", text: $browser.pathText)
+                .textFieldStyle(.roundedBorder)
+                .font(.system(size: 11.5, design: .monospaced))
+                .onSubmit {
+                    Task { await browser.navigate(to: browser.pathText) }
+                }
+
+            if device.isLocal {
+                Button {
+                    chooseLocalFolder()
+                } label: {
+                    Image(systemName: "folder")
+                }
+                .buttonStyle(.plain)
+                .help("Choose folder")
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 42)
+    }
+
+    private var columnHeader: some View {
+        HStack(spacing: 8) {
+            Text("Name")
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Text("Size")
+                .frame(width: 72, alignment: .trailing)
+            Text("Modified")
+                .frame(width: 126, alignment: .leading)
+        }
+        .font(.system(size: 10.5, weight: .medium))
+        .foregroundStyle(Theme.textTertiary)
+        .padding(.horizontal, 12)
+        .frame(height: 25)
+        .background(Theme.statusBarBackground.opacity(0.7))
+    }
+
+    private var listing: some View {
+        ScrollView {
+            LazyVStack(spacing: 1) {
+                ForEach(browser.entries) { entry in
+                    Button {
+                        Task { await browser.open(entry) }
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: icon(for: entry))
+                                .font(.system(size: 11.5))
+                                .foregroundStyle(
+                                    entry.kind == .directory ? Theme.accent : Theme.textTertiary
+                                )
+                                .frame(width: 16)
+                            Text(entry.name)
+                                .font(.system(size: 12.5))
+                                .foregroundStyle(Theme.text)
+                                .lineLimit(1)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            Text(size(for: entry))
+                                .font(.system(size: 10.5, design: .monospaced))
+                                .foregroundStyle(Theme.textTertiary)
+                                .frame(width: 72, alignment: .trailing)
+                            Text(modified(for: entry))
+                                .font(.system(size: 10.5))
+                                .foregroundStyle(Theme.textTertiary)
+                                .frame(width: 126, alignment: .leading)
+                        }
+                        .padding(.horizontal, 12)
+                        .frame(height: 28)
+                        .contentShape(Rectangle())
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(
+                                    browser.selectedPath == entry.path
+                                        ? Theme.accentWash
+                                        : Color.clear
+                                )
+                        )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(4)
+        }
+        .overlay {
+            if browser.entries.isEmpty, !browser.isLoading, browser.error == nil {
+                ContentUnavailableView(
+                    "Empty Folder",
+                    systemImage: "folder",
+                    description: Text("This folder contains no visible items.")
+                )
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            if let error = browser.error {
+                Image(systemName: "exclamationmark.triangle")
+                    .foregroundStyle(Theme.warning)
+                Text(error)
+                    .lineLimit(1)
+                    .help(error)
+            } else {
+                Text("\(browser.entries.count) items")
+            }
+            Spacer()
+            if let selected = browser.selectedEntry {
+                Text(selected.name)
+                    .lineLimit(1)
+            }
+        }
+        .font(.system(size: 10.5))
+        .foregroundStyle(Theme.textTertiary)
+        .padding(.horizontal, 10)
+        .frame(height: 28)
+        .background(Theme.statusBarBackground.opacity(0.7))
+    }
+
+    private func icon(for entry: DeviceFileEntry) -> String {
+        switch entry.kind {
+        case .directory: return entry.isPackage ? "shippingbox" : "folder"
+        case .regularFile: return "doc"
+        case .symbolicLink: return "link"
+        case .other: return "questionmark.square"
+        }
+    }
+
+    private func size(for entry: DeviceFileEntry) -> String {
+        guard let size = entry.size else { return "—" }
+        return ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+    }
+
+    private func modified(for entry: DeviceFileEntry) -> String {
+        guard let date = entry.modificationDate else { return "—" }
+        return date.formatted(date: .abbreviated, time: .shortened)
+    }
+
+    private func chooseLocalFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = URL(fileURLWithPath: browser.currentPath, isDirectory: true)
+        if panel.runModal() == .OK, let url = panel.url {
+            Task { await browser.navigate(to: url.path) }
+        }
+    }
+}

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -51,6 +51,9 @@ struct SidebarView: View {
                 actionRow(icon: "terminal", label: "New Terminal") {
                     model.newShellSession()
                 }
+                actionRow(icon: "folder", label: "Files") {
+                    model.openFileManager()
+                }
                 actionRow(icon: "magnifyingglass", label: "Search") {
                     model.showSearch = true
                 }
@@ -237,10 +240,11 @@ struct SidebarView: View {
 
     private func agentRow(_ entry: AppModel.AgentEntry) -> some View {
         let agent = entry.agent
-        let selected = model.selectedPane == entry.ref && model.selectedShellID == nil
+        let selected = !model.isFileManagerActive
+            && model.selectedPane == entry.ref
+            && model.selectedShellID == nil
         return Button {
-            model.selectedPane = entry.ref
-            model.selectedShellID = nil
+            model.selectAgent(entry.ref)
         } label: {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
@@ -279,7 +283,7 @@ struct SidebarView: View {
     }
 
     private func shellRow(_ session: ShellSession) -> some View {
-        let selected = model.selectedShellID == session.id
+        let selected = !model.isFileManagerActive && model.selectedShellID == session.id
         return Button {
             model.selectShell(session.id)
         } label: {


### PR DESCRIPTION
## Summary
- add a dedicated two-pane Files workspace for Local and configured SSH devices
- browse macOS/Linux directories with hidden-file controls, typed paths, and native local folder selection
- upload and download regular files with progress, cancellation, atomic `.part` staging, and Replace / Keep Both conflicts
- reuse the existing OpenSSH config, agent, known-hosts, and Keychain askpass flow; no additional SSH dependency

## Tests
- `swift test` (108 tests, 5 skipped, 0 failures)
- `swift test --filter DeviceFileServiceTests` (8 tests, 0 failures)
- Debug app build with ad-hoc signing (official main requires the release Developer ID certificate)