### PR TITLE
feat(sidebar): mark unread agents and persist drag order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Added
+- Sidebar Spaces and Agents share one set of conversation marks: a spinner
+  while running, a filled unread dot after a finish you have not opened,
+  nothing once viewed, and an exclamation if the agent needs input. A space
+  shows the strongest state among its agents.
+- Agents in the sidebar can be drag-reordered. The drop calls herdr's
+  `tab.move` (same RPC the TUI uses) so the order is the session's, not just
+  this window. Cross-space drops are ignored. ⌘K still ranks by urgency.
+
 ## [0.5.2] - 2026-08-28
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/Attention.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/Attention.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// One glyph for a Space, using the same marks as an agent row.
+/// Strongest state inside the space wins: needs input → unread → working.
+public enum SpaceAttention: Equatable, Sendable {
+    case blocked
+    case unreadDone
+    case working
+    case none
+
+    public static func rollup<S: Sequence>(_ agents: S) -> SpaceAttention
+    where S.Element == (status: AgentStatus, unreadDone: Bool) {
+        var sawUnreadDone = false
+        var sawWorking = false
+        for agent in agents {
+            if agent.status == .blocked { return .blocked }
+            if agent.status == .done, agent.unreadDone { sawUnreadDone = true }
+            else if agent.status == .working { sawWorking = true }
+        }
+        if sawUnreadDone { return .unreadDone }
+        if sawWorking { return .working }
+        return .none
+    }
+}
+
+/// Keys a "finished while you weren't looking" flag. herdr has no viewed
+/// state; this lives entirely in the GUI.
+public struct AgentUnreadKey: Hashable, Sendable {
+    public let deviceID: UUID
+    public let paneID: String
+
+    public init(deviceID: UUID, paneID: String) {
+        self.deviceID = deviceID
+        self.paneID = paneID
+    }
+}
+
+public enum AgentUnread: Sendable {
+    /// Apply a live status transition. Initial snapshots pass an empty
+    /// `previous` map and must not create unread flags.
+    ///
+    /// Finishing while the pane is selected still counts as unread; the GUI
+    /// clears the flag when the user *leaves* that row, not when they happen
+    /// to be sitting on it as the turn ends.
+    public static func applying(
+        previous: [String: AgentStatus],
+        agents: [AgentInfo],
+        unread: Set<AgentUnreadKey>,
+        deviceID: UUID
+    ) -> Set<AgentUnreadKey> {
+        var next = unread
+        let liveIDs = Set(agents.map(\.paneID))
+        next = next.filter { key in
+            key.deviceID != deviceID || liveIDs.contains(key.paneID)
+        }
+
+        guard !previous.isEmpty else { return next }
+
+        for agent in agents {
+            let key = AgentUnreadKey(deviceID: deviceID, paneID: agent.paneID)
+            if agent.status != .done {
+                next.remove(key)
+                continue
+            }
+            let old = previous[agent.paneID]
+            guard old != nil, old != agent.status else { continue }
+            next.insert(key)
+        }
+        return next
+    }
+}

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -327,6 +327,18 @@ public actor HerdrService {
         )
     }
 
+    /// Moves a tab to `insertIndex` among tabs in its workspace (`0...count`).
+    /// Same RPC the herdr TUI uses for tab reorder.
+    public func moveTab(tabID: String, insertIndex: UInt) async throws {
+        _ = try await client().request(
+            method: "tab.move",
+            params: .object([
+                "tab_id": .string(tabID),
+                "insert_index": .number(Double(insertIndex)),
+            ])
+        )
+    }
+
     /// Places one workspace at `insertIndex` in the device's workspace list
     /// (`0...count`). Prefer `moveWorkspaceBlock` for sidebar drag: it is how
     /// the herdr TUI reorders spaces, and it moves a worktree group atomically.

--- a/Packages/HerdrKit/Sources/HerdrKit/TabReorder.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/TabReorder.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Maps a sidebar agent drop onto herdr's `tab.move` `insert_index`.
+///
+/// `orderedIDs` is one workspace's tabs in display order (`number`). The drop
+/// target is another tab in that list. Returns `nil` when the drop would not
+/// change order (same row, already adjacent, unknown ids).
+public enum TabReorder: Sendable {
+    public static func insertIndex(
+        moving: String,
+        onto: String,
+        placeAfter: Bool,
+        orderedIDs: [String]
+    ) -> UInt? {
+        guard let plan = WorkspaceReorder.plan(
+            moving: moving,
+            onto: onto,
+            placeAfter: placeAfter,
+            orderedIDs: orderedIDs
+        ) else { return nil }
+
+        let remaining = orderedIDs.filter { $0 != moving }
+        if let before = plan.beforeWorkspaceID {
+            let index = remaining.firstIndex(of: before) ?? remaining.count
+            return UInt(index)
+        }
+        return UInt(remaining.count)
+    }
+}

