### PR TITLE
feat(sidebar): rename Space, Agent, and Terminal on double-click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ the Sparkle update description — a release without a section here fails CI.
   (same sheet as the context menu). Terminals now rename via `tab.rename`, and
   a user-set tab label wins over the OSC title so the new name is visible.
 
+### Fixed
+- Sidebar Space, Agent, and Terminal rows expose a VoiceOver default action
+  so Activate selects the row (they are not SwiftUI `Button`s).
+
 ## [0.5.3] - 2026-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Added
+- Double-click a Space, Agent, or herdr Terminal in the sidebar to rename it
+  (same sheet as the context menu). Terminals now rename via `tab.rename`, and
+  a user-set tab label wins over the OSC title so the new name is visible.
+
 ## [0.5.3] - 2026-08-29
 
 ### Added

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2161,6 +2161,54 @@
         }
       }
     },
+    "Rename Terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename Terminal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名终端"
+          }
+        }
+      }
+    },
+    "Rename Terminal…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename Terminal…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名终端…"
+          }
+        }
+      }
+    },
+    "Terminal name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal name"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端名称"
+          }
+        }
+      }
+    },
     "Agent name" : {
       "localizations" : {
         "en" : {

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -165,6 +165,7 @@ final class AppModel: ObservableObject {
     @Published var sshAuthenticationRequest: SSHAuthenticationRequest?
     @Published var spaceToRename: SpaceEntry?
     @Published var agentToRename: AgentEntry?
+    @Published var terminalToRename: TerminalEntry?
     /// Transient action failures: shown as an alert, never by tearing down sessions.
     @Published var actionError: String?
 
@@ -268,12 +269,13 @@ final class AppModel: ObservableObject {
         var ref: PaneRef { PaneRef(deviceID: device.id, paneID: pane.paneID) }
 
         var title: String {
+            // User tab labels must win or `tab.rename` is invisible behind OSC.
+            if let label = tab?.customLabel {
+                return label
+            }
             if let terminalTitle = pane.terminalTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
                !terminalTitle.isEmpty {
                 return terminalTitle
-            }
-            if let label = tab?.customLabel {
-                return label
             }
             if let cwd = pane.cwd, !cwd.isEmpty {
                 let basename = URL(fileURLWithPath: cwd).lastPathComponent
@@ -990,17 +992,23 @@ final class AppModel: ObservableObject {
     }
 
     func renameAgent(_ entry: AgentEntry, name: String) {
+        renameTabLabel(device: entry.device, tabID: entry.agent.tabID, current: entry.title, name: name)
+    }
+
+    func renameTerminal(_ entry: TerminalEntry, name: String) {
+        guard let tabID = entry.pane.tabID ?? entry.tab?.tabID else { return }
+        renameTabLabel(device: entry.device, tabID: tabID, current: entry.title, name: name)
+    }
+
+    private func renameTabLabel(device: Device, tabID: String, current: String, name: String) {
         let name = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty, name != entry.title else { return }
+        guard !name.isEmpty, name != current else { return }
         Task {
             do {
-                try await service(for: entry.device).renameTab(
-                    tabID: entry.agent.tabID,
-                    label: name
-                )
-                await refresh(entry.device.id)
+                try await service(for: device).renameTab(tabID: tabID, label: name)
+                await refresh(device.id)
             } catch {
-                actionError = actionErrorMessage(error, device: entry.device)
+                actionError = actionErrorMessage(error, device: device)
             }
         }
     }

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -60,6 +60,7 @@ struct RootView: View {
         .sheet(isPresented: $model.showNewSpace) { NewSpaceSheet(model: model) }
         .sheet(item: $model.spaceToRename) { entry in RenameSpaceSheet(model: model, entry: entry) }
         .sheet(item: $model.agentToRename) { entry in RenameAgentSheet(model: model, entry: entry) }
+        .sheet(item: $model.terminalToRename) { entry in RenameTerminalSheet(model: model, entry: entry) }
         .sheet(item: $model.deviceToEdit) { device in EditDeviceSheet(model: model, device: device) }
         .sheet(item: $model.sshAuthenticationRequest) { request in
             SSHAuthenticationSheet(model: model, request: request)
@@ -1337,6 +1338,58 @@ struct RenameAgentSheet: View {
                     .keyboardShortcut(.cancelAction)
                 Button("Rename") {
                     model.renameAgent(entry, name: name)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(trimmedName.isEmpty || trimmedName == entry.title)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .frame(width: 400)
+        .onAppear { name = entry.title }
+    }
+}
+
+struct RenameTerminalSheet: View {
+    @ObservedObject var model: AppModel
+    let entry: AppModel.TerminalEntry
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SheetHeader(
+                systemImage: "pencil",
+                title: String(localized: "Rename Terminal"),
+                subtitle: String(localized: "Rename \(entry.title) on \(entry.device.name)")
+            )
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            VStack(alignment: .leading, spacing: 8) {
+                SheetSectionLabel("NAME")
+                TextField("Terminal name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                Text("Chinese, spaces, and punctuation are allowed.")
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            .padding(16)
+
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Rename") {
+                    model.renameTerminal(entry, name: name)
                     dismiss()
                 }
                 .buttonStyle(.borderedProminent)

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -292,6 +292,7 @@ struct SidebarView: View {
                 )
             }
             .accessibilityAddTraits(.isButton)
+            .accessibilityAction { model.selectAgent(entry.ref) }
             .accessibilityLabel(entry.title)
         }
     }
@@ -411,6 +412,7 @@ struct SidebarView: View {
             )
         }
         .accessibilityAddTraits(.isButton)
+        .accessibilityAction { model.selectAgent(entry.ref) }
         .accessibilityLabel(accessibilityLabel(unread: unread))
     }
 
@@ -788,6 +790,7 @@ private struct SpaceRowView: View {
             )
         }
         .accessibilityAddTraits(.isButton)
+        .accessibilityAction { model.selectSpace(entry.ref) }
         .accessibilityLabel(accessibilityLabel)
     }
 

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -122,12 +122,7 @@ struct SidebarView: View {
                         groupHeader("Terminals", expanded: $terminalsExpanded)
                         if terminalsExpanded {
                             ForEach(model.visibleTerminals) { entry in
-                                terminalRow(entry)
-                                    .contextMenu {
-                                        Button("Close Terminal…", role: .destructive) {
-                                            model.requestClosePane(entry.ref, name: entry.title)
-                                        }
-                                    }
+                                TerminalRowView(entry: entry, model: model)
                             }
                             ForEach(model.shellSessions) { session in
                                 shellRow(session)
@@ -245,13 +240,15 @@ struct SidebarView: View {
         .buttonStyle(SidebarRowButtonStyle(selected: selected))
     }
 
-    private func terminalRow(_ entry: AppModel.TerminalEntry) -> some View {
-        let selected = !model.isFileManagerActive
-            && model.selectedPane == entry.ref
-            && model.selectedShellID == nil
-        return Button {
-            model.selectAgent(entry.ref)
-        } label: {
+    private struct TerminalRowView: View {
+        let entry: AppModel.TerminalEntry
+        @ObservedObject var model: AppModel
+        @State private var hovered = false
+
+        var body: some View {
+            let selected = !model.isFileManagerActive
+                && model.selectedPane == entry.ref
+                && model.selectedShellID == nil
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
                     Image(systemName: "terminal")
@@ -273,7 +270,7 @@ struct SidebarView: View {
                         .lineLimit(1)
                     Spacer(minLength: 0)
                     if model.showsRowDeviceBadges {
-                        deviceBadge(entry.device)
+                        DeviceChip(device: entry.device)
                     }
                 }
             }
@@ -281,8 +278,22 @@ struct SidebarView: View {
             .padding(.vertical, 7)
             .frame(height: 51)
             .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(selected || hovered ? AnyShapeStyle(Theme.itemWashSelected) : AnyShapeStyle(.clear))
+            )
+            .onHover { hovered = $0 }
+            .overlay {
+                TerminalRowDragHost(
+                    entryID: entry.id,
+                    onClick: { model.selectAgent(entry.ref) },
+                    onRename: { model.terminalToRename = entry },
+                    onClose: { model.requestClosePane(entry.ref, name: entry.title) }
+                )
+            }
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel(entry.title)
         }
-        .buttonStyle(SidebarRowButtonStyle(selected: selected))
     }
 
     /// App-owned standalone shell (local login shell or plain ssh), outside
@@ -311,10 +322,6 @@ struct SidebarView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(SidebarRowButtonStyle(selected: selected))
-    }
-
-    private func deviceBadge(_ device: Device) -> some View {
-        DeviceChip(device: device)
     }
 
     private struct AgentRowView: View {

--- a/Sources/HerdrM/SpaceRowDrag.swift
+++ b/Sources/HerdrM/SpaceRowDrag.swift
@@ -15,30 +15,35 @@ struct SidebarRowDragHost: NSViewRepresentable {
     let pasteboardType: NSPasteboard.PasteboardType
     let menuItems: [SidebarContextMenuItem]
     let onClick: () -> Void
-    let onDragStart: (String) -> Void
-    let onDragEnd: () -> Void
-    let onDropHover: (Bool) -> Void
-    let onHoverExit: () -> Void
-    let onDrop: (String, Bool) -> Void
+    var onDoubleClick: (() -> Void)?
+    var allowsDrag = true
+    var onDragStart: ((String) -> Void)?
+    var onDragEnd: (() -> Void)?
+    var onDropHover: ((Bool) -> Void)?
+    var onHoverExit: (() -> Void)?
+    var onDrop: ((String, Bool) -> Void)?
 
     func makeNSView(context: Context) -> SidebarRowDragNSView {
         // Non-zero seed frame: a SwiftUI overlay NSView that starts at .zero
         // can stay 0-size, so clicks and drags never arrive (#42).
         let view = SidebarRowDragNSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
         view.pasteboardType = pasteboardType
-        view.registerForDraggedTypes([pasteboardType])
+        view.allowsDrag = allowsDrag
+        if allowsDrag { view.registerForDraggedTypes([pasteboardType]) }
         return view
     }
 
     func updateNSView(_ view: SidebarRowDragNSView, context: Context) {
-        if view.pasteboardType != pasteboardType {
+        if view.pasteboardType != pasteboardType || view.allowsDrag != allowsDrag {
             view.unregisterDraggedTypes()
             view.pasteboardType = pasteboardType
-            view.registerForDraggedTypes([pasteboardType])
+            if allowsDrag { view.registerForDraggedTypes([pasteboardType]) }
         }
         view.entryID = entryID
         view.menuItems = menuItems
+        view.allowsDrag = allowsDrag
         view.onClick = onClick
+        view.onDoubleClick = onDoubleClick
         view.onDragStart = onDragStart
         view.onDragEnd = onDragEnd
         view.onDropHover = onDropHover
@@ -69,6 +74,7 @@ struct SpaceRowDragHost: View {
                 .destructive(title: String(localized: "Close Space \"\(label)\"…"), action: onClose),
             ],
             onClick: onClick,
+            onDoubleClick: onRename,
             onDragStart: onDragStart,
             onDragEnd: onDragEnd,
             onDropHover: onDropHover,
@@ -99,6 +105,7 @@ struct AgentRowDragHost: View {
                 .destructive(title: String(localized: "Close Agent…"), action: onClose),
             ],
             onClick: onClick,
+            onDoubleClick: onRename,
             onDragStart: onDragStart,
             onDragEnd: onDragEnd,
             onDropHover: onDropHover,
@@ -108,14 +115,41 @@ struct AgentRowDragHost: View {
     }
 }
 
+/// Click / menu / double-click for herdr terminals. Drag stays off until
+/// `tab.move` is wired for this section.
+struct TerminalRowDragHost: View {
+    let entryID: String
+    let onClick: () -> Void
+    let onRename: () -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        SidebarRowDragHost(
+            entryID: entryID,
+            pasteboardType: SidebarRowDragNSView.terminalPasteboardType,
+            menuItems: [
+                .item(title: String(localized: "Rename Terminal…"), action: onRename),
+                .separator,
+                .destructive(title: String(localized: "Close Terminal…"), action: onClose),
+            ],
+            onClick: onClick,
+            onDoubleClick: onRename,
+            allowsDrag: false
+        )
+    }
+}
+
 final class SidebarRowDragNSView: NSView, NSDraggingSource {
     static let spacePasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.space-id")
     static let agentPasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.agent-id")
+    static let terminalPasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.terminal-id")
 
     var pasteboardType = SidebarRowDragNSView.spacePasteboardType
     var entryID = ""
     var menuItems: [SidebarContextMenuItem] = []
+    var allowsDrag = true
     var onClick: (() -> Void)?
+    var onDoubleClick: (() -> Void)?
     var onDragStart: ((String) -> Void)?
     var onDragEnd: (() -> Void)?
     var onDropHover: ((Bool) -> Void)?
@@ -148,7 +182,7 @@ final class SidebarRowDragNSView: NSView, NSDraggingSource {
     }
 
     override func mouseDragged(with event: NSEvent) {
-        guard let down = downEvent, !didDrag else { return }
+        guard allowsDrag, let down = downEvent, !didDrag else { return }
         let start = convert(down.locationInWindow, from: nil)
         let now = convert(event.locationInWindow, from: nil)
         guard hypot(now.x - start.x, now.y - start.y) >= 4 else { return }
@@ -162,7 +196,15 @@ final class SidebarRowDragNSView: NSView, NSDraggingSource {
     }
 
     override func mouseUp(with event: NSEvent) {
-        if !didDrag { onClick?() }
+        if !didDrag {
+            // Native clickCount on mouse-up (Apple NSEvent.clickCount), not a
+            // home-grown streak. First up is 1 (select); second is 2 (rename).
+            if event.clickCount >= 2, let onDoubleClick {
+                onDoubleClick()
+            } else {
+                onClick?()
+            }
+        }
         downEvent = nil
         didDrag = false
     }


### PR DESCRIPTION
## Summary
- Double-click a sidebar Space, Agent, or herdr Terminal to open the existing rename sheet (Finder-style: first click selects, second click renames via `NSEvent.clickCount`).
- herdr Terminals can now be renamed from the context menu as well, using `tab.rename` like agents.
- A user-set tab label wins over the OSC terminal title so a rename is actually visible.

## Test plan
- [ ] Double-click an Agent: first click selects, second click opens Rename Agent; Chinese / spaces save and show in the sidebar.
- [ ] Double-click a Space: same sheet as “Rename Space…”.
- [ ] Double-click a herdr Terminal (not standalone): rename sheet appears; new name stays after refresh / OSC title updates.
- [ ] Right-click still offers Rename / Close; Agent and Space drag-reorder still works.
- [ ] Standalone Terminal is unchanged (no rename).
- [ ] `make build` locally.


Made with [Cursor](https://cursor.com)