### PR TITLE
fix(terminal): fix powerline separators in light mode

### DIFF
--- a/Sources/HerdrM/TerminalColorFilter.swift
+++ b/Sources/HerdrM/TerminalColorFilter.swift
@@ -28,7 +28,30 @@ struct LightTerminalANSIAdapter {
             guard end < pending.count else { break }
 
             let sequence = Array(pending[index...end])
-            output.append(contentsOf: pending[end] == 0x6D ? transformSGR(sequence) : sequence)
+            if pending[end] == 0x6D {
+                // A Powerline separator is a foreground-colored shape painted
+                // over the next segment's background.  Its foreground is not
+                // ordinary text: it is deliberately the previous segment's
+                // background.  Wait for the next scalar so the light-theme
+                // contrast transform does not turn that join into a dark,
+                // blended-looking arrow.
+                if let preservesPowerlineForeground = powerlineFollowsSGR(after: end + 1) {
+                    output.append(contentsOf: transformSGR(
+                        sequence,
+                        preservePowerlineForeground: preservesPowerlineForeground
+                    ))
+                } else if sequenceContainsForegroundColor(sequence) {
+                    // Only a foreground SGR can be the color of a following
+                    // separator. Do not hold resets/background-only updates at
+                    // the end of a PTY read; otherwise typed echo can inherit
+                    // the previous cell's style until another output arrives.
+                    break
+                } else {
+                    output.append(contentsOf: transformSGR(sequence))
+                }
+            } else {
+                output.append(contentsOf: sequence)
+            }
             index = end + 1
         }
 
@@ -94,7 +117,62 @@ struct LightTerminalANSIAdapter {
         return (levels[value / 36], levels[(value / 6) % 6], levels[value % 6])
     }
 