--- a/Packages/HerdrKit/Tests/HerdrKitTests/AttentionTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/AttentionTests.swift
@@ -1,0 +1,104 @@
+import XCTest
+@testable import HerdrKit
+
+final class AttentionTests: XCTestCase {
+    func testRollupPicksTheStrongestAgentState() {
+        XCTAssertEqual(
+            SpaceAttention.rollup([
+                (status: .working, unreadDone: false),
+                (status: .done, unreadDone: true),
+                (status: .blocked, unreadDone: false),
+            ]),
+            .blocked
+        )
+        XCTAssertEqual(
+            SpaceAttention.rollup([
+                (status: .working, unreadDone: false),
+                (status: .done, unreadDone: true),
+                (status: .done, unreadDone: false),
+            ]),
+            .unreadDone
+        )
+        XCTAssertEqual(
+            SpaceAttention.rollup([
+                (status: .working, unreadDone: false),
+                (status: .done, unreadDone: false),
+            ]),
+            .working
+        )
+        XCTAssertEqual(
+            SpaceAttention.rollup([
+                (status: .done, unreadDone: false),
+                (status: .idle, unreadDone: false),
+            ]),
+            .none
+        )
+        XCTAssertEqual(
+            SpaceAttention.rollup([
+                (status: .idle, unreadDone: false),
+            ]),
+            .none
+        )
+    }
+
+    func testInitialSnapshotDoesNotMarkUnread() throws {
+        let agent = try decodeDone(paneID: "w1:p1")
+        let device = UUID()
+        let unread = AgentUnread.applying(
+            previous: [:],
+            agents: [agent],
+            unread: [],
+            deviceID: device
+        )
+        XCTAssertTrue(unread.isEmpty)
+    }
+
+    func testTransitionToDoneMarksUnreadEvenIfSelected() throws {
+        let agent = try decodeDone(paneID: "w1:p1")
+        let device = UUID()
+        let unread = AgentUnread.applying(
+            previous: ["w1:p1": .working],
+            agents: [agent],
+            unread: [],
+            deviceID: device
+        )
+        XCTAssertEqual(unread, [AgentUnreadKey(deviceID: device, paneID: "w1:p1")])
+    }
+
+    func testLeavingDoneClearsUnreadAndGonePanesArePruned() throws {
+        let device = UUID()
+        let key = AgentUnreadKey(deviceID: device, paneID: "w1:p1")
+        let other = AgentUnreadKey(deviceID: UUID(), paneID: "w2:p1")
+        let working = try decodeAgent(paneID: "w1:p1", status: "working")
+        let next = AgentUnread.applying(
+            previous: ["w1:p1": .done],
+            agents: [working],
+            unread: [key, other],
+            deviceID: device
+        )
+        XCTAssertEqual(next, [other])
+
+        let pruned = AgentUnread.applying(
+            previous: ["w1:p1": .done],
+            agents: [],
+            unread: [key, other],
+            deviceID: device
+        )
+        XCTAssertEqual(pruned, [other])
+    }
+
+    private func decodeDone(paneID: String) throws -> AgentInfo {
+        try decodeAgent(paneID: paneID, status: "done")
+    }
+
+    private func decodeAgent(paneID: String, status: String) throws -> AgentInfo {
+        let data = Data("""
+            {
+              "terminal_id": "t", "agent": "codex", "name": "codex",
+              "agent_status": "\(status)", "workspace_id": "w1", "tab_id": "w1:t1",
+              "pane_id": "\(paneID)", "focused": false, "revision": 0
+            }
+            """.utf8)
+        return try JSONDecoder().decode(AgentInfo.self, from: data)
+    }
+}

--- a/Packages/HerdrKit/Tests/HerdrKitTests/TabReorderTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/TabReorderTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import HerdrKit
+
+final class TabReorderTests: XCTestCase {
+    private let order = ["t1", "t2", "t3"]
+
+    func testDropOnEarlierRowInsertsBeforeIt() {
+        XCTAssertEqual(
+            TabReorder.insertIndex(moving: "t2", onto: "t1", placeAfter: false, orderedIDs: order),
+            0
+        )
+    }
+
+    func testDropOnLowerHalfOfLastRowAppends() {
+        XCTAssertEqual(
+            TabReorder.insertIndex(moving: "t1", onto: "t3", placeAfter: true, orderedIDs: order),
+            2
+        )
+    }
+
+    func testDropOnLowerHalfWhenNextIsTheDraggedRowIsNoOp() {
+        XCTAssertNil(
+            TabReorder.insertIndex(moving: "t2", onto: "t1", placeAfter: true, orderedIDs: order)
+        )
+    }
+
+    func testAlreadyImmediatelyBeforeTheTargetIsNoOp() {
+        XCTAssertNil(
+            TabReorder.insertIndex(moving: "t1", onto: "t2", placeAfter: false, orderedIDs: order)
+        )
+    }
+
+    func testMoveLastToFront() {
+        XCTAssertEqual(
+            TabReorder.insertIndex(moving: "t3", onto: "t1", placeAfter: false, orderedIDs: order),
+            0
+        )
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1409,6 +1409,22 @@
         }
       }
     },
