### PR TITLE
feat(paste): extend image and file pasting to five more agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Added
+- Pasting images and files into an attached terminal now works for Cursor,
+  Gemini, Grok, OpenCode, and pi, alongside the existing Claude Code, Codex,
+  and Copilot support. On a local device an image on the clipboard forwards
+  Ctrl+V so the agent attaches the pixels itself; on an SSH device the image
+  or file is staged on that host and its path is pasted.
+- Settings → Agents can now override the binary path for pi.
+
+### Fixed
+- Kimi and pi rows show their bundled brand icon instead of no icon at all —
+  both marks shipped in the app but were missing from the icon lookup. Kinds
+  that only match a prefix ("claude-code-next") now resolve to the longest
+  matching mark rather than an arbitrary one, and only on a `-` boundary so a
+  two-letter kind like `pi` can't claim an unrelated name such as `pilot`.
+
 ## [0.5.2] - 2026-08-28
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/AttachmentDelivery.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/AttachmentDelivery.swift
@@ -108,14 +108,30 @@ public struct AgentAttachmentCapabilityRegistry: Sendable, Equatable {
         agentKind.lowercased().replacingOccurrences(of: "_", with: "-")
     }
 
-    /// Compatibility for Herdr servers predating manifest capabilities. Once
-    /// any manifest advertises capabilities, the server becomes authoritative.
+    /// Compatibility for Herdr servers predating manifest capabilities — which
+    /// is every release through 0.8.2, so today this table is what actually
+    /// applies. Once any manifest advertises capabilities, the server becomes
+    /// authoritative. Alias spellings mirror the `aliases` in herdr's
+    /// agent-detection manifests; herdr reports the manifest id as a pane's
+    /// agent kind, so the aliases are only defensive.
+    ///
+    /// Every kind listed binds Ctrl+V to a clipboard read that attaches image
+    /// pixels (each shells out to `osascript` for `«class PNGf»` on macOS), and
+    /// resolves a pasted path — Claude, Codex, Cursor, Gemini and OpenCode
+    /// attach it in the composer, while Copilot, Grok and pi leave it as text
+    /// for a file-read tool that returns images as vision input. Kinds whose
+    /// handling is unverified stay out of the table and paste as plain text.
     private static let legacyFallbacks: [([String], AgentAttachmentCapabilities)] = [
         (
             [
                 "claude", "claude-code",
                 "codex", "codex-cli", "openai-codex",
                 "copilot", "github-copilot", "ghcs",
+                "cursor", "cursor-agent",
+                "gemini",
+                "grok", "grok-build",
+                "opencode", "open-code",
+                "pi",
             ],
             AgentAttachmentCapabilities(
                 nativeClipboardImageData: true,

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SSHAuthenticationTests.swift
@@ -371,6 +371,98 @@ final class AgentAttachmentDeliveryPolicyTests: XCTestCase {
         XCTAssertNil(capabilityAwareRegistry.capabilities(for: "claude"))
     }
 
+    /// herdr 0.8.2's `server.agent_manifests` reports only an id and version —
+    /// no aliases, no capabilities — so the built-in table has to recognize the
+    /// bare manifest ids. Kinds outside it must stay nil and paste as plain text.
+    func testBuiltInFallbackCoversVerifiedAgentKinds() throws {
+        let data = Data(
+            """
+            [
+              { "agent": "claude", "active_version": "2026.08.21.1" },
+              { "agent": "codex", "active_version": "2026.08.09.1" },
+              { "agent": "copilot", "active_version": "2026.07.07.1" },
+              { "agent": "cursor", "active_version": "2026.08.03.1" },
+              { "agent": "gemini", "active_version": "2026.06.10.1" },
+              { "agent": "grok", "active_version": "2026.07.16.2" },
+              { "agent": "opencode", "active_version": "2026.06.10.1" },
+              { "agent": "pi", "active_version": "2026.06.10.1" },
+              { "agent": "kimi", "active_version": "2026.06.10.1" }
+            ]
+            """.utf8
+        )
+        let registry = AgentAttachmentCapabilityRegistry(
+            manifests: try JSONDecoder().decode([AgentManifestInfo].self, from: data)
+        )
+
+        for kind in ["claude", "codex", "copilot", "cursor", "gemini", "grok", "opencode", "pi"] {
+            XCTAssertEqual(
+                registry.capabilities(for: kind),
+                pathCapabilities,
+                "\(kind) should support pasted attachments"
+            )
+        }
+
+        // herdr's own manifest aliases, in case detection ever reports one.
+        XCTAssertEqual(registry.capabilities(for: "cursor-agent"), pathCapabilities)
+        XCTAssertEqual(registry.capabilities(for: "grok-build"), pathCapabilities)
+        XCTAssertEqual(registry.capabilities(for: "open-code"), pathCapabilities)
+
+        // Advertised by herdr but unverified here: no capabilities, plain paste.
+        XCTAssertNil(registry.capabilities(for: "kimi"))
+        XCTAssertNil(registry.capabilities(for: "devin"))
+    }
+
+    func testVerifiedAgentsDeliverImagesLocallyAndRemotely() throws {
+        let data = Data(
+            """
+            [
+              { "agent": "cursor" },
+              { "agent": "gemini" },
+              { "agent": "grok" },
+              { "agent": "opencode" },
+              { "agent": "pi" }
+            ]
+            """.utf8
+        )
+        let registry = AgentAttachmentCapabilityRegistry(
+            manifests: try JSONDecoder().decode([AgentManifestInfo].self, from: data)
+        )
+        let remote = Device.Kind.ssh(target: "user@example.test")
+
+        for kind in ["cursor", "gemini", "grok", "opencode", "pi"] {
+            let capabilities = registry.capabilities(for: kind)
+            // Local: the agent shells out to osascript and reads the clipboard.
+            XCTAssertEqual(
+                AgentAttachmentDeliveryPolicy.action(
+                    capabilities: capabilities,
+                    deviceKind: .local,
+                    source: .imageData
+                ),
+                .nativeClipboard,
+                "\(kind) should read the local clipboard"
+            )
+            // Remote: the Mac clipboard is unreachable, so stage and paste paths.
+            XCTAssertEqual(
+                AgentAttachmentDeliveryPolicy.action(
+                    capabilities: capabilities,
+                    deviceKind: remote,
+                    source: .imageData
+                ),
+                .devicePaths(.shellQuoted),
+                "\(kind) should paste a staged remote path"
+            )
+            XCTAssertEqual(
+                AgentAttachmentDeliveryPolicy.action(
+                    capabilities: capabilities,
+                    deviceKind: .local,
+                    source: .files(allImages: false)
+                ),
+                .devicePaths(.shellQuoted),
+                "\(kind) should paste a local path for generic files"
+            )
+        }
+    }
+
     func testLocalDeliveryUsesNativeClipboardForImages() {
         XCTAssertEqual(
             AgentAttachmentDeliveryPolicy.action(

--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ macOS window on top of it, and it's grown well past "attach to a terminal":
   upload or download regular files with progress, cancellation, and explicit Replace / Keep
   Both conflict handling. Transfers use the same OpenSSH config, agent, host-key, and Keychain
   password flow as terminals.
-- **Paste files and images** into Claude Code, Codex, or Copilot. Local pastes forward as
-  Ctrl+V; remote pastes stream over SSH into a self-pruning cache (7-day retention, 50 MB cap).
+- **Paste files and images** into Claude Code, Codex, Copilot, Cursor, Gemini, Grok, OpenCode,
+  or pi. Local pastes forward as Ctrl+V so the agent reads the clipboard itself; remote pastes
+  stream over SSH into a self-pruning cache (7-day retention, 50 MB cap) and paste the path.
 - **Search** — ⌘K across every device, ordered by urgency, scrolling to follow your selection.
 - **Notifications** — a sound and a system alert when any agent finishes or needs input;
   clicking jumps straight to it. Agents you're already watching stay quiet.

--- a/Sources/HerdrM/BrandIcon.swift
+++ b/Sources/HerdrM/BrandIcon.swift
@@ -68,15 +68,21 @@ enum BrandIconLoader {
             "deepseek": "deepseek",
             "qwen": "qwen", "qwen-code": "qwen",
             "copilot": "copilot", "github-copilot": "githubcopilot",
+            "kimi": "kimi",
+            "pi": "pi",
         ]
         var base: String?
         if let exact = map[normalized] {
             base = exact
         } else {
-            for (key, value) in map where normalized.hasPrefix(key) {
-                base = value
-                break
-            }
+            // Suffixed kinds ("claude-code-next") fall back to their base mark.
+            // Longest key first so "claude-code" outranks "claude" — a plain
+            // dictionary walk picked an arbitrary one — and the "-" boundary
+            // keeps a two-letter kind like "pi" from claiming "pilot".
+            base = map
+                .filter { normalized.hasPrefix("\($0.key)-") }
+                .max { $0.key.count < $1.key.count }?
+                .value
         }
         guard let base else { return nil }
         if Bundle.main.url(forResource: "\(base)-color", withExtension: "svg") != nil {

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -274,6 +274,7 @@ struct AgentsSettingsView: View {
         ("grok", "Grok", "grok"),
         ("kimi", "Kimi", "kimi"),
         ("opencode", "OpenCode", "opencode"),
+        ("pi", "Pi", "pi"),
         ("copilot", "Copilot", "copilot"),
     ]
 


### PR DESCRIPTION
Cursor, Gemini, Grok, OpenCode, and pi join Claude Code, Codex, and Copilot in the built-in capability table. That table is what actually applies today: no herdr release through 0.8.2 advertises manifest capabilities, so the server only becomes authoritative once one does.

Every kind listed binds Ctrl+V to a clipboard read that attaches image pixels, so a local paste forwards Ctrl+V and lets the agent read the clipboard itself, while a remote paste stages the file on that host and pastes its path. Claude, Codex, Cursor, Gemini, and OpenCode attach that path in the composer; Copilot, Grok, and pi leave it as text for a file-read tool that returns images as vision input. Kinds whose handling is unverified stay out of the table and keep pasting as plain text. The alias spellings mirror the aliases in herdr's agent-detection manifests and are only defensive, since herdr reports the manifest id as a pane's agent kind.

Settings → Agents can now override the binary path for pi.

Also fixes the sidebar brand marks. Kimi and pi shipped their icons in the bundle but were missing from the lookup, and the prefix fallback walked the dictionary in arbitrary order, so a suffixed kind could resolve to whichever key happened to come first. It now takes the longest matching key, so "claude-code-next" prefers "claude-code" over "claude", and requires a "-" boundary so a two-letter kind like "pi" cannot claim an unrelated name such as "pilot".