-    private func transformSGR(_ sequence: [UInt8]) -> [UInt8] {
+    private func sequenceContainsForegroundColor(_ sequence: [UInt8]) -> Bool {
+        guard sequence.count >= 3 else { return false }
+        let parameters = sequence[2..<(sequence.count - 1)]
+        let values = String(decoding: parameters, as: UTF8.self)
+            .split(separator: ";", omittingEmptySubsequences: false)
+        return values.contains { $0 == "38" }
+    }
+
+    /// Looks past complete control sequences for the next UTF-8 scalar.
+    /// `nil` means that the current chunk ends before the scalar (or its
+    /// intervening CSI), so the caller must retain the SGR for the next feed.
+    private func powerlineFollowsSGR(after start: Int) -> Bool? {
+        var index = start
+        while index < pending.count {
+            // SGRs are sometimes split into separate writes by a prompt
+            // renderer. Skip a complete CSI while looking for the glyph.
+            if pending[index] == 0x1B {
+                guard index + 1 < pending.count else { return nil }
+                guard pending[index + 1] == 0x5B else { return false }
+                var end = index + 2
+                while end < pending.count, !(0x40...0x7E).contains(pending[end]) {
+                    end += 1
+                }
+                guard end < pending.count else { return nil }
+                index = end + 1
+                continue
+            }
+
+            // Do not classify an incomplete UTF-8 sequence as an ordinary
+            // character: dataReceived can split the glyph across chunks.
+            let first = pending[index]
+            let scalarLength: Int
+            switch first {
+            case 0xC2...0xDF: scalarLength = 2
+            case 0xE0...0xEF: scalarLength = 3
+            case 0xF0...0xF4: scalarLength = 4
+            default:
+                return false
+            }
+            guard index + scalarLength <= pending.count else { return nil }
+            let scalarBytes = pending[index..<(index + scalarLength)]
+            guard let scalar = String(decoding: scalarBytes, as: UTF8.self).unicodeScalars.first else {
+                return false
+            }
+            // Include the thin and rounded Powerline variants as well as the
+            // four shapes SwiftTerm draws itself. All of them use the same
+            // foreground/background layering contract.
+            return (0xE0B0...0xE0D7).contains(scalar.value)
+        }
+        return nil
+    }
+
+    private func transformSGR(
+        _ sequence: [UInt8],
+        preservePowerlineForeground: Bool = false
+    ) -> [UInt8] {
         guard sequence.count >= 3 else { return sequence }
         let parameters = sequence[2..<(sequence.count - 1)]
         let values = String(decoding: parameters, as: UTF8.self)
@@ -111,7 +189,13 @@ struct LightTerminalANSIAdapter {
                let green = Int(values[index + 3]),
                let blue = Int(values[index + 4]),
                (0...255).contains(red), (0...255).contains(green), (0...255).contains(blue) {
-                let light = Self.adapt(red: red, green: green, blue: blue, isBackground: isBackground)
+                let light = preservePowerlineForeground && !isBackground
+                    // Separator foregrounds are neighboring backgrounds, so
+                    // use the background transform rather than the text
+                    // contrast transform. This also keeps dark prompts
+                    // internally consistent after their backgrounds flip.
+                    ? Self.adapt(red: red, green: green, blue: blue, isBackground: true)
+                    : Self.adapt(red: red, green: green, blue: blue, isBackground: isBackground)
                 output += [values[index], "2", String(light.red), String(light.green), String(light.blue)]
                 index += 5
             } else if isColor, index + 2 < values.count, values[index + 1] == "5",
@@ -120,7 +204,9 @@ struct LightTerminalANSIAdapter {
                       // already themed; rewriting them here would flip them twice.
                       (16...255).contains(paletteIndex) {
                 let base = Self.xterm256RGB(paletteIndex)
-                let light = Self.adapt(red: base.red, green: base.green, blue: base.blue, isBackground: isBackground)
+                let light = preservePowerlineForeground && !isBackground
+                    ? Self.adapt(red: base.red, green: base.green, blue: base.blue, isBackground: true)
+                    : Self.adapt(red: base.red, green: base.green, blue: base.blue, isBackground: isBackground)
                 output += [values[index], "2", String(light.red), String(light.green), String(light.blue)]
                 index += 3
             } else {

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -151,6 +151,14 @@ final class LineBreakTerminalView: LocalProcessTerminalView {
     var usesLightColors = false
     var appliedDarkAppearance: Bool?
     private var lightColorAdapter = LightTerminalANSIAdapter()
+
+    /// A light-mode feed can retain a partial SGR while waiting to identify a
+    /// Powerline separator. Drop that parser state when switching themes so a
+    /// later light-mode session cannot prepend stale bytes to new output.
+    func resetLightColorAdapter() {
+        lightColorAdapter = LightTerminalANSIAdapter()
+    }
+
     /// Last non-empty caret frame, used when the TUI hides the hardware cursor
     /// and SwiftTerm's `firstRect` would otherwise report `.zero`.
     private var lastIMECaretFrame: NSRect = .zero
@@ -873,6 +881,7 @@ func applyTerminalAppearance(
     guard let view = view as? LineBreakTerminalView,
           view.appliedDarkAppearance != dark
     else { return }
+    view.resetLightColorAdapter()
     view.appliedDarkAppearance = dark
     view.usesLightColors = !dark
     view.nativeBackgroundColor = dark ? TerminalDefaults.darkBackground : TerminalDefaults.lightBackground

--- a/Tests/TerminalColorFilterTests.swift
+++ b/Tests/TerminalColorFilterTests.swift
@@ -12,6 +12,10 @@ struct TerminalColorFilterTests {
         expect(result.contains("38;2;25;25;25"), "light foreground should become dark")
         expect(result.contains("48;2;225;225;225"), "dark input background should become light")
 
+        var resetAdapter = LightTerminalANSIAdapter()
+        let resetResult = String(decoding: resetAdapter.transform(Array("\u{1B}[0m".utf8)[...]), as: UTF8.self)
+        expect(resetResult == "\u{1B}[0m", "a trailing reset should not wait for another output chunk")
+
         var splitAdapter = LightTerminalANSIAdapter()
         let first = Array("before\u{1B}[48;2;30;".utf8)
         let second = Array("30;30mafter".utf8)
@@ -38,6 +42,52 @@ struct TerminalColorFilterTests {
         let lightThemeResult = String(decoding: lightThemeAdapter.transform(lightTheme[...]), as: UTF8.self)
         expect(lightThemeResult.contains("48;2;245;245;245"), "light backgrounds must not flip dark")
         expect(lightThemeResult.contains("38;2;50;50;50"), "dark foregrounds on light rows must stay dark")
+
+        // Powerline separators are layered: the separator foreground is the
+        // previous segment's background, while the cell background is the next
+        // segment's background. Do not run the foreground through the normal
+        // contrast transform or the join turns into a dark blended arrow.
+        var powerlineAdapter = LightTerminalANSIAdapter()
+        let powerlineText = "\u{1B}[48;2;243;139;168;38;2;17;17;27muser"
+            + "\u{1B}[48;2;250;179;135;38;2;243;139;168m\u{E0B0}"
+            + "\u{1B}[38;2;17;17;27mpath"
+        let powerline = Array(powerlineText.utf8)
+        let powerlineResult = String(decoding: powerlineAdapter.transform(powerline[...]), as: UTF8.self)
+        expect(
+            powerlineResult.contains("48;2;250;179;135;38;2;243;139;168m\u{E0B0}"),
+            "powerline foreground should retain the neighboring segment color"
+        )
+        expect(
+            powerlineResult.contains("38;2;17;17;27mpath"),
+            "ordinary foreground after a powerline separator should still adapt normally"
+        )
+
+        var darkPowerlineAdapter = LightTerminalANSIAdapter()
+        let darkPowerline = Array(
+            "\u{1B}[48;2;30;30;30;38;2;30;30;30m\u{E0B0}".utf8
+        )
+        let darkPowerlineResult = String(
+            decoding: darkPowerlineAdapter.transform(darkPowerline[...]),
+            as: UTF8.self
+        )
+        expect(
+            darkPowerlineResult.contains("48;2;225;225;225;38;2;225;225;225m\u{E0B0}"),
+            "a dark powerline separator should follow the flipped neighboring background"
+        )
+
+        // The separator and its UTF-8 bytes may arrive in separate PTY reads.
+        var splitPowerlineAdapter = LightTerminalANSIAdapter()
+        let splitPowerlineBytes = Array("\u{E0B0}next".utf8)
+        let splitPowerlineFirst = Array("\u{1B}[48;2;250;179;135;38;2;243;139;168m".utf8)
+            + [splitPowerlineBytes[0]]
+        let splitPowerlineSecond = Array(splitPowerlineBytes[1...])
+        let splitPowerlineResult = splitPowerlineAdapter.transform(splitPowerlineFirst[...])
+            + splitPowerlineAdapter.transform(splitPowerlineSecond[...])
+        expect(
+            String(decoding: splitPowerlineResult, as: UTF8.self)
+                == "\u{1B}[48;2;250;179;135;38;2;243;139;168m\u{E0B0}next",
+            "split powerline glyphs should retain their layered foreground"
+        )
 
         // Foregrounds that already read well on white keep their color;
         // only dark backgrounds flip.


### PR DESCRIPTION
Fix #63 

## Problem

In light mode, HerdrM rewrites ANSI colors through `LightTerminalANSIAdapter` before passing the output to SwiftTerm.

Powerline separators are not ordinary text. Their foreground color represents the previous segment's background, while the cell background represents the next segment. This layered color relationship produces a continuous separator.

The previous implementation applied the normal text-foreground contrast transformation to these separator colors. As a result, the separators became darker than their neighboring segments and rendered differently from Ghostty.

## Solution

The ANSI adapter now recognizes Powerline characters and applies the background-color transformation to the separator foreground instead of the normal text-foreground transformation.

The implementation also handles ANSI sequences and UTF-8 Powerline characters split across PTY chunks, while preserving the existing behavior for ordinary text and backgrounds.

## Changes

### `Sources/HerdrM/TerminalColorFilter.swift`

- Added Powerline character detection for `U+E0B0...U+E0D7`.
- Added lookahead across complete CSI sequences and split UTF-8 input.
- Apply background transformation rules to Powerline foreground colors.
- Keep ordinary foreground/background transformations unchanged.
- Avoid delaying ordinary trailing reset sequences.

### `Sources/HerdrM/TerminalView.swift`

- Reset the ANSI adapter when switching between light and dark appearances, preventing stale partial sequences from affecting later output.

### `Tests/TerminalColorFilterTests.swift`

Added coverage for:

- Ordinary ANSI foreground and background conversion.
- Powerline separator color preservation.
- Dark Powerline prompts in light mode.
- ANSI and UTF-8 sequences split across PTY chunks.
- Immediate handling of trailing reset sequences.

## Verification

The color-adapter tests pass, and the application builds successfully with Xcode. This fix was mostly done with help from AI, so please take an extra careful look — thanks!
<img width="522" height="175" alt="e2dd2ff6768dfc575792d321d04a8a22" src="https://github.com/user-attachments/assets/35e510f9-4583-47a3-ade6-86e21089e498" />