+    "Unread" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unread"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "未查看"
+          }
+        }
+      }
+    },
     "Reconnect" : {
       "localizations" : {
         "en" : {

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -116,7 +116,17 @@ final class AppModel: ObservableObject {
     private static let deviceFilterKey = "device.filter"
     @Published var sessions: [UUID: DeviceSessionState] = [:]
     @Published var selectedSpace: SpaceRef?
-    @Published var selectedPane: PaneRef?
+    @Published var selectedPane: PaneRef? {
+        didSet {
+            // Leaving a finished agent marks it viewed. Staying on it while
+            // the turn ends must not swallow the unread flag.
+            if let old = oldValue, old != selectedPane {
+                unreadAgents.remove(AgentUnreadKey(deviceID: old.deviceID, paneID: old.paneID))
+            }
+        }
+    }
+    /// Finished agents the user has not opened since they flipped to `done`.
+    @Published private(set) var unreadAgents: Set<AgentUnreadKey> = []
 
     @Published var showAddDevice = false
     @Published var showNewAgent = false
@@ -125,6 +135,10 @@ final class AppModel: ObservableObject {
     @Published var showSearch = false
     @Published var isFileManagerActive = false
     @Published var shellSplitAxis: SplitAxis?
+    /// Set by `reveal` when a jump lands while the ⌘D split is open, and consumed once the
+    /// main window is key again. Only an actual jump sets it: dismissing the search with
+    /// Escape never calls `reveal`, and the sidebar assigns `selectedPane` directly.
+    @Published var pendingSplitAgentFocus = false
     /// The pane that currently holds the keyboard within the ⌘D split. Reset to
     /// the agent side whenever the split closes so reopening it is predictable.
     @Published var activeSplitSide: SplitSide = .agent
@@ -323,7 +337,8 @@ final class AppModel: ObservableObject {
         }
     }
 
-    /// Agents across the scope, filtered by selected space, status-bucket sorted.
+    /// Agents across the scope, filtered by selected space, in herdr tab order
+    /// (device → workspace → tab number) so sidebar drag matches the TUI.
     var visibleAgents: [AgentEntry] {
         var entries = devicesInScope.flatMap { device in
             session(device.id).agents.map { agentEntry(device: device, agent: $0) }
@@ -333,11 +348,16 @@ final class AppModel: ObservableObject {
                 $0.device.id == space.deviceID && $0.agent.workspaceID == space.workspaceID
             }
         }
-        return entries.sorted {
-            if $0.agent.status.sortBucket != $1.agent.status.sortBucket {
-                return $0.agent.status.sortBucket < $1.agent.status.sortBucket
-            }
-            return ($0.agent.revision ?? 0) > ($1.agent.revision ?? 0)
+        let deviceRank = Dictionary(uniqueKeysWithValues: devicesInScope.enumerated().map { ($1.id, $0) })
+        return entries.sorted { lhs, rhs in
+            let d0 = deviceRank[lhs.device.id] ?? Int.max
+            let d1 = deviceRank[rhs.device.id] ?? Int.max
+            if d0 != d1 { return d0 < d1 }
+            let w0 = workspaceRank(deviceID: lhs.device.id, workspaceID: lhs.agent.workspaceID)
+            let w1 = workspaceRank(deviceID: rhs.device.id, workspaceID: rhs.agent.workspaceID)
+            if w0 != w1 { return w0 < w1 }
+            return tabRank(deviceID: lhs.device.id, tabID: lhs.agent.tabID)
+                < tabRank(deviceID: rhs.device.id, tabID: rhs.agent.tabID)
         }
     }
 
@@ -363,6 +383,51 @@ final class AppModel: ObservableObject {
             }
         }
         return entries
+    }
+
+    func isUnread(_ entry: AgentEntry) -> Bool {
+        unreadAgents.contains(AgentUnreadKey(deviceID: entry.device.id, paneID: entry.agent.paneID))
+    }
+
+    func attention(in entry: SpaceEntry) -> SpaceAttention {
+        let agents = session(entry.device.id).agents.filter {
+            $0.workspaceID == entry.workspace.workspaceID
+        }
+        return SpaceAttention.rollup(agents.map {
+            (
+                status: $0.status,
+                unreadDone: unreadAgents.contains(
+                    AgentUnreadKey(deviceID: entry.device.id, paneID: $0.paneID)
+                )
+            )
+        })
+    }
+
+    var scopeAttention: SpaceAttention {
+        SpaceAttention.rollup(devicesInScope.flatMap { device in
+            session(device.id).agents.map {
+                (
+                    status: $0.status,
+                    unreadDone: unreadAgents.contains(
+                        AgentUnreadKey(deviceID: device.id, paneID: $0.paneID)
+                    )
+                )
+            }
+        })
+    }
+
+    private func workspaceRank(deviceID: UUID, workspaceID: String) -> Int {
+        session(deviceID).workspaces.firstIndex { $0.workspaceID == workspaceID } ?? Int.max
+    }
+
+    private func tabRank(deviceID: UUID, tabID: String) -> Int {
+        session(deviceID).tabs.firstIndex { $0.tabID == tabID } ?? Int.max
+    }
+
+    private func orderedTabIDs(deviceID: UUID, workspaceID: String) -> [String] {
+        session(deviceID).tabs
+            .filter { $0.workspaceID == workspaceID }
+            .map(\.tabID)
     }
 
     var scopeAgentCount: Int {
@@ -423,7 +488,7 @@ final class AppModel: ObservableObject {
             if ref == nil { return }
             if entry.device.id == ref!.deviceID && entry.workspaceID == ref!.workspaceID { return }
         }
-        selectedPane = firstVisiblePaneRef
+        selectedPane = preferredVisibleAgent()?.ref ?? firstVisiblePaneRef
     }
 
     func setDeviceFilter(_ id: UUID?) {
@@ -432,14 +497,21 @@ final class AppModel: ObservableObject {
             selectedSpace = nil
         }
         if let id, let selected = selectedPane, selected.deviceID != id {
-            selectedPane = firstVisiblePaneRef
+            selectedPane = preferredVisibleAgent()?.ref ?? firstVisiblePaneRef
         }
     }
 
-    /// Set by `reveal` when a jump lands while the ⌘D split is open, and consumed once the
-    /// main window is key again. Only an actual jump sets it: dismissing the search with
-    /// Escape never calls `reveal`, and the sidebar assigns `selectedPane` directly.
-    @Published var pendingSplitAgentFocus = false
+    /// When jumping into a space, land on whoever still needs a look — not
+    /// merely the first tab.
+    private func preferredVisibleAgent() -> AgentEntry? {
+        let agents = visibleAgents
+        if let blocked = agents.first(where: { $0.agent.status == .blocked }) { return blocked }
+        if let unread = agents.first(where: { $0.agent.status == .done && isUnread($0) }) {
+            return unread
+        }
+        if let working = agents.first(where: { $0.agent.status == .working }) { return working }
+        return agents.first
+    }
 
     /// Jump target used by the search sheet and by notification clicks.
     func reveal(_ ref: PaneRef) {
@@ -703,7 +775,9 @@ final class AppModel: ObservableObject {
         store.save(devices)
         if deviceFilter == device.id { deviceFilter = nil }
         if selectedSpace?.deviceID == device.id { selectedSpace = nil }
-        if selectedPane?.deviceID == device.id { selectedPane = firstVisiblePaneRef }
+        if selectedPane?.deviceID == device.id {
+            selectedPane = preferredVisibleAgent()?.ref ?? firstVisiblePaneRef
+        }
     }
 
     // MARK: - Refresh
@@ -712,6 +786,12 @@ final class AppModel: ObservableObject {
         guard let device = device(deviceID), let service = services[deviceID] else { return }
         do {
             let snapshot = try await service.snapshot()
+            unreadAgents = AgentUnread.applying(
+                previous: previousStatuses[deviceID] ?? [:],
+                agents: snapshot.agents,
+                unread: unreadAgents,
+                deviceID: device.id
+            )
             notifyTransitions(
                 device: device,
                 from: previousStatuses[deviceID] ?? [:],
@@ -724,8 +804,12 @@ final class AppModel: ObservableObject {
             )
             sessions[deviceID]?.agents = snapshot.agents
             sessions[deviceID]?.workspaces = snapshot.workspaces
+            sessions[deviceID]?.workspaces = snapshot.workspaces
+            sessions[deviceID]?.tabs = Self.orderedTabs(
+                snapshot.tabs ?? [],
+                workspaces: snapshot.workspaces
+            )
             sessions[deviceID]?.panes = snapshot.ordinaryTerminalPanes
-            sessions[deviceID]?.tabs = snapshot.tabs ?? []
             let paneIDs = Set((snapshot.panes ?? []).map(\.paneID))
                 .union(snapshot.agents.map(\.paneID))
             if let selected = selectedPane, selected.deviceID == deviceID,
@@ -748,7 +832,9 @@ final class AppModel: ObservableObject {
                         selectedPane = focused
                     }
                 }
-                if selectedPane == nil { selectedPane = firstVisiblePaneRef }
+                if selectedPane == nil {
+                    selectedPane = preferredVisibleAgent()?.ref ?? firstVisiblePaneRef
+                }
             }
         } catch {
             sessions[deviceID]?.connection = .failed(error.localizedDescription)
@@ -951,6 +1037,86 @@ final class AppModel: ObservableObject {
                 actionError = actionErrorMessage(error, device: source.device)
             }
         }
+    }
+
+    /// Reorders an agent tab by dropping it on another agent in the same space.
+    /// Cross-space and cross-device drops are ignored (`tab.move` is in-workspace).
+    func moveAgent(_ source: AgentEntry, onto target: AgentEntry, placeAfter: Bool) {
+        guard source.device.id == target.device.id,
+              source.agent.workspaceID == target.agent.workspaceID
+        else { return }
+        let orderedIDs = orderedTabIDs(
+            deviceID: source.device.id,
+            workspaceID: source.agent.workspaceID
+        )
+        guard let insertIndex = TabReorder.insertIndex(
+            moving: source.agent.tabID,
+            onto: target.agent.tabID,
+            placeAfter: placeAfter,
+            orderedIDs: orderedIDs
+        ) else { return }
+        guard let plan = WorkspaceReorder.plan(
+            moving: source.agent.tabID,
+            onto: target.agent.tabID,
+            placeAfter: placeAfter,
+            orderedIDs: orderedIDs
+        ) else { return }
+
+        if let current = sessions[source.device.id]?.tabs {
+            let scoped = current.filter { $0.workspaceID == source.agent.workspaceID }
+            let reordered = WorkspaceReorder.applying(scoped, id: \.tabID, plan: plan)
+            sessions[source.device.id]?.tabs = Self.replacingTabs(
+                current,
+                workspaceID: source.agent.workspaceID,
+                with: reordered
+            )
+        }
+
+        Task {
+            do {
+                try await service(for: source.device).moveTab(
+                    tabID: source.agent.tabID,
+                    insertIndex: insertIndex
+                )
+                await refresh(source.device.id)
+            } catch {
+                await refresh(source.device.id)
+                actionError = actionErrorMessage(error, device: source.device)
+            }
+        }
+    }
+
+    private static func orderedTabs(_ tabs: [TabInfo], workspaces: [WorkspaceInfo]) -> [TabInfo] {
+        let wsIndex = Dictionary(uniqueKeysWithValues: workspaces.enumerated().map {
+            ($1.workspaceID, $0)
+        })
+        return tabs.sorted {
+            let w0 = wsIndex[$0.workspaceID] ?? Int.max
+            let w1 = wsIndex[$1.workspaceID] ?? Int.max
+            if w0 != w1 { return w0 < w1 }
+            return ($0.number ?? Int.max) < ($1.number ?? Int.max)
+        }
+    }
+
+    private static func replacingTabs(
+        _ tabs: [TabInfo],
+        workspaceID: String,
+        with reordered: [TabInfo]
+    ) -> [TabInfo] {
+        var result: [TabInfo] = []
+        var inserted = false
+        for tab in tabs {
+            if tab.workspaceID == workspaceID {
+                if !inserted {
+                    result.append(contentsOf: reordered)
+                    inserted = true
+                }
+            } else {
+                result.append(tab)
+            }
+        }
+        if !inserted { result.append(contentsOf: reordered) }
+        return result
     }
 
     /// Creates a workspace rooted at the given directory ("~" expands to the device's

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -242,11 +242,9 @@ struct DetailView: View {
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(Theme.warning)
         case .done:
-            Image(systemName: "checkmark")
-                .font(.system(size: 11, weight: .bold))
-                .foregroundStyle(Theme.success)
+            EmptyView()
         case .idle, .unknown:
-            Circle().fill(Theme.textGhost).frame(width: 7, height: 7)
+            EmptyView()
         }
     }
 

--- a/Sources/HerdrM/SearchView.swift
+++ b/Sources/HerdrM/SearchView.swift
@@ -56,15 +56,26 @@ struct SearchSheet: View {
                 || model.spaceName(deviceID: entry.device.id, workspaceID: entry.pane.workspaceID)
                     .lowercased().contains(q)
         }
-        // Same ordering as the sidebar (AppModel.visibleAgents): whoever needs the
-        // user first, then most recently updated inside each bucket.
+        // Sidebar follows herdr tab order so drag-reorder sticks. ⌘K still
+        // ranks by urgency: needs input, unread, working, then the rest.
         let ranked = agents.sorted {
-            if $0.agent.status.sortBucket != $1.agent.status.sortBucket {
-                return $0.agent.status.sortBucket < $1.agent.status.sortBucket
-            }
+            let r0 = searchRank($0)
+            let r1 = searchRank($1)
+            if r0 != r1 { return r0 < r1 }
             return ($0.agent.revision ?? 0) > ($1.agent.revision ?? 0)
         }
         return ranked.map(Result.agent) + terminals.map(Result.terminal) + spaces.map(Result.space)
+    }
+
+    private func searchRank(_ entry: AppModel.AgentEntry) -> Int {
+        switch entry.agent.status {
+        case .blocked: return 0
+        case .done where model.isUnread(entry): return 1
+        case .working: return 2
+        case .done: return 3
+        case .idle: return 4
+        case .unknown: return 5
+        }
     }
 
     var body: some View {
@@ -178,7 +189,7 @@ struct SearchSheet: View {
                     .font(.system(size: 13))
                     .foregroundStyle(Theme.text)
                     .lineLimit(1)
-                AgentStatusGlyph(status: entry.agent.status)
+                AgentStatusGlyph(status: entry.agent.status, unreadDone: model.isUnread(entry))
                 Spacer(minLength: 8)
                 if entry.agent.status == .blocked {
                     Text("needs input")

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -24,6 +24,8 @@ struct SidebarView: View {
     @State private var deviceButtonHovered = false
     @State private var draggingSpaceID: String?
     @State private var spaceDrop: (id: String, after: Bool)?
+    @State private var draggingAgentID: String?
+    @State private var agentDrop: (id: String, after: Bool)?
     @State private var spacesExpanded = true
     @State private var agentsExpanded = true
     @State private var terminalsExpanded = true
@@ -106,16 +108,12 @@ struct SidebarView: View {
                                 .padding(8)
                         }
                         ForEach(model.visibleAgents) { entry in
-                            agentRow(entry)
-                                .contextMenu {
-                                    Button("Rename Agent…") {
-                                        model.agentToRename = entry
-                                    }
-                                    Divider()
-                                    Button("Close Agent…", role: .destructive) {
-                                        model.requestClosePane(entry.ref, name: entry.title)
-                                    }
-                                }
+                            AgentRowView(
+                                entry: entry,
+                                model: model,
+                                draggingAgentID: $draggingAgentID,
+                                agentDrop: $agentDrop
+                            )
                         }
                     }
 
@@ -235,56 +233,13 @@ struct SidebarView: View {
                     .font(.system(size: 13))
                     .foregroundStyle(selected ? Theme.text : Theme.textSecondary)
                 Spacer()
+                SpaceAttentionGlyph(attention: model.scopeAttention)
                 Text("\(model.scopeAgentCount)")
                     .font(.system(size: 11))
                     .foregroundStyle(Theme.textGhost)
             }
             .padding(.horizontal, 8)
             .frame(height: 30)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(SidebarRowButtonStyle(selected: selected))
-    }
-
-    private func agentRow(_ entry: AppModel.AgentEntry) -> some View {
-        let agent = entry.agent
-        let selected = !model.isFileManagerActive
-            && model.selectedPane == entry.ref
-            && model.selectedShellID == nil
-        return Button {
-            model.selectAgent(entry.ref)
-        } label: {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 6) {
-                    Text(entry.title)
-                        .font(.system(size: 13.5))
-                        .foregroundStyle(Theme.text)
-                        .lineLimit(1)
-                    Spacer(minLength: 0)
-                    AgentStatusGlyph(status: agent.status)
-                }
-                HStack(spacing: 5) {
-                    AgentKindBadge(kind: agent.agent)
-                    Text("·")
-                        .font(.system(size: 11.5))
-                        .foregroundStyle(Theme.textGhost)
-                    Image(systemName: "folder")
-                        .font(.system(size: 9.5))
-                        .foregroundStyle(Theme.textTertiary)
-                    Text(model.spaceName(deviceID: entry.device.id, workspaceID: agent.workspaceID))
-                        .font(.system(size: 11.5))
-                        .foregroundStyle(Theme.textTertiary)
-                        .lineLimit(1)
-                    Spacer(minLength: 0)
-                    trailingDetail(agent)
-                    if model.showsRowDeviceBadges {
-                        deviceBadge(entry.device)
-                    }
-                }
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 7)
-            .frame(height: 51)
             .contentShape(Rectangle())
         }
         .buttonStyle(SidebarRowButtonStyle(selected: selected))
@@ -358,19 +313,112 @@ struct SidebarView: View {
         .buttonStyle(SidebarRowButtonStyle(selected: selected))
     }
 
-    /// Tinted name chip marking which device a row belongs to.
     private func deviceBadge(_ device: Device) -> some View {
         DeviceChip(device: device)
     }
 
-    @ViewBuilder
-    private func trailingDetail(_ agent: AgentInfo) -> some View {
-        if agent.status == .blocked {
-            Text("needs input")
-                .font(.system(size: 11.5))
-                .foregroundStyle(Theme.warning)
+    private struct AgentRowView: View {
+    let entry: AppModel.AgentEntry
+    @ObservedObject var model: AppModel
+    @Binding var draggingAgentID: String?
+    @Binding var agentDrop: (id: String, after: Bool)?
+    @State private var hovered = false
+
+    var body: some View {
+        let agent = entry.agent
+        let selected = !model.isFileManagerActive
+            && model.selectedPane == entry.ref
+            && model.selectedShellID == nil
+        let unread = model.isUnread(entry)
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(entry.title)
+                    .font(.system(size: 13.5))
+                    .foregroundStyle(Theme.text)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                AgentStatusGlyph(status: agent.status, unreadDone: unread)
+            }
+            HStack(spacing: 5) {
+                AgentKindBadge(kind: agent.agent)
+                Text("·")
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(Theme.textGhost)
+                Image(systemName: "folder")
+                    .font(.system(size: 9.5))
+                    .foregroundStyle(Theme.textTertiary)
+                Text(model.spaceName(deviceID: entry.device.id, workspaceID: agent.workspaceID))
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(Theme.textTertiary)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                if agent.status == .blocked {
+                    Text("needs input")
+                        .font(.system(size: 11.5))
+                        .foregroundStyle(Theme.warning)
+                }
+                if model.showsRowDeviceBadges {
+                    DeviceChip(device: entry.device)
+                }
+            }
         }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .frame(height: 51)
+        .contentShape(Rectangle())
+        .background(
+            RoundedRectangle(cornerRadius: 7)
+                .fill(selected || hovered ? AnyShapeStyle(Theme.itemWashSelected) : AnyShapeStyle(.clear))
+        )
+        .onHover { hovered = $0 }
+        .opacity(draggingAgentID == entry.id ? 0.4 : 1)
+        .overlay(alignment: (agentDrop?.after ?? false) ? .bottom : .top) {
+            if agentDrop?.id == entry.id {
+                Rectangle()
+                    .fill(Theme.accent)
+                    .frame(height: 2)
+            }
+        }
+        .overlay {
+            AgentRowDragHost(
+                entryID: entry.id,
+                onClick: { model.selectAgent(entry.ref) },
+                onRename: { model.agentToRename = entry },
+                onClose: { model.requestClosePane(entry.ref, name: entry.title) },
+                onDragStart: { draggingAgentID = $0 },
+                onDragEnd: {
+                    draggingAgentID = nil
+                    agentDrop = nil
+                },
+                onDropHover: { after in agentDrop = (entry.id, after) },
+                onHoverExit: {
+                    if agentDrop?.id == entry.id { agentDrop = nil }
+                },
+                onDrop: { sourceID, after in
+                    draggingAgentID = nil
+                    agentDrop = nil
+                    guard let source = model.visibleAgents.first(where: { $0.id == sourceID })
+                    else { return }
+                    model.moveAgent(source, onto: entry, placeAfter: after)
+                }
+            )
+        }
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(accessibilityLabel(unread: unread))
     }
+
+    private func accessibilityLabel(unread: Bool) -> String {
+        var parts = [entry.title]
+        switch entry.agent.status {
+        case .working: parts.append(String(localized: "Working"))
+        case .blocked: parts.append(String(localized: "Needs input"))
+        case .done where unread: parts.append(String(localized: "Unread"))
+        case .done: break
+        case .idle, .unknown: break
+        }
+        return parts.joined(separator: ", ")
+    }
+}
 
     // MARK: - Footer (device filter)
 
@@ -683,6 +731,7 @@ private struct SpaceRowView: View {
                 .foregroundStyle(selected ? Theme.text : Theme.textSecondary)
                 .lineLimit(1)
             Spacer()
+            SpaceAttentionGlyph(attention: model.attention(in: entry))
             if model.showsRowDeviceBadges {
                 DeviceChip(device: entry.device)
             }
@@ -732,7 +781,18 @@ private struct SpaceRowView: View {
             )
         }
         .accessibilityAddTraits(.isButton)
-        .accessibilityLabel(entry.workspace.label)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        var parts = [entry.workspace.label]
+        switch model.attention(in: entry) {
+        case .blocked: parts.append(String(localized: "Needs input"))
+        case .unreadDone: parts.append(String(localized: "Unread"))
+        case .working: parts.append(String(localized: "Working"))
+        case .none: break
+        }
+        return parts.joined(separator: ", ")
     }
 }
 

