### PR TITLE
fix(build): fall back to ad-hoc signing without the Developer ID cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Fixed
+- `make build` works without the maintainer's Developer ID certificate. It pins
+  that identity for Debug so dev builds keep UserNotifications working, but
+  xcodegen rewrites the project on every build, so an Xcode-side signing change
+  never survived and contributors were left with a hard failure. It now falls
+  back to ad-hoc signing when the certificate is absent — ad-hoc rather than
+  unsigned because arm64 refuses to exec a binary with no signature at all.
+
 ## [0.5.2] - 2026-08-28
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,32 @@
 .PHONY: gen build run test kit-test clean
 
+# project.yml pins the maintainer's Developer ID for Debug so dev builds keep
+# entitlement-backed features (UserNotifications) working. Contributors don't
+# have that certificate, and xcodegen rewrites the project on every build, so an
+# Xcode-side signing change never survives. Fall back to ad-hoc signing when the
+# certificate isn't in the Keychain.
+#
+# Ad-hoc, not unsigned: arm64 refuses to exec a binary with no signature at all,
+# so CODE_SIGNING_ALLOWED=NO produces an app that cannot launch. The tradeoff is
+# that ad-hoc builds lose entitlement-backed features.
+SIGN_ID := Developer ID Application: MOE AI LLC (NCFNX3LJ83)
+HAVE_SIGN_ID := $(shell security find-identity -v -p codesigning 2>/dev/null | grep -c 'NCFNX3LJ83')
+ifeq ($(HAVE_SIGN_ID),0)
+SIGN_FLAGS := CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM=
+endif
+
+XCODEBUILD := xcodebuild -project HerdrM.xcodeproj -scheme HerdrM \
+	-configuration Debug -derivedDataPath build -skipPackagePluginValidation
+
 gen:
 	xcodegen generate
 
 build: gen
-	xcodebuild -project HerdrM.xcodeproj -scheme HerdrM -configuration Debug -derivedDataPath build build -skipPackagePluginValidation | tail -5
+ifeq ($(HAVE_SIGN_ID),0)
+	@echo "note: '$(SIGN_ID)' not in the Keychain — signing ad-hoc."
+	@echo "      UserNotifications and other entitlement-backed features will not work."
+endif
+	$(XCODEBUILD) $(SIGN_FLAGS) build | tail -5
 
 run: build
 	open build/Build/Products/Debug/herdrm.app


### PR DESCRIPTION
## Summary

`make build` currently fails for anyone who isn't the maintainer:

```
error: No certificate for team 'NCFNX3LJ83' matching
'Developer ID Application: MOE AI LLC (NCFNX3LJ83)' found
```

`project.yml` pins that identity for Debug, which is deliberate — dev builds keep
entitlement-backed features like UserNotifications working. But `xcodegen` rewrites
the project on every `make build`, so changing the signing settings in Xcode never
survives, and there was no way for a contributor to get a working build.

The Makefile now probes the Keychain for the identity and falls back to ad-hoc
signing when it's absent, printing what that costs:

```
note: 'Developer ID Application: MOE AI LLC (NCFNX3LJ83)' not in the Keychain — signing ad-hoc.
      UserNotifications and other entitlement-backed features will not work.
```

Maintainer builds are unchanged: with the certificate present, `SIGN_FLAGS` is empty
and the command is exactly what it was.

## Why ad-hoc rather than unsigned

`CODE_SIGNING_ALLOWED=NO` looks like the obvious fix, but arm64 refuses to `exec` a
binary carrying no signature at all, so it produces an app that builds and then
can't launch. `CODE_SIGN_IDENTITY=-` is the smallest thing that yields a runnable app.

## Testing

- Without the certificate (this machine): prints the note, `** BUILD SUCCEEDED **`,
  and the app launches.
- The `xcodebuild` invocation was factored into a variable with no change to its flags,
  so the signed path is byte-identical apart from the appended `SIGN_FLAGS`.