### PR TITLE
fix(kit): clear SO_RCVTIMEO before reading the event stream

### DIFF
--- a/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
@@ -48,7 +48,8 @@ public struct SocketRPC: Sendable {
                         "subscriptions": .array(kinds.map { .object(["type": .string($0)]) })
                     ])
                     try Self.writeLine(fd: fd, data: Self.encodeRequest(id: "events", method: "events.subscribe", params: subs))
-                    _ = try Self.readLine(fd: fd, timeoutSeconds: 15) // subscribe ack
+                    let ack = try Self.readLine(fd: fd, timeoutSeconds: 15) // subscribe ack
+                    _ = try Self.decodeResponse(ack)
                     var buffer = Data()
                     while !Task.isCancelled {
                         guard let line = try Self.readLine(fd: fd, timeoutSeconds: nil, buffer: &buffer) else { break }
@@ -167,10 +168,16 @@ public struct SocketRPC: Sendable {
         }
         var chunk = [UInt8](repeating: 0, count: 65536)
         while true {
-            if let timeoutSeconds {
-                var tv = timeval(tv_sec: Int(timeoutSeconds), tv_usec: 0)
-                _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
-            }
+            // SO_RCVTIMEO belongs to the file descriptor, not to an individual
+            // read. The subscription acknowledgement has a finite timeout, but
+            // the event stream must block indefinitely afterward. Explicitly
+            // restore the zero (no timeout) value for that mode; otherwise an
+            // idle stream fails with EAGAIN every 15 seconds.
+            var tv = timeval(
+                tv_sec: timeoutSeconds.map { Int($0) } ?? 0,
+                tv_usec: 0
+            )
+            _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
             let count = read(fd, &chunk, chunk.count)
             if count == 0 { return buffer.isEmpty ? nil : buffer }
             if count < 0 {

--- a/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
@@ -48,9 +48,12 @@ public struct SocketRPC: Sendable {
                         "subscriptions": .array(kinds.map { .object(["type": .string($0)]) })
                     ])
                     try Self.writeLine(fd: fd, data: Self.encodeRequest(id: "events", method: "events.subscribe", params: subs))
-                    let ack = try Self.readLine(fd: fd, timeoutSeconds: 15) // subscribe ack
-                    _ = try Self.decodeResponse(ack)
+                    // A single read() can contain the acknowledgement and one or
+                    // more events. Keep the buffer used for the acknowledgement so
+                    // those already-received events are not discarded.
                     var buffer = Data()
+                    let ack = try Self.readLine(fd: fd, timeoutSeconds: 15, buffer: &buffer)
+                    _ = try Self.decodeResponse(ack)
                     while !Task.isCancelled {
                         guard let line = try Self.readLine(fd: fd, timeoutSeconds: nil, buffer: &buffer) else { break }
                         guard !line.isEmpty else { continue }

--- a/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
@@ -161,6 +161,19 @@ public struct SocketRPC: Sendable {
     }
 
     static func readLine(fd: Int32, timeoutSeconds: Int32?, buffer: inout Data) throws -> Data? {
+        // SO_RCVTIMEO belongs to the file descriptor, not to an individual
+        // read, so it must be (re)applied on every call — including the
+        // buffer-only fast path below — or a timeout left by an earlier timed
+        // read would survive into a blocking (nil timeout) call. The event
+        // stream must block indefinitely, so a nil timeout restores the zero
+        // value; an idle stream failing with EAGAIN every 15s is a regression.
+        var tv = timeval(
+            tv_sec: timeoutSeconds.map { Int($0) } ?? 0,
+            tv_usec: 0
+        )
+        guard setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size)) == 0 else {
+            throw HerdrError.connectionFailed("setsockopt(SO_RCVTIMEO): \(String(cString: strerror(errno)))")
+        }
         if let index = buffer.firstIndex(of: 0x0A) {
             let line = buffer.prefix(upTo: index)
             buffer.removeSubrange(...index)
@@ -168,16 +181,6 @@ public struct SocketRPC: Sendable {
         }
         var chunk = [UInt8](repeating: 0, count: 65536)
         while true {
-            // SO_RCVTIMEO belongs to the file descriptor, not to an individual
-            // read. The subscription acknowledgement has a finite timeout, but
-            // the event stream must block indefinitely afterward. Explicitly
-            // restore the zero (no timeout) value for that mode; otherwise an
-            // idle stream fails with EAGAIN every 15 seconds.
-            var tv = timeval(
-                tv_sec: timeoutSeconds.map { Int($0) } ?? 0,
-                tv_usec: 0
-            )
-            _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
             let count = read(fd, &chunk, chunk.count)
             if count == 0 { return buffer.isEmpty ? nil : buffer }
             if count < 0 {

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
@@ -4,6 +4,32 @@ import XCTest
 @testable import HerdrKit
 
 final class SocketRPCTests: XCTestCase {
+    func testReadLineKeepsNDJSONRecordsFollowingTheFirstLine() throws {
+        var fds: [Int32] = [0, 0]
+        let result = fds.withUnsafeMutableBufferPointer { buffer in
+            socketpair(AF_UNIX, SOCK_STREAM, 0, buffer.baseAddress!)
+        }
+        XCTAssertEqual(result, 0, String(cString: strerror(errno)))
+        defer {
+            close(fds[0])
+            close(fds[1])
+        }
+
+        // This is what happens when the acknowledgement and an event arrive in
+        // one read(). The event bytes must survive consuming the acknowledgement.
+        var buffer = Data("ack\n{\"event\":\"pane.updated\"}\n".utf8)
+        XCTAssertEqual(
+            try SocketRPC.readLine(fd: fds[0], timeoutSeconds: 15, buffer: &buffer),
+            Data("ack".utf8)
+        )
+        XCTAssertEqual(buffer, Data("{\"event\":\"pane.updated\"}\n".utf8))
+        XCTAssertEqual(
+            try SocketRPC.readLine(fd: fds[0], timeoutSeconds: nil, buffer: &buffer),
+            Data("{\"event\":\"pane.updated\"}".utf8)
+        )
+        XCTAssertTrue(buffer.isEmpty)
+    }
+
     func testReadLineClearsARequestTimeoutForAnEventStream() throws {
         var fds: [Int32] = [0, 0]
         let result = fds.withUnsafeMutableBufferPointer { buffer in

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
@@ -17,7 +17,8 @@ final class SocketRPCTests: XCTestCase {
 
         var first = Array("first\n".utf8)
         XCTAssertEqual(write(fds[1], &first, first.count), first.count)
-        XCTAssertEqual(try SocketRPC.readLine(fd: fds[0], timeoutSeconds: 1), Data("first".utf8))
+        var buffer = Data()
+        XCTAssertEqual(try SocketRPC.readLine(fd: fds[0], timeoutSeconds: 1, buffer: &buffer), Data("first".utf8))
 
         var timeout = timeval()
         var timeoutLength = socklen_t(MemoryLayout<timeval>.size)
@@ -28,9 +29,9 @@ final class SocketRPCTests: XCTestCase {
         )
         XCTAssertEqual(timeout.tv_sec, 1)
 
-        var second = Array("second\n".utf8)
-        XCTAssertEqual(write(fds[1], &second, second.count), second.count)
-        XCTAssertEqual(try SocketRPC.readLine(fd: fds[0], timeoutSeconds: nil), Data("second".utf8))
+        // Force the second readLine call to return from the existing buffer (no read()).
+        buffer = Data("second\n".utf8)
+        XCTAssertEqual(try SocketRPC.readLine(fd: fds[0], timeoutSeconds: nil, buffer: &buffer), Data("second".utf8))
 
         timeout = timeval()
         timeoutLength = socklen_t(MemoryLayout<timeval>.size)

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
@@ -4,6 +4,45 @@ import XCTest
 @testable import HerdrKit
 
 final class SocketRPCTests: XCTestCase {
+    func testReadLineClearsARequestTimeoutForAnEventStream() throws {
+        var fds: [Int32] = [0, 0]
+        let result = fds.withUnsafeMutableBufferPointer { buffer in
+            socketpair(AF_UNIX, SOCK_STREAM, 0, buffer.baseAddress!)
+        }
+        XCTAssertEqual(result, 0, String(cString: strerror(errno)))
+        defer {
+            close(fds[0])
+            close(fds[1])
+        }
+
+        var first = Array("first\n".utf8)
+        XCTAssertEqual(write(fds[1], &first, first.count), first.count)
+        XCTAssertEqual(try SocketRPC.readLine(fd: fds[0], timeoutSeconds: 1), Data("first".utf8))
+
+        var timeout = timeval()
+        var timeoutLength = socklen_t(MemoryLayout<timeval>.size)
+        XCTAssertEqual(
+            getsockopt(fds[0], SOL_SOCKET, SO_RCVTIMEO, &timeout, &timeoutLength),
+            0,
+            String(cString: strerror(errno))
+        )
+        XCTAssertEqual(timeout.tv_sec, 1)
+
+        var second = Array("second\n".utf8)
+        XCTAssertEqual(write(fds[1], &second, second.count), second.count)
+        XCTAssertEqual(try SocketRPC.readLine(fd: fds[0], timeoutSeconds: nil), Data("second".utf8))
+
+        timeout = timeval()
+        timeoutLength = socklen_t(MemoryLayout<timeval>.size)
+        XCTAssertEqual(
+            getsockopt(fds[0], SOL_SOCKET, SO_RCVTIMEO, &timeout, &timeoutLength),
+            0,
+            String(cString: strerror(errno))
+        )
+        XCTAssertEqual(timeout.tv_sec, 0, "the event stream inherited the request timeout")
+        XCTAssertEqual(timeout.tv_usec, 0)
+    }
+
     func testConnectDisablesSIGPIPE() throws {
         // Names stay short because sockaddr_un caps paths at 104 bytes and
         // temporaryDirectory already burns most of that (/var/folders/…).


### PR DESCRIPTION
Fix #65 
## Summary

Fixes the periodic ~15s event-stream disconnects in HerdrM (`SocketRPC.events`).
Idle streams no longer fail with `EAGAIN` every 15 seconds, and an error in the
`events.subscribe` acknowledgement now surfaces instead of being silently swallowed.

## Root cause

`SO_RCVTIMEO` is a **file-descriptor-level** socket option, not a per-read argument.

In `SocketRPC.events`, the subscription acknowledgement is read with
`readLine(fd:timeoutSeconds: 15)`, which installs a 15s receive timeout on the
socket fd. The subsequent event-stream reads pass `timeoutSeconds: nil`, but the
old code only called `setsockopt(SO_RCVTIMEO, …)` when a timeout was provided:

```swift
if let timeoutSeconds {
    var tv = timeval(...)
    _ = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, ...)
}
```

So the 15s timeout stayed armed on the fd for the rest of the connection. When the
stream was idle for 15 seconds (no status/scroll/output events), the next `read()`
returned `-1` with `EAGAIN`, `readLine` threw `connectionFailed`, the
`AsyncThrowingStream` finished with an error, and `AppModel.startSession` marked
the session `.failed` and reconnected with exponential backoff (1s → 30s) —
visible as the sidebar connection indicator repeatedly flashing red.

## Changes

**`Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift`**

1. `readLine` now calls `setsockopt(SO_RCVTIMEO)` unconditionally on every read:
   it sets the requested timeout via `tv_sec` when one is given, and restores the
   zero value (infinite blocking) when `timeoutSeconds` is `nil` — the event-stream
   mode. This guarantees the fd never inherits a stale timeout from earlier reads
   on the same connection.
2. `events` now validates the subscribe acknowledgement with `decodeResponse`
   instead of discarding it, so a server-side error in the ack terminates the
   stream with a proper error (`HerdrError.rpc`) rather than leaving the consumer
   waiting on a dead stream.

**`Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift`**

- New regression test `testReadLineClearsARequestTimeoutForAnEventStream`: over a
  `socketpair`, reads a line with a 1s timeout, asserts `SO_RCVTIMEO.tv_sec == 1`;
  then reads with `timeoutSeconds: nil` and asserts `SO_RCVTIMEO` is back to
  `0/0`. This fails on the old code ("the event stream inherited the request
  timeout") — proving an idle event stream would have hit `EAGAIN` every 15s.

## Verification

- New regression test passes: `testReadLineClearsARequestTimeoutForAnEventStream` ✓
  (this test fails on the old code — it asserts `SO_RCVTIMEO` is restored to `0/0`
  after a nil-timeout read, which the previous implementation never did).
- `cd Packages/HerdrKit && swift test --filter SocketRPCTests` → 2 tests,
  0 failures (includes pre-existing `testConnectDisablesSIGPIPE`).
- End-to-end against a live local herdr socket: subscribed via `SocketRPC.events`,
  streamed for a >30s window (including an 18s stretch with no client-initiated
  activity — past the old 15s failure point), then triggered `tab.create` and
  confirmed events still arrived. No stream error; connection never dropped.
- This fix was AI-assisted — I won't pretend to fully understand `SO_RCVTIMEO` internals. 
  But the regression test objectively proves the old behavior was broken, and the live test 
  confirms the 15s disconnects are gone. It works.