### PR TITLE
fix(ssh): preserve environment for remote attaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Fixed
+- Remote terminal attaches now inherit the captured shell environment, so
+  OpenSSH keeps the user's `PATH` and `SSH_AUTH_SOCK` when evaluating SSH
+  configuration and agent-backed identities.
+
 ## [0.5.1] - 2026-08-27
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -580,6 +580,13 @@ public actor HerdrService {
                 + "exec \"$hb\" agent attach '\(paneID)' --takeover"
             let remote = "exec /bin/sh -c \(Self.shellQuoted(script))"
             let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
+            var environment = (ShellEnvironment.cached ?? .empty).launchEnvironment(binary: nil)
+            environment.merge(authentication.environment) { _, authenticationValue in
+                authenticationValue
+            }
+            environment.removeValue(forKey: "TERM")
+            environment.removeValue(forKey: "COLUMNS")
+            environment.removeValue(forKey: "LINES")
             return AttachCommand(
                 executable: "/usr/bin/ssh",
                 args: ["-tt"] + authentication.arguments + [
@@ -592,7 +599,7 @@ public actor HerdrService {
                     "-o", "ServerAliveCountMax=3",
                     SSHTunnel.sshDestination(target), remote,
                 ],
-                environment: authentication.environment,
+                environment: environment,
                 authorizationID: authentication.authorizationID
             )
         }

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
@@ -137,6 +137,21 @@ final class AttachBinarySelectionTests: XCTestCase {
         // The whole script must run under sh on the far side, not the login shell.
         XCTAssertTrue(remote.args.last?.hasPrefix("exec /bin/sh -c '") == true)
         XCTAssertTrue(remote.args.last?.contains("export PATH=") == true)
+        XCTAssertEqual(
+            remote.environment["HOME"],
+            ProcessInfo.processInfo.environment["HOME"],
+            "remote attach must inherit the local environment used by OpenSSH"
+        )
+        XCTAssertTrue(
+            remote.environment["PATH"]?.contains("/opt/homebrew/bin") == true,
+            "remote attach must expose Match exec helpers installed by Homebrew"
+        )
+        if let agentSocket = ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"] {
+            XCTAssertEqual(
+                remote.environment["SSH_AUTH_SOCK"], agentSocket,
+                "remote attach must preserve access to the caller's SSH agent"
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- seed remote terminal attaches from the captured shell launch environment
- overlay authentication and Keychain/askpass variables with authentication values taking precedence
- leave `TERM`, `COLUMNS`, and `LINES` under SwiftTerm control
- add regression coverage for `HOME`, Homebrew `PATH`, and `SSH_AUTH_SOCK`

## Root cause

The long-lived SSH tunnel and the terminal pane use separate child processes. SwiftTerm launched the pane's `ssh -tt` process with a sparse environment, so OpenSSH `Match exec` helpers could not find Homebrew tools and agent-backed identities lost `SSH_AUTH_SOCK`. This ended in `Permission denied (publickey)` even while the device tunnel remained healthy.

## Minimum live reproduction

1. Configure any SSH host whose private key is available only through `ssh-agent`.
2. Confirm `ssh user@host` works from a normal Terminal session.
3. Launch Herdrm normally from Finder.
4. Add the same host as an SSH device and connect.
5. Open or attach to a remote pane.

On upstream `main`, the persistent device tunnel connects, but the pane's separate `ssh -tt` process exits with `Permission denied (publickey)` because it cannot access the agent socket.

## Verification

- focused environment regression test passes
- full HerdrKit suite passes: 101 tests passed; 5 optional remote E2E tests skipped because their environment variables were unset
- Debug macOS build succeeds with ad-hoc signing
- installed Debug app verified against the affected remote device: both the `ssh -N` tunnel and `ssh -tt` terminal attach remain connected
- `git diff --check` passes

## Related work

#54 also changes `HerdrService.swift` while adding standalone SSH sessions. If it lands first, this patch may need a small rebase or adaptation.




## Authorship

Created by OpenAI Codex and reviewed by @OnkayC.