--- a/Sources/HerdrM/SpaceRowDrag.swift
+++ b/Sources/HerdrM/SpaceRowDrag.swift
@@ -1,10 +1,53 @@
 import AppKit
 import SwiftUI
 
+enum SidebarContextMenuItem {
+    case item(title: String, action: () -> Void)
+    case destructive(title: String, action: () -> Void)
+    case separator
+}
+
 /// AppKit drag/drop host. SwiftUI `.onDrag` on macOS does not start when a
 /// `Button` (or even `onTapGesture`) owns mouseDown; a few points of movement
 /// here begin an `NSDraggingSession` instead.
-struct SpaceRowDragHost: NSViewRepresentable {
+struct SidebarRowDragHost: NSViewRepresentable {
+    let entryID: String
+    let pasteboardType: NSPasteboard.PasteboardType
+    let menuItems: [SidebarContextMenuItem]
+    let onClick: () -> Void
+    let onDragStart: (String) -> Void
+    let onDragEnd: () -> Void
+    let onDropHover: (Bool) -> Void
+    let onHoverExit: () -> Void
+    let onDrop: (String, Bool) -> Void
+
+    func makeNSView(context: Context) -> SidebarRowDragNSView {
+        // Non-zero seed frame: a SwiftUI overlay NSView that starts at .zero
+        // can stay 0-size, so clicks and drags never arrive (#42).
+        let view = SidebarRowDragNSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+        view.pasteboardType = pasteboardType
+        view.registerForDraggedTypes([pasteboardType])
+        return view
+    }
+
+    func updateNSView(_ view: SidebarRowDragNSView, context: Context) {
+        if view.pasteboardType != pasteboardType {
+            view.unregisterDraggedTypes()
+            view.pasteboardType = pasteboardType
+            view.registerForDraggedTypes([pasteboardType])
+        }
+        view.entryID = entryID
+        view.menuItems = menuItems
+        view.onClick = onClick
+        view.onDragStart = onDragStart
+        view.onDragEnd = onDragEnd
+        view.onDropHover = onDropHover
+        view.onHoverExit = onHoverExit
+        view.onDrop = onDrop
+    }
+}
+
+struct SpaceRowDragHost: View {
     let entryID: String
     let label: String
     let onClick: () -> Void
@@ -16,34 +59,63 @@ struct SpaceRowDragHost: NSViewRepresentable {
     let onHoverExit: () -> Void
     let onDrop: (String, Bool) -> Void
 
-    func makeNSView(context: Context) -> SpaceRowDragNSView {
-        // Non-zero seed frame: a SwiftUI overlay NSView that starts at .zero
-        // can stay 0-size, so clicks and drags never arrive (#42).
-        SpaceRowDragNSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
-    }
-
-    func updateNSView(_ view: SpaceRowDragNSView, context: Context) {
-        view.entryID = entryID
-        view.label = label
-        view.onClick = onClick
-        view.onRename = onRename
-        view.onClose = onClose
-        view.onDragStart = onDragStart
-        view.onDragEnd = onDragEnd
-        view.onDropHover = onDropHover
-        view.onHoverExit = onHoverExit
-        view.onDrop = onDrop
+    var body: some View {
+        SidebarRowDragHost(
+            entryID: entryID,
+            pasteboardType: SidebarRowDragNSView.spacePasteboardType,
+            menuItems: [
+                .item(title: String(localized: "Rename Space…"), action: onRename),
+                .separator,
+                .destructive(title: String(localized: "Close Space \"\(label)\"…"), action: onClose),
+            ],
+            onClick: onClick,
+            onDragStart: onDragStart,
+            onDragEnd: onDragEnd,
+            onDropHover: onDropHover,
+            onHoverExit: onHoverExit,
+            onDrop: onDrop
+        )
     }
 }
 
-final class SpaceRowDragNSView: NSView, NSDraggingSource {
-    static let pasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.space-id")
+struct AgentRowDragHost: View {
+    let entryID: String
+    let onClick: () -> Void
+    let onRename: () -> Void
+    let onClose: () -> Void
+    let onDragStart: (String) -> Void
+    let onDragEnd: () -> Void
+    let onDropHover: (Bool) -> Void
+    let onHoverExit: () -> Void
+    let onDrop: (String, Bool) -> Void
 
+    var body: some View {
+        SidebarRowDragHost(
+            entryID: entryID,
+            pasteboardType: SidebarRowDragNSView.agentPasteboardType,
+            menuItems: [
+                .item(title: String(localized: "Rename Agent…"), action: onRename),
+                .separator,
+                .destructive(title: String(localized: "Close Agent…"), action: onClose),
+            ],
+            onClick: onClick,
+            onDragStart: onDragStart,
+            onDragEnd: onDragEnd,
+            onDropHover: onDropHover,
+            onHoverExit: onHoverExit,
+            onDrop: onDrop
+        )
+    }
+}
+
+final class SidebarRowDragNSView: NSView, NSDraggingSource {
+    static let spacePasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.space-id")
+    static let agentPasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.agent-id")
+
+    var pasteboardType = SidebarRowDragNSView.spacePasteboardType
     var entryID = ""
-    var label = ""
+    var menuItems: [SidebarContextMenuItem] = []
     var onClick: (() -> Void)?
-    var onRename: (() -> Void)?
-    var onClose: (() -> Void)?
     var onDragStart: ((String) -> Void)?
     var onDragEnd: (() -> Void)?
     var onDropHover: ((Bool) -> Void)?
@@ -55,12 +127,10 @@ final class SpaceRowDragNSView: NSView, NSDraggingSource {
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        registerForDraggedTypes([Self.pasteboardType])
     }
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
-        registerForDraggedTypes([Self.pasteboardType])
     }
 
     override var isFlipped: Bool { true }
@@ -85,7 +155,7 @@ final class SpaceRowDragNSView: NSView, NSDraggingSource {
         didDrag = true
         onDragStart?(entryID)
         let pbItem = NSPasteboardItem()
-        pbItem.setString(entryID, forType: Self.pasteboardType)
+        pbItem.setString(entryID, forType: pasteboardType)
         let item = NSDraggingItem(pasteboardWriter: pbItem)
         item.setDraggingFrame(bounds, contents: nil)
         beginDraggingSession(with: [item], event: down, source: self)
@@ -99,24 +169,26 @@ final class SpaceRowDragNSView: NSView, NSDraggingSource {
 
     override func menu(for event: NSEvent) -> NSMenu? {
         let menu = NSMenu()
-        let rename = menu.addItem(
-            withTitle: String(localized: "Rename Space…"),
-            action: #selector(renameSpace),
-            keyEquivalent: ""
-        )
-        rename.target = self
-        menu.addItem(.separator())
-        let close = menu.addItem(
-            withTitle: String(localized: "Close Space \"\(label)\"…"),
-            action: #selector(closeSpace),
-            keyEquivalent: ""
-        )
-        close.target = self
+        for item in menuItems {
+            switch item {
+            case .separator:
+                menu.addItem(.separator())
+            case .item(let title, let action):
+                let menuItem = menu.addItem(withTitle: title, action: #selector(runMenuItem(_:)), keyEquivalent: "")
+                menuItem.target = self
+                menuItem.representedObject = MenuAction(action)
+            case .destructive(let title, let action):
+                let menuItem = menu.addItem(withTitle: title, action: #selector(runMenuItem(_:)), keyEquivalent: "")
+                menuItem.target = self
+                menuItem.representedObject = MenuAction(action)
+            }
+        }
         return menu
     }
 
-    @objc private func renameSpace() { onRename?() }
-    @objc private func closeSpace() { onClose?() }
+    @objc private func runMenuItem(_ sender: NSMenuItem) {
+        (sender.representedObject as? MenuAction)?.run()
+    }
 
     func draggingSession(
         _ session: NSDraggingSession,
@@ -165,6 +237,12 @@ final class SpaceRowDragNSView: NSView, NSDraggingSource {
     }
 
     private func draggedID(from sender: NSDraggingInfo) -> String? {
-        sender.draggingPasteboard.string(forType: Self.pasteboardType)
+        sender.draggingPasteboard.string(forType: pasteboardType)
     }
+}
+
+/// NSMenu `representedObject` must be an object; a closure is not.
+private final class MenuAction: NSObject {
+    let run: () -> Void
+    init(_ run: @escaping () -> Void) { self.run = run }
 }

--- a/Sources/HerdrM/Theme.swift
+++ b/Sources/HerdrM/Theme.swift
@@ -68,10 +68,11 @@ enum Theme {
     }
 }
 
-/// Status marker shared by the sidebar rows and the ⌘K search results, so both
-/// surfaces speak the same visual language for "working / needs input / done".
+/// Codex-style conversation marks: spinner while running, a filled unread
+/// dot after a finish you have not opened, nothing once you have looked.
 struct AgentStatusGlyph: View {
     let status: AgentStatus
+    var unreadDone: Bool = false
 
     var body: some View {
         switch status {
@@ -83,10 +84,30 @@ struct AgentStatusGlyph: View {
                 .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(Theme.warning)
         case .done:
-            Image(systemName: "checkmark")
-                .font(.system(size: 10.5, weight: .bold))
-                .foregroundStyle(Theme.success)
+            if unreadDone {
+                Circle()
+                    .fill(Theme.working)
+                    .frame(width: 7, height: 7)
+            }
         case .idle, .unknown:
+            EmptyView()
+        }
+    }
+}
+
+/// Space row uses the same glyph as an agent, for the strongest state inside.
+struct SpaceAttentionGlyph: View {
+    let attention: SpaceAttention
+
+    var body: some View {
+        switch attention {
+        case .blocked:
+            AgentStatusGlyph(status: .blocked)
+        case .unreadDone:
+            AgentStatusGlyph(status: .done, unreadDone: true)
+        case .working:
+            AgentStatusGlyph(status: .working)
+        case .none:
             EmptyView()
         }
     }


### PR DESCRIPTION
## Summary
- Spaces and Agents share one set of conversation marks: spinner (running), a filled unread dot (finished, not opened yet), nothing once viewed, exclamation if the agent needs input. A space shows the strongest state among its agents.
- Agents can be drag-reordered in the sidebar. The drop calls herdr's `tab.move` (same RPC the TUI uses) so the order is the session's, not just this window. Cross-space drops are ignored.

## Why
herdrm's pitch is that you stop polling — status lives in the sidebar. Finished agents currently keep a sticky done mark, so a busy session does not tell you *who finished while you were away*. Unread is GUI-only (`AgentUnread`); the first snapshot does not seed it. The flag clears when you *leave* that pane, not while you happen to be sitting on it as the turn ends.

Spaces already drag-reorder (`workspace.move_block`). Agents are tabs in a space; without `tab.move` the GUI cannot match the TUI order. The sidebar itself follows herdr tab order so a drop can persist. ⌘K still ranks by urgency (needs input, unread, working, then the rest).

## Testing
- `swift test --package-path Packages/HerdrKit --filter 'AttentionTests|TabReorderTests'` — 9 tests, 0 failures
- Debug build against current `main` (0.5.2 terminals + files workspace)


Made with [Cursor](https://cursor.com)