### PR TITLE
Add persistent terminal panes across local and SSH devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Added
+- Bare Herdr shell panes now appear alongside agents and can be attached on
+  local or SSH devices. **New Terminal** creates a persistent shell tab in a
+  chosen device and space instead of an app-owned local-only process. (#57)
+
 ## [0.5.1] - 2026-08-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,8 +52,9 @@ auto-bumped after each release.
   `pane.agent_status_changed` / `pane.scroll_changed` / `pane.output_matched` are
   pane-scoped (require `pane_id`) and cannot be subscribed globally — status changes
   arrive globally as `pane.updated`. Full global kind list: `HerdrEvent.allKinds`.
-- Terminal attach: `herdr agent attach <pane_id> --takeover` (takes the pane over from
-  other attached clients). Remote devices run it through `ssh -tt` with PATH prepended
+- Terminal attach: agents use `herdr agent attach <pane_id> --takeover`; bare shells use
+  `herdr terminal attach <terminal_id> --takeover` (takes the pane over from other attached
+  clients). Remote devices run it through `ssh -tt` with PATH prepended
   (`sshd` exec is not a login shell; herdr lives in `/opt/homebrew/bin` on macOS hosts).
 - Agent status buckets sort Blocked > Done > Working > Idle (matches Heeler).
 

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -552,7 +552,17 @@ public actor HerdrService {
     /// `serverVersion` (from the device's last successful ping) lets the attach
     /// pick a herdr binary whose protocol matches the server's — see
     /// `attachBinarySelection`.
-    public nonisolated func attachCommand(paneID: String, serverVersion: String? = nil) -> AttachCommand {
+    public nonisolated func attachCommand(
+        target: TerminalAttachTarget,
+        serverVersion: String? = nil
+    ) -> AttachCommand {
+        let attachArguments: String
+        switch target {
+        case .agent(let paneID):
+            attachArguments = "agent attach \(Self.shellQuoted(paneID)) --takeover"
+        case .terminal(let terminalID):
+            attachArguments = "terminal attach \(Self.shellQuoted(terminalID)) --takeover"
+        }
         switch device.kind {
         case .local:
             // Same PATH we used to discover `herdr`: login-shell snapshot, GUI
@@ -564,7 +574,7 @@ public actor HerdrService {
             environment.removeValue(forKey: "COLUMNS")
             environment.removeValue(forKey: "LINES")
             let script = "\(Self.attachBinarySelection(serverVersion: serverVersion)); "
-                + "exec \"$hb\" agent attach '\(paneID)' --takeover"
+                + "exec \"$hb\" \(attachArguments)"
             return AttachCommand(
                 executable: "/bin/sh",
                 args: ["-c", script],
@@ -577,7 +587,7 @@ public actor HerdrService {
             // runs in the user's login shell, and the script's sh syntax must
             // not depend on it.
             let script = "\(SSHTunnel.remotePathExport); \(Self.attachBinarySelection(serverVersion: serverVersion)); "
-                + "exec \"$hb\" agent attach '\(paneID)' --takeover"
+                + "exec \"$hb\" \(attachArguments)"
             let remote = "exec /bin/sh -c \(Self.shellQuoted(script))"
             let authentication = SSHTunnel.authenticationConfiguration(for: device.id)
             return AttachCommand(
@@ -597,6 +607,16 @@ public actor HerdrService {
             )
         }
     }
+
+    /// Compatibility convenience for agent callers.
+    public nonisolated func attachCommand(paneID: String, serverVersion: String? = nil) -> AttachCommand {
+        attachCommand(target: .agent(paneID: paneID), serverVersion: serverVersion)
+    }
+}
+
+public enum TerminalAttachTarget: Sendable, Equatable {
+    case agent(paneID: String)
+    case terminal(terminalID: String)
 }
 
 public struct AttachCommand: Sendable {

--- a/Packages/HerdrKit/Sources/HerdrKit/Models.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/Models.swift
@@ -155,6 +155,7 @@ public struct WorkspaceInfo: Codable, Sendable, Identifiable, Equatable {
 /// Any pane in the session, agent or bare shell.
 public struct PaneInfo: Codable, Sendable, Identifiable, Equatable {
     public let paneID: String
+    public let terminalID: String?
     public let workspaceID: String
     public let tabID: String?
     public let agentKindRaw: String?
@@ -168,6 +169,7 @@ public struct PaneInfo: Codable, Sendable, Identifiable, Equatable {
 
     enum CodingKeys: String, CodingKey {
         case paneID = "pane_id"
+        case terminalID = "terminal_id"
         case workspaceID = "workspace_id"
         case tabID = "tab_id"
         case agentKindRaw = "agent"
@@ -178,19 +180,53 @@ public struct PaneInfo: Codable, Sendable, Identifiable, Equatable {
     }
 }
 
+/// A tab in a workspace. Snapshot tabs provide the user-facing label for panes
+/// whose terminal application has not published an OSC title.
+public struct TabInfo: Codable, Sendable, Identifiable, Equatable {
+    public let tabID: String
+    public let workspaceID: String
+    public let number: Int?
+    public let label: String
+    public let focused: Bool?
+    public let paneCount: Int?
+
+    public var id: String { tabID }
+
+    enum CodingKeys: String, CodingKey {
+        case tabID = "tab_id"
+        case workspaceID = "workspace_id"
+        case number
+        case label
+        case focused
+        case paneCount = "pane_count"
+    }
+}
+
 public struct SessionSnapshot: Codable, Sendable, Equatable {
     public let agents: [AgentInfo]
     public let workspaces: [WorkspaceInfo]
     public let panes: [PaneInfo]?
+    public let tabs: [TabInfo]?
     public let focusedPaneID: String?
     public let focusedWorkspaceID: String?
     public let version: String?
     public let protocolVersion: Int?
 
+    /// Server-owned panes that are attachable as ordinary terminals. Agent panes
+    /// are excluded by the authoritative agent list so the UI never shows one in
+    /// both sections while detection metadata is changing.
+    public var ordinaryTerminalPanes: [PaneInfo] {
+        let agentPaneIDs = Set(agents.map(\.paneID))
+        return (panes ?? []).filter {
+            $0.terminalID != nil && !agentPaneIDs.contains($0.paneID)
+        }
+    }
+
     enum CodingKeys: String, CodingKey {
         case agents
         case workspaces
         case panes
+        case tabs
         case focusedPaneID = "focused_pane_id"
         case focusedWorkspaceID = "focused_workspace_id"
         case version

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
@@ -36,6 +36,9 @@ final class LocalSocketTests: XCTestCase {
         // snapshot and dedicated list endpoints must agree
         XCTAssertEqual(Set(snapshot.agents.map(\.paneID)), Set(agents.map(\.paneID)))
         XCTAssertEqual(Set(snapshot.workspaces.map(\.workspaceID)), Set(workspaces.map(\.workspaceID)))
+        for pane in snapshot.panes ?? [] {
+            XCTAssertNotNil(pane.terminalID, "pane \(pane.paneID) has no attachable terminal id")
+        }
         XCTAssertFalse(manifests.isEmpty, "server advertised no agent manifests")
         _ = AgentAttachmentCapabilityRegistry(manifests: manifests)
         // every agent belongs to a listed workspace

--- a/Packages/HerdrKit/Tests/HerdrKitTests/RemoteSSHTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/RemoteSSHTests.swift
@@ -35,6 +35,10 @@ final class RemoteSSHTests: XCTestCase {
             after.workspaces.count >= snapshot.workspaces.count,
             "workspace count went backwards after tab.create"
         )
+        XCTAssertNotNil(
+            after.panes?.first(where: { $0.paneID == paneID })?.terminalID,
+            "created remote pane has no attachable terminal id"
+        )
         try await service.closePane(paneID: paneID)
         await service.disconnect()
     }

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
@@ -138,6 +138,20 @@ final class AttachBinarySelectionTests: XCTestCase {
         XCTAssertTrue(remote.args.last?.hasPrefix("exec /bin/sh -c '") == true)
         XCTAssertTrue(remote.args.last?.contains("export PATH=") == true)
     }
+
+    func testOrdinaryTerminalAttachCommandsUseTerminalIDLocallyAndRemotely() {
+        let local = HerdrService(device: Device(name: "L", kind: .local), localServer: nil)
+            .attachCommand(target: .terminal(terminalID: "term_abc123"), serverVersion: "0.8.2")
+        XCTAssertTrue(
+            local.args.last?.contains("exec \"$hb\" terminal attach 'term_abc123' --takeover") == true
+        )
+
+        let remote = HerdrService(device: Device(name: "R", kind: .ssh(target: "u@h")), localServer: nil)
+            .attachCommand(target: .terminal(terminalID: "term_abc123"), serverVersion: "0.8.2")
+        XCTAssertEqual(remote.executable, "/usr/bin/ssh")
+        XCTAssertTrue(remote.args.last?.contains("terminal attach") == true)
+        XCTAssertTrue(remote.args.last?.contains("term_abc123") == true)
+    }
 }
 
 final class SSHFileTransferTests: XCTestCase {

--- a/Packages/HerdrKit/Tests/HerdrKitTests/TerminalSnapshotTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/TerminalSnapshotTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import XCTest
+@testable import HerdrKit
+
+final class TerminalSnapshotTests: XCTestCase {
+    func testSnapshotDecodesPaneTerminalIDsAndTabLabels() throws {
+        let data = Data(#"""
+        {
+          "agents": [],
+          "workspaces": [],
+          "panes": [{
+            "pane_id": "w7:p1",
+            "terminal_id": "term_abc123",
+            "workspace_id": "w7",
+            "tab_id": "w7:t1",
+            "agent_status": "unknown",
+            "cwd": "/tmp/project",
+            "revision": 3
+          }],
+          "tabs": [{
+            "tab_id": "w7:t1",
+            "workspace_id": "w7",
+            "number": 1,
+            "label": "server",
+            "focused": true,
+            "pane_count": 1
+          }],
+          "focused_pane_id": "w7:p1",
+          "focused_workspace_id": "w7",
+          "version": "0.8.2",
+          "protocol": 20
+        }
+        """#.utf8)
+
+        let snapshot = try JSONDecoder().decode(SessionSnapshot.self, from: data)
+        XCTAssertEqual(snapshot.panes?.first?.terminalID, "term_abc123")
+        XCTAssertEqual(snapshot.tabs?.first?.label, "server")
+        XCTAssertEqual(snapshot.tabs?.first?.workspaceID, "w7")
+    }
+
+    func testOlderSnapshotWithoutPanesOrTabsStillDecodes() throws {
+        let data = Data(#"{"agents":[],"workspaces":[],"protocol":17,"version":"0.7.4"}"#.utf8)
+        let snapshot = try JSONDecoder().decode(SessionSnapshot.self, from: data)
+        XCTAssertNil(snapshot.panes)
+        XCTAssertNil(snapshot.tabs)
+    }
+
+    func testOrdinaryTerminalPanesExcludeAgentPanes() throws {
+        let data = Data(#"""
+        {
+          "agents": [{
+            "agent": "codex",
+            "agent_status": "working",
+            "workspace_id": "w1",
+            "tab_id": "w1:t1",
+            "pane_id": "w1:p1"
+          }],
+          "workspaces": [],
+          "panes": [
+            {"pane_id":"w1:p1","terminal_id":"term_agent","workspace_id":"w1"},
+            {"pane_id":"w1:p2","terminal_id":"term_shell","workspace_id":"w1"}
+          ]
+        }
+        """#.utf8)
+
+        let snapshot = try JSONDecoder().decode(SessionSnapshot.self, from: data)
+        XCTAssertEqual(snapshot.ordinaryTerminalPanes.map(\.paneID), ["w1:p2"])
+    }
+}

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ macOS window on top of it, and it's grown well past "attach to a terminal":
 | | |
 |---|---|
 | 🖥️ **Every device** | Local + remote over SSH — keys, Tailscale, or a Keychain password — with auto-reconnect |
-| 🧭 **Live status** | Spaces & Agents sorted by urgency: blocked → done → working → idle |
+| 🧭 **Live status** | Spaces, Agents & Terminals across every connected device |
 | ⌨️ **Real terminal** | Full PTY attach, not a chat wrapper — native selection, legible fonts, resilient sessions |
 | 📎 **Paste anything** | Files and images land straight in the agent's pane, locally or over SSH |
 | 🔔 **Notifications** | A system alert the moment an agent needs you — click it to jump right there |
@@ -63,19 +63,21 @@ macOS window on top of it, and it's grown well past "attach to a terminal":
   `AllowStreamLocalForwarding`, or *why* a disconnected device is unreachable — never a bare
   "not connected".
 
-### Spaces & Agents, always current
-- **Spaces & Agents sidebar** — every workspace and agent (claude, codex, gemini, grok,
-  opencode, …), same canonical order the ⌘K palette uses.
-- **New Agent / New Space** — locally the picker only lists advertised CLIs found on the
+### Spaces, Agents & Terminals, always current
+- **Spaces, Agents & Terminals sidebar** — every workspace, coding agent (claude, codex,
+  gemini, grok, opencode, …), and ordinary Herdr shell pane, across local and SSH devices.
+- **New Agent / New Terminal / New Space** — New Terminal creates a persistent shell tab in
+  any device and space. Locally the agent picker only lists advertised CLIs found on the
   login-shell PATH (captured once from a real interactive + login shell, not by grepping rc
   files or trusting LaunchServices); SSH devices follow the remote server's manifest catalog
   and validate on start. Each agent's bypass-permissions flag is on by default. **⌘N** for a
-  new agent, **⇧⌘N** for a new space. New Space includes an inline directory browser that
+  new agent, **⌘T** for a new terminal, **⇧⌘N** for a new space. New Space includes an inline directory browser that
   works over SSH. Settings → Agents accepts a per-kind binary path when detection is wrong.
 - Spaces rename straight from the sidebar's context menu.
 
 ### A real terminal, not a chat wrapper
-- **Live terminal** — attaches directly to the agent's PTY (`herdr agent attach`); grabs
+- **Live terminal** — attaches directly to an agent or shell PTY (`herdr agent attach` /
+  `herdr terminal attach`); grabs
   keyboard focus the moment you jump in from ⌘K, the sidebar, or a notification.
 - **Native text selection** — drag to select, no Shift needed; right-click for Copy/Paste/Select
   All plus link actions (⌘-click opens a URL).

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2705,6 +2705,166 @@
         }
       }
     },
+    "Close Terminal…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close Terminal…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "关闭终端…"
+          }
+        }
+      }
+    },
+    "Create a space on this device before opening a terminal." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Create a space on this device before opening a terminal."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "请先在此设备上创建空间，然后再打开终端。"
+          }
+        }
+      }
+    },
+    "Creates a persistent shell in %@ on %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Creates a persistent shell in %@ on %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 %@（%@）中创建持久 Shell"
+          }
+        }
+      }
+    },
+    "No agents or terminals in this space yet" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No agents or terminals in this space yet"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此空间还没有 Agent 或终端"
+          }
+        }
+      }
+    },
+    "No terminal selected" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No terminal selected"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未选择终端"
+          }
+        }
+      }
+    },
+    "Open Terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Terminal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "打开终端"
+          }
+        }
+      }
+    },
+    "Search agents, terminals, and spaces…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search agents, terminals, and spaces…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "搜索 Agent、终端和空间…"
+          }
+        }
+      }
+    },
+    "Select an agent or terminal, or start a new one" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select an agent or terminal, or start a new one"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "选择 Agent 或终端，或新建一个"
+          }
+        }
+      }
+    },
+    "Terminal · %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal · %@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端 · %@"
+          }
+        }
+      }
+    },
+    "a Herdr space" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "a Herdr space"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "一个 Herdr 空间"
+          }
+        }
+      }
+    },
     "The remote file transfer service is unavailable." : {
       "localizations" : {
         "en" : {

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -45,6 +45,7 @@ struct DeviceSessionState {
     var agents: [AgentInfo] = []
     var workspaces: [WorkspaceInfo] = []
     var panes: [PaneInfo] = []
+    var tabs: [TabInfo] = []
     var agentCatalog: AgentCatalogState = .loading
     var attachmentCapabilities = AgentAttachmentCapabilityRegistry()
 }
@@ -60,15 +61,8 @@ struct SSHAuthenticationRequest: Identifiable {
 enum SplitAxis { case vertical, horizontal }
 
 /// Identifies one of the two panes in the ⌘D split. Used for focus tracking and
-/// keyboard-driven resize; standalone `ShellSession`s are not part of this.
+/// keyboard-driven resize.
 enum SplitSide { case agent, shell }
-
-/// A standalone local shell shown as its own sidebar entry — not a herdr pane
-/// (herdr refuses to attach agent-less panes) and not the ⌘D split.
-struct ShellSession: Identifiable, Equatable {
-    let id: UUID
-    var title: String
-}
 
 /// Per-kind CLI path overrides persisted in user defaults. Empty means automatic
 /// lookup on the login-shell search PATH. Invalid paths hide that kind until
@@ -117,6 +111,7 @@ final class AppModel: ObservableObject {
 
     @Published var showAddDevice = false
     @Published var showNewAgent = false
+    @Published var showNewTerminal = false
     @Published var showNewSpace = false
     @Published var showSearch = false
     @Published var shellSplitAxis: SplitAxis?
@@ -136,10 +131,6 @@ final class AppModel: ObservableObject {
     /// Held weakly so the views are not kept alive by the model.
     weak var splitAgentView: LocalProcessTerminalView?
     weak var splitShellView: LocalProcessTerminalView?
-    /// Standalone local terminals. Their views stay alive while deselected —
-    /// unlike agents, a local shell has no server side to reattach to.
-    @Published var shellSessions: [ShellSession] = []
-    @Published var selectedShellID: UUID?
     /// In-window device panel (NSPopover crashes in ViewBridge on macOS 26+ betas).
     @Published var showDevicePanel = false
     @Published var deviceToEdit: Device?
@@ -229,6 +220,71 @@ final class AppModel: ObservableObject {
         var ref: PaneRef { PaneRef(deviceID: device.id, paneID: agent.paneID) }
     }
 
+    struct TerminalEntry: Identifiable {
+        let device: Device
+        let pane: PaneInfo
+        let tab: TabInfo?
+        let terminalID: String
+
+        var id: String { "\(device.id.uuidString)-\(pane.paneID)" }
+        var ref: PaneRef { PaneRef(deviceID: device.id, paneID: pane.paneID) }
+
+        var title: String {
+            if let terminalTitle = pane.terminalTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !terminalTitle.isEmpty {
+                return terminalTitle
+            }
+            if let tab, !tab.label.isEmpty, tab.label != (tab.number.map(String.init) ?? "") {
+                return tab.label
+            }
+            if let cwd = pane.cwd, !cwd.isEmpty {
+                let basename = URL(fileURLWithPath: cwd).lastPathComponent
+                if !basename.isEmpty { return basename }
+            }
+            return String(localized: "Terminal")
+        }
+    }
+
+    enum AttachedEntry: Identifiable {
+        case agent(AgentEntry)
+        case terminal(TerminalEntry)
+
+        var id: String {
+            switch self {
+            case .agent(let entry): return "agent-\(entry.id)"
+            case .terminal(let entry): return "terminal-\(entry.id)"
+            }
+        }
+
+        var device: Device {
+            switch self {
+            case .agent(let entry): return entry.device
+            case .terminal(let entry): return entry.device
+            }
+        }
+
+        var ref: PaneRef {
+            switch self {
+            case .agent(let entry): return entry.ref
+            case .terminal(let entry): return entry.ref
+            }
+        }
+
+        var workspaceID: String {
+            switch self {
+            case .agent(let entry): return entry.agent.workspaceID
+            case .terminal(let entry): return entry.pane.workspaceID
+            }
+        }
+
+        var attachTarget: TerminalAttachTarget {
+            switch self {
+            case .agent(let entry): return .agent(paneID: entry.agent.paneID)
+            case .terminal(let entry): return .terminal(terminalID: entry.terminalID)
+            }
+        }
+    }
+
     struct SpaceEntry: Identifiable {
         let device: Device
         let workspace: WorkspaceInfo
@@ -261,6 +317,30 @@ final class AppModel: ObservableObject {
         }
     }
 
+    func terminalEntries(for device: Device) -> [TerminalEntry] {
+        let state = session(device.id)
+        let tabsByID = Dictionary(uniqueKeysWithValues: state.tabs.map { ($0.tabID, $0) })
+        return state.panes.compactMap { pane in
+            guard let terminalID = pane.terminalID else { return nil }
+            return TerminalEntry(
+                device: device,
+                pane: pane,
+                tab: pane.tabID.flatMap { tabsByID[$0] },
+                terminalID: terminalID
+            )
+        }
+    }
+
+    var visibleTerminals: [TerminalEntry] {
+        var entries = devicesInScope.flatMap { terminalEntries(for: $0) }
+        if let space = selectedSpace {
+            entries = entries.filter {
+                $0.device.id == space.deviceID && $0.pane.workspaceID == space.workspaceID
+            }
+        }
+        return entries
+    }
+
     var scopeAgentCount: Int {
         devicesInScope.reduce(0) { $0 + session($1.id).agents.count }
     }
@@ -270,6 +350,21 @@ final class AppModel: ObservableObject {
         guard let agent = session(selected.deviceID).agents.first(where: { $0.paneID == selected.paneID })
         else { return nil }
         return AgentEntry(device: device, agent: agent)
+    }
+
+    var selectedTerminalEntry: TerminalEntry? {
+        guard let selected = selectedPane, let device = device(selected.deviceID) else { return nil }
+        return terminalEntries(for: device).first { $0.pane.paneID == selected.paneID }
+    }
+
+    var selectedAttachedEntry: AttachedEntry? {
+        if let selectedEntry { return .agent(selectedEntry) }
+        if let selectedTerminalEntry { return .terminal(selectedTerminalEntry) }
+        return nil
+    }
+
+    private var firstVisiblePaneRef: PaneRef? {
+        visibleAgents.first?.ref ?? visibleTerminals.first?.ref
     }
 
     func agentCount(in entry: SpaceEntry) -> Int {
@@ -298,12 +393,11 @@ final class AppModel: ObservableObject {
 
     func selectSpace(_ ref: SpaceRef?) {
         selectedSpace = ref
-        selectedShellID = nil
-        if let entry = selectedEntry {
+        if let entry = selectedAttachedEntry {
             if ref == nil { return }
-            if entry.device.id == ref!.deviceID && entry.agent.workspaceID == ref!.workspaceID { return }
+            if entry.device.id == ref!.deviceID && entry.workspaceID == ref!.workspaceID { return }
         }
-        selectedPane = visibleAgents.first?.ref
+        selectedPane = firstVisiblePaneRef
     }
 
     func setDeviceFilter(_ id: UUID?) {
@@ -311,8 +405,8 @@ final class AppModel: ObservableObject {
         if let id, let space = selectedSpace, space.deviceID != id {
             selectedSpace = nil
         }
-        if let id, let entry = selectedEntry, entry.device.id != id {
-            selectedPane = visibleAgents.first?.ref
+        if let id, let selected = selectedPane, selected.deviceID != id {
+            selectedPane = firstVisiblePaneRef
         }
     }
 
@@ -328,7 +422,6 @@ final class AppModel: ObservableObject {
         }
         selectedSpace = nil
         selectedPane = ref
-        selectedShellID = nil
         // Only the search sheet needs the deferred request: its dismissal restores the
         // parent window's previous responder after the view tree has asked for focus.
         // `showSearch` is still true here — SearchView calls this before dismissing.
@@ -339,33 +432,6 @@ final class AppModel: ObservableObject {
         // the shell. Those clicks get focus from the recreated attach and from the
         // entry-change request instead.
         if shellSplitAxis != nil, showSearch { pendingSplitAgentFocus = true }
-    }
-
-    // MARK: - Shell terminals
-
-    var selectedShell: ShellSession? {
-        selectedShellID.flatMap { id in shellSessions.first { $0.id == id } }
-    }
-
-    /// Every click opens another terminal, like New Agent opens another agent.
-    func newShellSession() {
-        let n = shellSessions.count + 1
-        let session = ShellSession(id: UUID(), title: String(localized: "Terminal \(n)"))
-        shellSessions.append(session)
-        selectShell(session.id)
-    }
-
-    func selectShell(_ id: UUID) {
-        selectedShellID = id
-        ShellViewRegistry.focus(id)
-    }
-
-    func closeShellSession(_ id: UUID) {
-        shellSessions.removeAll { $0.id == id }
-        if selectedShellID == id {
-            selectedShellID = shellSessions.last?.id
-            if let remaining = selectedShellID { ShellViewRegistry.focus(remaining) }
-        }
     }
 
     // MARK: - Lifecycle
@@ -566,7 +632,7 @@ final class AppModel: ObservableObject {
         store.save(devices)
         if deviceFilter == device.id { deviceFilter = nil }
         if selectedSpace?.deviceID == device.id { selectedSpace = nil }
-        if selectedPane?.deviceID == device.id { selectedPane = visibleAgents.first?.ref }
+        if selectedPane?.deviceID == device.id { selectedPane = firstVisiblePaneRef }
     }
 
     // MARK: - Refresh
@@ -586,9 +652,12 @@ final class AppModel: ObservableObject {
             )
             sessions[deviceID]?.agents = snapshot.agents
             sessions[deviceID]?.workspaces = snapshot.workspaces
-            sessions[deviceID]?.panes = snapshot.panes ?? []
+            sessions[deviceID]?.panes = snapshot.ordinaryTerminalPanes
+            sessions[deviceID]?.tabs = snapshot.tabs ?? []
+            let paneIDs = Set((snapshot.panes ?? []).map(\.paneID))
+                .union(snapshot.agents.map(\.paneID))
             if let selected = selectedPane, selected.deviceID == deviceID,
-               !snapshot.agents.contains(where: { $0.paneID == selected.paneID }) {
+               !paneIDs.contains(selected.paneID) {
                 selectedPane = nil
             }
             if let space = selectedSpace, space.deviceID == deviceID,
@@ -596,7 +665,18 @@ final class AppModel: ObservableObject {
                 selectedSpace = nil
             }
             if selectedPane == nil {
-                selectedPane = visibleAgents.first?.ref
+                if let focusedPaneID = snapshot.focusedPaneID,
+                   paneIDs.contains(focusedPaneID),
+                   deviceFilter == nil || deviceFilter == deviceID {
+                    let focused = PaneRef(deviceID: deviceID, paneID: focusedPaneID)
+                    if selectedSpace == nil
+                        || selectedAttachedEntry.map({
+                            $0.ref == focused && $0.workspaceID == selectedSpace?.workspaceID
+                        }) == true {
+                        selectedPane = focused
+                    }
+                }
+                if selectedPane == nil { selectedPane = firstVisiblePaneRef }
             }
         } catch {
             sessions[deviceID]?.connection = .failed(error.localizedDescription)
@@ -817,6 +897,26 @@ final class AppModel: ObservableObject {
                 await refresh(device.id)
                 selectedSpace = SpaceRef(deviceID: device.id, workspaceID: created.workspaceID)
                 showNewAgent = true
+            } catch {
+                actionError = actionErrorMessage(error, device: device)
+            }
+        }
+    }
+
+    /// Creates a persistent shell tab on the selected Herdr device. Local and
+    /// remote terminals use the same server-owned lifecycle and can be detached
+    /// and reattached without killing the shell process.
+    func startNewTerminal(device: Device, workspaceID: String) {
+        Task {
+            do {
+                let paneID = try await service(for: device).createTab(
+                    workspaceID: workspaceID,
+                    cwd: nil,
+                    label: nil
+                )
+                await refresh(device.id)
+                selectedSpace = SpaceRef(deviceID: device.id, workspaceID: workspaceID)
+                selectedPane = PaneRef(deviceID: device.id, paneID: paneID)
             } catch {
                 actionError = actionErrorMessage(error, device: device)
             }

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -56,6 +56,7 @@ struct RootView: View {
         .onAppear { model.start() }
         .sheet(isPresented: $model.showAddDevice) { AddDeviceSheet(model: model) }
         .sheet(isPresented: $model.showNewAgent) { NewAgentSheet(model: model) }
+        .sheet(isPresented: $model.showNewTerminal) { NewTerminalSheet(model: model) }
         .sheet(isPresented: $model.showNewSpace) { NewSpaceSheet(model: model) }
         .sheet(item: $model.spaceToRename) { entry in RenameSpaceSheet(model: model, entry: entry) }
         .sheet(item: $model.agentToRename) { entry in RenameAgentSheet(model: model, entry: entry) }
@@ -119,7 +120,7 @@ struct DetailView: View {
                 // on teardown. Remove this and "split open with no agent selected"
                 // becomes reachable, which is a state a deferred focus request can be
                 // armed into with nothing left in the tree to consume it.
-                .onChange(of: model.selectedEntry?.id) { _, id in
+                .onChange(of: model.selectedAttachedEntry?.id) { _, id in
                     if id == nil { model.shellSplitAxis = nil }
                 }
         }
@@ -137,41 +138,51 @@ struct DetailView: View {
                     sidebarCollapsed = false
                 }
             }
-            if let shell = model.selectedShell {
-                Image(systemName: "terminal")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Theme.textTertiary)
-                Text(shell.title)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(Theme.text)
-                Text("Local")
-                    .font(.system(size: 11.5))
-                    .foregroundStyle(Theme.textTertiary)
-                Spacer()
-            } else if let entry = model.selectedEntry {
-                let agent = entry.agent
-                statusGlyph(agent.status)
-                Text(agent.title)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(Theme.text)
-                    .lineLimit(1)
-                    .layoutPriority(1)
-                    .help((agent.cwd as NSString?)?.abbreviatingWithTildeInPath ?? "")
-                Spacer(minLength: 12)
-                AgentKindBadge(kind: agent.agent)
-                Text("·")
-                    .font(.system(size: 11.5))
-                    .foregroundStyle(Theme.textGhost)
-                Text(model.spaceName(deviceID: entry.device.id, workspaceID: agent.workspaceID))
-                    .font(.system(size: 11.5))
-                    .foregroundStyle(Theme.textTertiary)
-                    .lineLimit(1)
-                if model.showsRowDeviceBadges {
-                    DeviceChip(device: entry.device)
+            if let attached = model.selectedAttachedEntry {
+                switch attached {
+                case .agent(let entry):
+                    let agent = entry.agent
+                    statusGlyph(agent.status)
+                    Text(agent.title)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(Theme.text)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+                        .help((agent.cwd as NSString?)?.abbreviatingWithTildeInPath ?? "")
+                    Spacer(minLength: 12)
+                    AgentKindBadge(kind: agent.agent)
+                    Text("·")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Theme.textGhost)
+                    Text(model.spaceName(deviceID: entry.device.id, workspaceID: agent.workspaceID))
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Theme.textTertiary)
+                        .lineLimit(1)
+                    if model.showsRowDeviceBadges {
+                        DeviceChip(device: entry.device)
+                    }
+                    statusPill(agent.status)
+                case .terminal(let entry):
+                    Image(systemName: "terminal")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Theme.textTertiary)
+                    Text(entry.title)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(Theme.text)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+                        .help((entry.pane.cwd as NSString?)?.abbreviatingWithTildeInPath ?? "")
+                    Spacer(minLength: 12)
+                    Text(model.spaceName(deviceID: entry.device.id, workspaceID: entry.pane.workspaceID))
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Theme.textTertiary)
+                        .lineLimit(1)
+                    if model.showsRowDeviceBadges {
+                        DeviceChip(device: entry.device)
+                    }
                 }
-                statusPill(agent.status)
             } else {
-                Text("No agent selected")
+                Text("No terminal selected")
                     .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(Theme.textTertiary)
                 Spacer()
@@ -239,36 +250,20 @@ struct DetailView: View {
 
     @ViewBuilder
     private var terminal: some View {
-        ZStack {
-            agentTerminal
-            // Standalone shells stay in the hierarchy while deselected: unlike a
-            // herdr pane, a local shell has no server side to reattach to, so
-            // tearing the view down would kill whatever is running in it.
-            ForEach(model.shellSessions) { session in
-                ShellTerminalView(
-                    sessionID: session.id,
-                    fontName: terminalFontName,
-                    fontSize: terminalFontSize,
-                    thinStrokes: terminalThinStrokes,
-                    fontWeight: terminalFontWeight,
-                    lineSpacing: terminalLineSpacing,
-                    dark: colorScheme == .dark,
-                    mouseReporting: terminalMouseReporting,
-                    onExit: { _ in model.closeShellSession(session.id) }
-                )
-                    .id("shell-\(session.id)")
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 8)
-                    .opacity(model.selectedShellID == session.id ? 1 : 0)
-                    .allowsHitTesting(model.selectedShellID == session.id)
-            }
-        }
+        attachedTerminal
         .background(Theme.terminalBackground)
     }
 
     @ViewBuilder
-    private var agentTerminal: some View {
-        if let entry = model.selectedEntry {
+    private var attachedTerminal: some View {
+        if let entry = model.selectedAttachedEntry {
+            let attachmentCapabilities: AgentAttachmentCapabilities? = {
+                guard case .agent(let agentEntry) = entry else { return nil }
+                return model.attachmentCapabilities(
+                    deviceID: agentEntry.device.id,
+                    agentKind: agentEntry.agent.agentKindRaw
+                )
+            }()
             SplitContainer(
                 axis: model.shellSplitAxis,
                 activeSide: model.activeSplitSide,
@@ -277,12 +272,9 @@ struct DetailView: View {
                 ZStack {
                     AttachTerminalView(
                         device: entry.device,
-                        paneID: entry.agent.paneID,
+                        target: entry.attachTarget,
                         serverVersion: model.serverVersion(deviceID: entry.device.id),
-                        attachmentCapabilities: model.attachmentCapabilities(
-                            deviceID: entry.device.id,
-                            agentKind: entry.agent.agentKindRaw
-                        ),
+                        attachmentCapabilities: attachmentCapabilities,
                         fontName: terminalFontName,
                         fontSize: terminalFontSize,
                         thinStrokes: terminalThinStrokes,
@@ -351,7 +343,7 @@ struct DetailView: View {
             // that follows the sheet's responder restore. Filtered to the terminal's own
             // window and consumed no matter which window it was, so a pending request can
             // never survive to a later, unrelated activation — coming back from ⌘Tab or
-            // closing Settings would otherwise yank the keyboard into a live agent.
+            // closing Settings would otherwise yank the keyboard into a live pane.
             .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { note in
                 guard model.pendingSplitAgentFocus else { return }
                 model.pendingSplitAgentFocus = false
@@ -372,7 +364,7 @@ struct DetailView: View {
             }
         } else {
             // The .onReceive below only exists on the branch above, so a request armed
-            // while no agent is selected would have no consumer and would be cashed in by
+            // while no pane is selected would have no consumer and would be cashed in by
             // some later activation. Revealing a pane that has since gone away lands here.
             VStack(spacing: 10) {
                 Image(systemName: "terminal")
@@ -401,7 +393,7 @@ struct DetailView: View {
 
     /// ssh exits 255 for transport failures; everything else is the far end closing
     /// (takeover by another client, the pane going away, herdr stopping).
-    private func attachEndedOverlay(_ entry: AppModel.AgentEntry) -> some View {
+    private func attachEndedOverlay(_ entry: AppModel.AttachedEntry) -> some View {
         let dropped = endedAttachCode == 255
         return VStack(spacing: 10) {
             Image(systemName: dropped ? "bolt.horizontal.circle" : "rectangle.slash")
@@ -450,10 +442,12 @@ struct DetailView: View {
         case .connecting: return String(localized: "Connecting…")
         case .failed(let reason): return reason
         default:
-            if model.selectedSpace != nil && model.visibleAgents.isEmpty {
-                return String(localized: "No agents in this space yet")
+            if model.selectedSpace != nil
+                && model.visibleAgents.isEmpty
+                && model.visibleTerminals.isEmpty {
+                return String(localized: "No agents or terminals in this space yet")
             }
-            return String(localized: "Select an agent, or start a new one")
+            return String(localized: "Select an agent or terminal, or start a new one")
         }
     }
 
@@ -867,6 +861,105 @@ struct DirectoryPickerField: View {
         var trimmed = path
         while trimmed.count > 1 && trimmed.hasSuffix("/") { trimmed.removeLast() }
         return trimmed
+    }
+}
+
+struct NewTerminalSheet: View {
+    @ObservedObject var model: AppModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var deviceID = Device.local.id
+    @State private var workspaceID = ""
+
+    private var chosenDevice: Device {
+        model.device(deviceID) ?? .local
+    }
+
+    private var spaces: [WorkspaceInfo] {
+        model.session(deviceID).workspaces
+    }
+
+    private var spaceLabel: String {
+        spaces.first { $0.workspaceID == workspaceID }?.label ?? String(localized: "a Herdr space")
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SheetHeader(
+                systemImage: "terminal",
+                title: String(localized: "New Terminal"),
+                subtitle: String(localized: "Creates a persistent shell in \(spaceLabel) on \(chosenDevice.name)")
+            )
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            VStack(alignment: .leading, spacing: 8) {
+                if model.showsDeviceBadges {
+                    SheetSectionLabel("DEVICE")
+                    Picker("", selection: $deviceID) {
+                        ForEach(model.devices) { device in
+                            Text(device.name).tag(device.id)
+                        }
+                    }
+                    .labelsHidden()
+                    .fixedSize()
+                    .onChange(of: deviceID) { _, _ in
+                        workspaceID = spaces.first?.workspaceID ?? ""
+                    }
+
+                    Spacer().frame(height: 8)
+                }
+
+                SheetSectionLabel("SPACE")
+                if spaces.isEmpty {
+                    Text("Create a space on this device before opening a terminal.")
+                        .font(.system(size: 12.5))
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(minHeight: 32)
+                } else {
+                    Picker("", selection: $workspaceID) {
+                        ForEach(spaces) { workspace in
+                            Text(workspace.label).tag(workspace.workspaceID)
+                        }
+                    }
+                    .labelsHidden()
+                    .fixedSize()
+                }
+            }
+            .padding(16)
+
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Open Terminal") {
+                    model.startNewTerminal(device: chosenDevice, workspaceID: workspaceID)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(!spaces.contains { $0.workspaceID == workspaceID })
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .frame(width: 420)
+        .onAppear {
+            deviceID = model.selectedSpace?.deviceID
+                ?? model.selectedAttachedEntry?.device.id
+                ?? model.deviceFilter
+                ?? model.devices.first?.id
+                ?? Device.local.id
+            let preferredSpace = model.selectedSpace?.deviceID == deviceID
+                ? model.selectedSpace?.workspaceID
+                : model.selectedAttachedEntry.flatMap {
+                    $0.device.id == deviceID ? $0.workspaceID : nil
+                }
+            workspaceID = preferredSpace.flatMap { preferred in
+                spaces.contains { $0.workspaceID == preferred } ? preferred : nil
+            } ?? spaces.first?.workspaceID ?? ""
+        }
     }
 }
 

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -92,6 +92,9 @@ struct HerdrMApp: App {
                 Button("New Agent") { focusedModel?.showNewAgent = true }
                     .keyboardShortcut("n", modifiers: .command)
                     .disabled(focusedModel == nil)
+                Button("New Terminal") { focusedModel?.showNewTerminal = true }
+                    .keyboardShortcut("t", modifiers: .command)
+                    .disabled(focusedModel == nil)
                 Button("New Space") { focusedModel?.showNewSpace = true }
                     .keyboardShortcut("n", modifiers: [.command, .shift])
                     .disabled(focusedModel == nil)
@@ -104,16 +107,16 @@ struct HerdrMApp: App {
             }
 
             CommandMenu("Terminal") {
-                // Guarded on selectedEntry, not just on the model: with the placeholder
+                // Guarded on selectedAttachedEntry, not just on the model: with the placeholder
                 // on screen there is no SplitContainer to render into, so a split would
                 // be invisible yet leave shellSplitAxis non-nil — and the next ⌘W would
                 // "close" that phantom instead of the window.
                 Button("Split Vertically") { focusedModel?.shellSplitAxis = .vertical }
                     .keyboardShortcut("d", modifiers: .command)
-                    .disabled(focusedModel?.selectedEntry == nil)
+                    .disabled(focusedModel?.selectedAttachedEntry == nil)
                 Button("Split Horizontally") { focusedModel?.shellSplitAxis = .horizontal }
                     .keyboardShortcut("d", modifiers: [.command, .shift])
-                    .disabled(focusedModel?.selectedEntry == nil)
+                    .disabled(focusedModel?.selectedAttachedEntry == nil)
 
                 Divider()
 
@@ -172,13 +175,11 @@ struct HerdrMApp: App {
                 .disabled(focusedSplitAxis != .horizontal)
             }
             CommandGroup(replacing: .saveItem) {
-                // ⌘W closes the most local thing first: the split, then the
-                // selected standalone terminal, then the window.
+                // ⌘W closes the most local thing first: the split, then the window.
+                // Server-owned panes close from their confirmed sidebar action.
                 Button(closeButtonTitle) {
                     if let model = focusedModel, model.shellSplitAxis != nil {
                         model.shellSplitAxis = nil
-                    } else if let model = focusedModel, let shell = model.selectedShell {
-                        model.closeShellSession(shell.id)
                     } else {
                         NSApp.keyWindow?.performClose(nil)
                     }
@@ -194,7 +195,6 @@ struct HerdrMApp: App {
 
     private var closeButtonTitle: String {
         if focusedModel?.shellSplitAxis != nil { return String(localized: "Close Split") }
-        if focusedModel?.selectedShell != nil { return String(localized: "Close Terminal") }
         return String(localized: "Close")
     }
 

--- a/Sources/HerdrM/SearchView.swift
+++ b/Sources/HerdrM/SearchView.swift
@@ -1,7 +1,7 @@
 import HerdrKit
 import SwiftUI
 
-/// Command-palette style search over agents and spaces across all devices (⌘K).
+/// Command-palette style search over agents, terminals, and spaces across all devices (⌘K).
 struct SearchSheet: View {
     @ObservedObject var model: AppModel
     @Environment(\.dismiss) private var dismiss
@@ -11,11 +11,13 @@ struct SearchSheet: View {
 
     enum Result: Identifiable {
         case agent(AppModel.AgentEntry)
+        case terminal(AppModel.TerminalEntry)
         case space(AppModel.SpaceEntry)
 
         var id: String {
             switch self {
             case .agent(let entry): return "agent-\(entry.id)"
+            case .terminal(let entry): return "terminal-\(entry.id)"
             case .space(let entry): return "space-\(entry.id)"
             }
         }
@@ -43,6 +45,15 @@ struct SearchSheet: View {
                 || entry.workspace.label.lowercased().contains(q)
                 || entry.device.name.lowercased().contains(q)
         }
+        let terminals = model.devices.flatMap { model.terminalEntries(for: $0) }.filter { entry in
+            q.isEmpty
+                || entry.title.lowercased().contains(q)
+                || (entry.pane.cwd?.lowercased().contains(q) ?? false)
+                || (entry.tab?.label.lowercased().contains(q) ?? false)
+                || entry.device.name.lowercased().contains(q)
+                || model.spaceName(deviceID: entry.device.id, workspaceID: entry.pane.workspaceID)
+                    .lowercased().contains(q)
+        }
         // Same ordering as the sidebar (AppModel.visibleAgents): whoever needs the
         // user first, then most recently updated inside each bucket.
         let ranked = agents.sorted {
@@ -51,7 +62,7 @@ struct SearchSheet: View {
             }
             return ($0.agent.revision ?? 0) > ($1.agent.revision ?? 0)
         }
-        return ranked.map(Result.agent) + spaces.map(Result.space)
+        return ranked.map(Result.agent) + terminals.map(Result.terminal) + spaces.map(Result.space)
     }
 
     var body: some View {
@@ -60,7 +71,7 @@ struct SearchSheet: View {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 13))
                     .foregroundStyle(Theme.textTertiary)
-                TextField("Search agents and spaces…", text: $query)
+                TextField("Search agents, terminals, and spaces…", text: $query)
                     .textFieldStyle(.plain)
                     .font(.system(size: 14))
                     .focused($fieldFocused)
@@ -176,6 +187,20 @@ struct SearchSheet: View {
                     "\(entry.agent.agent) · \(model.spaceName(deviceID: entry.device.id, workspaceID: entry.agent.workspaceID))",
                     device: entry.device
                 )
+            case .terminal(let entry):
+                Image(systemName: "terminal")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(width: 16)
+                Text(entry.title)
+                    .font(.system(size: 13))
+                    .foregroundStyle(Theme.text)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                trailing(
+                    String(localized: "Terminal · \(model.spaceName(deviceID: entry.device.id, workspaceID: entry.pane.workspaceID))"),
+                    device: entry.device
+                )
             case .space(let entry):
                 Image(systemName: "folder")
                     .font(.system(size: 12))
@@ -219,6 +244,8 @@ struct SearchSheet: View {
     private func choose(_ result: Result) {
         switch result {
         case .agent(let entry):
+            model.reveal(entry.ref)
+        case .terminal(let entry):
             model.reveal(entry.ref)
         case .space(let entry):
             if let filter = model.deviceFilter, filter != entry.device.id {

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -46,10 +46,8 @@ struct SidebarView: View {
                 actionRow(icon: "square.and.pencil", label: "New Agent") {
                     model.showNewAgent = true
                 }
-                // Every click opens another standalone local shell, listed under
-                // TERMINALS below — the ⌘D split beside an agent is separate.
                 actionRow(icon: "terminal", label: "New Terminal") {
-                    model.newShellSession()
+                    model.showNewTerminal = true
                 }
                 actionRow(icon: "magnifyingglass", label: "Search") {
                     model.showSearch = true
@@ -116,15 +114,15 @@ struct SidebarView: View {
                         }
                     }
 
-                    if !model.shellSessions.isEmpty {
+                    if !model.visibleTerminals.isEmpty {
                         Spacer().frame(height: 10)
                         groupHeader("Terminals", expanded: $terminalsExpanded)
                         if terminalsExpanded {
-                            ForEach(model.shellSessions) { session in
-                                shellRow(session)
+                            ForEach(model.visibleTerminals) { entry in
+                                terminalRow(entry)
                                     .contextMenu {
-                                        Button("Close Terminal", role: .destructive) {
-                                            model.closeShellSession(session.id)
+                                        Button("Close Terminal…", role: .destructive) {
+                                            model.requestClosePane(entry.ref, name: entry.title)
                                         }
                                     }
                             }
@@ -237,10 +235,9 @@ struct SidebarView: View {
 
     private func agentRow(_ entry: AppModel.AgentEntry) -> some View {
         let agent = entry.agent
-        let selected = model.selectedPane == entry.ref && model.selectedShellID == nil
+        let selected = model.selectedPane == entry.ref
         return Button {
             model.selectedPane = entry.ref
-            model.selectedShellID = nil
         } label: {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
@@ -278,27 +275,39 @@ struct SidebarView: View {
         .buttonStyle(SidebarRowButtonStyle(selected: selected))
     }
 
-    private func shellRow(_ session: ShellSession) -> some View {
-        let selected = model.selectedShellID == session.id
+    private func terminalRow(_ entry: AppModel.TerminalEntry) -> some View {
+        let selected = model.selectedPane == entry.ref
         return Button {
-            model.selectShell(session.id)
+            model.selectedPane = entry.ref
         } label: {
-            HStack(spacing: 6) {
-                Image(systemName: "terminal")
-                    .font(.system(size: 11))
-                    .foregroundStyle(Theme.textTertiary)
-                Text(session.title)
-                    .font(.system(size: 13.5))
-                    .foregroundStyle(Theme.text)
-                    .lineLimit(1)
-                Spacer(minLength: 0)
-                Text("Local")
-                    .font(.system(size: 11))
-                    .foregroundStyle(Theme.textGhost)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 6) {
+                    Image(systemName: "terminal")
+                        .font(.system(size: 11))
+                        .foregroundStyle(Theme.textTertiary)
+                    Text(entry.title)
+                        .font(.system(size: 13.5))
+                        .foregroundStyle(Theme.text)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                }
+                HStack(spacing: 5) {
+                    Image(systemName: "folder")
+                        .font(.system(size: 9.5))
+                        .foregroundStyle(Theme.textTertiary)
+                    Text(model.spaceName(deviceID: entry.device.id, workspaceID: entry.pane.workspaceID))
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Theme.textTertiary)
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                    if model.showsRowDeviceBadges {
+                        deviceBadge(entry.device)
+                    }
+                }
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 7)
-            .frame(height: 34)
+            .frame(height: 51)
             .contentShape(Rectangle())
         }
         .buttonStyle(SidebarRowButtonStyle(selected: selected))

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -709,10 +709,11 @@ private extension NSView {
     }
 }
 
-/// Embeds a SwiftTerm terminal running `herdr agent attach` (directly or over ssh).
+/// Embeds a SwiftTerm terminal running a direct agent or ordinary-terminal attach
+/// (locally or over SSH).
 struct AttachTerminalView: NSViewRepresentable {
     let device: Device
-    let paneID: String
+    let target: TerminalAttachTarget
     /// The device's herdr server version, so attach picks a matching CLI binary.
     var serverVersion: String?
     /// nil when the server or active manifest does not advertise attachment support.
@@ -752,7 +753,7 @@ struct AttachTerminalView: NSViewRepresentable {
 
         let service = HerdrService(device: device)
         view.attachmentService = service
-        let command = service.attachCommand(paneID: paneID, serverVersion: serverVersion)
+        let command = service.attachCommand(target: target, serverVersion: serverVersion)
         var environment = Terminal.getEnvironmentVariables(termName: "xterm-256color")
         environment.append("LANG=en_US.UTF-8")
         for (key, value) in command.environment {
@@ -880,36 +881,10 @@ func applyTerminalAppearance(
     view.needsDisplay = true
 }
 
-/// A local login shell, side by side with the agent attach — no herdr pane and no
+/// A local login shell, side by side with the attached Herdr pane — no herdr pane and no
 /// attachment paste. It does take first responder when it appears, so splitting hands the
 /// keyboard to the new shell; closing the split gives it back via `focusRemainingTerminal`.
-/// Standalone shell views stay in the hierarchy while deselected (a local shell
-/// has no server side to reattach to), so re-selecting one needs a way to hand
-/// it the keyboard again — the registry maps session ids to their live views.
-@MainActor
-enum ShellViewRegistry {
-    private struct WeakView { weak var view: LocalProcessTerminalView? }
-    private static var views: [UUID: WeakView] = [:]
-
-    static func register(_ view: LocalProcessTerminalView, for id: UUID) {
-        views[id] = WeakView(view: view)
-    }
-
-    static func unregister(_ id: UUID) {
-        views[id] = nil
-    }
-
-    static func focus(_ id: UUID) {
-        DispatchQueue.main.async {
-            guard let view = views[id]?.view, let window = view.window else { return }
-            window.makeFirstResponder(view)
-        }
-    }
-}
-
 struct ShellTerminalView: NSViewRepresentable {
-    /// Session identity for the registry; nil for the ⌘D split shell.
-    var sessionID: UUID?
     var fontName: String = ""
     var fontSize: Double = TerminalDefaults.defaultFontSize
     var thinStrokes: Bool = true
@@ -928,7 +903,6 @@ struct ShellTerminalView: NSViewRepresentable {
         let view = LineBreakTerminalView(frame: .zero)
         view.processDelegate = context.coordinator
         context.coordinator.onExit = onExit
-        context.coordinator.sessionID = sessionID
         applyTerminalAppearance(
             view,
             fontName: fontName,
@@ -947,9 +921,6 @@ struct ShellTerminalView: NSViewRepresentable {
             args: ["-c", "cd \"$HOME\"; exec \"${SHELL:-/bin/zsh}\" -l"],
             environment: environment
         )
-        if let sessionID {
-            ShellViewRegistry.register(view, for: sessionID)
-        }
         // Opening a shell hands it the keyboard: `makeNSView` runs once per shell
         // (the `.id` is stable across theme changes), so this never steals focus
         // back afterwards. The hop to the next runloop pass is required — the
@@ -978,9 +949,6 @@ struct ShellTerminalView: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: LocalProcessTerminalView, coordinator: Coordinator) {
         coordinator.onExit = nil
-        if let sessionID = coordinator.sessionID {
-            ShellViewRegistry.unregister(sessionID)
-        }
         let shellPid = nsView.process?.shellPid ?? 0
         nsView.terminate()
         // terminate() sends SIGTERM, which interactive shells ignore — a closed
@@ -1002,7 +970,6 @@ struct ShellTerminalView: NSViewRepresentable {
 
     final class Coordinator: NSObject, LocalProcessTerminalViewDelegate {
         var onExit: ((Int32?) -> Void)?
-        var sessionID: UUID?
 
         func sizeChanged(source: LocalProcessTerminalView, newCols: Int, newRows: Int) {}
         func setTerminalTitle(source: LocalProcessTerminalView, title: String) {}


### PR DESCRIPTION
This is my proposed implementation for feature request #57.

## Overview

This PR adds first-class support for persistent shell terminals managed by Herdr, including terminals running on remote SSH devices.

Previously, Herdr displayed remote agents but did not expose ordinary shell terminals from the same Herdr session. The only “new terminal” flow created an app-owned local shell, which meant users could not discover or attach to existing terminal panes created by Herdr.

This implementation treats agents and ordinary terminals as two attachable pane types while preserving the existing agent workflow.

## High-level design

### Terminal discovery

The session snapshot model now understands:

- Terminal IDs associated with panes.
- Tab metadata, including workspace association and labels.
- Optional terminal/tab fields for compatibility with older Herdr versions.

Ordinary terminals are derived by filtering terminal-backed panes and excluding panes already represented by the authoritative agent list. This prevents an agent pane from appearing twice—once as an agent and once as a terminal.

### Unified attachment targets

Attachment is represented by a typed target:

- `agent(paneID:)`
- `terminal(terminalID:)`

The service layer generates the appropriate Herdr command while sharing the existing local/SSH transport, authentication, keepalive, and server-version handling:

```text
herdr agent attach '<pane-id>' --takeover
herdr terminal attach '<terminal-id>' --takeover
```

This keeps terminal attachment behavior consistent across local and remote devices.

### App state and selection
Terminal entries now participate in the same device, space, search, selection, reconnect, and split-view flows as agents.
Terminal titles use the following fallback order:
1. Terminal-provided title.
2. Non-generic tab label.
3. Current working directory basename.
4. Localized “Terminal” fallback.
The refresh path prefers the focused pane when available and otherwise selects the first visible agent or terminal. Existing selections are retained when possible.

### Creating new terminals
The New Terminal sheet lets the user choose:
- A device.
- An existing Herdr space/workspace on that device.
Creation uses the existing persistent tab API rather than creating an app-owned shell. After creation, the app refreshes the snapshot and selects the newly available terminal.
A terminal cannot be created until the device has at least one Herdr space, and the UI explains that requirement.

### UI and commands
- Added a Terminals section to the sidebar.
- Added terminal results to search.
- Added New Terminal in the sidebar and as ⌘T.
- Added terminal-aware detail views, reconnect handling, split view, and close confirmation.
- Kept ⌘D split behavior for local app-owned shells.
- Avoided silently terminating server-managed terminal processes when closing the app window.
- Added English and Simplified Chinese localization.

## Compatibility
Terminal and tab metadata are decoded as optional fields, so snapshots from older Herdr versions continue to decode. Existing agent attachment behavior and command generation remain supported through the compatibility overload.

## Testing
- Added snapshot decoding tests for terminal IDs and tabs.
- Added tests ensuring agent panes are not duplicated as ordinary terminals.
- Added local and SSH attach-command coverage.
- Added terminal ID assertions to local socket and remote SSH tests.
- swift test: 105 passed, 5 remote-only tests skipped.
- Unsigned macOS Xcode build succeeded.
- Localization JSON and whitespace validation passed.

## Manual testing
I manually tested the implementation and confirmed that:
- Existing persistent terminals appear in the sidebar.
- Remote terminals can be selected and attached over SSH.
- New Terminal creates a persistent terminal in the selected Herdr space.
- Search, reconnect, split view, and close confirmation work for terminals.
- Agent panes continue to behave as before.

This implementation was written with assistance from gpt-5.6-sol using high reasoning effort.