### PR TITLE
feat(sidebar): drag-reorder Terminals and fix tab.move order sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ the Sparkle update description — a release without a section here fails CI.
 - After `tab.move`, a leftover numeric tab label (`"2"` on tab number 1)
   is no longer treated as a display name, so Agents keep their real title.
 
+### Fixed
+- Sidebar Space, Agent, and Terminal rows expose a VoiceOver default action
+  so Activate selects the row (they are not SwiftUI `Button`s).
+
 ## [0.5.3] - 2026-08-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ the Sparkle update description — a release without a section here fails CI.
 - Double-click a Space, Agent, or herdr Terminal in the sidebar to rename it
   (same sheet as the context menu). Terminals now rename via `tab.rename`, and
   a user-set tab label wins over the OSC title so the new name is visible.
+- herdr Terminals in the sidebar can be drag-reordered. The drop calls the
+  same `tab.move` path as Agents; cross-space drops are ignored. Standalone
+  shells stay in creation order. Drag uses snapshot array order (the
+  `insert_index` herdr actually applies), not tab `number`. Rows slide into
+  place and the dragged row follows the pointer.
+
+### Fixed
+- After `tab.move`, a leftover numeric tab label (`"2"` on tab number 1)
+  is no longer treated as a display name, so Agents keep their real title.
 
 ## [0.5.3] - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Added
+- Double-click a Space, Agent, or herdr Terminal in the sidebar to rename it
+  (same sheet as the context menu). Terminals now rename via `tab.rename`, and
+  a user-set tab label wins over the OSC title so the new name is visible.
+
 ## [0.5.3] - 2026-08-29
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/Models.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/Models.swift
@@ -213,10 +213,13 @@ public struct TabInfo: Codable, Sendable, Identifiable, Equatable {
 
     /// herdr labels fresh tabs with their number ("1", "2"); only a label
     /// someone actually set is a display name.
+    ///
+    /// After `tab.move`, `number` and `label` can desync (`number=1`,
+    /// `label="2"`). Any all-digit label is still a default, not a name.
     public var customLabel: String? {
         let trimmed = label.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
-        if let number, trimmed == String(number) { return nil }
+        if trimmed.allSatisfy(\.isNumber) { return nil }
         return trimmed
     }
 

--- a/Packages/HerdrKit/Sources/HerdrKit/TabReorder.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/TabReorder.swift
@@ -1,11 +1,37 @@
 import Foundation
 
-/// Maps a sidebar agent drop onto herdr's `tab.move` `insert_index`.
+/// Maps a sidebar drop onto herdr's `tab.move` `insert_index`.
 ///
-/// `orderedIDs` is one workspace's tabs in display order (`number`). The drop
-/// target is another tab in that list. Returns `nil` when the drop would not
-/// change order (same row, already adjacent, unknown ids).
+/// `orderedIDs` is one workspace's tabs in snapshot / `tab.list` display
+/// order — not `number`. Herdr applies `insert_index` before removing the
+/// source tab (`tab.moved` returns that workspace's updated ordered list).
+/// Returns `nil` when the drop would not change order (same row, already
+/// adjacent, unknown ids).
 public enum TabReorder: Sendable {
+    /// Groups by workspace list order and keeps snapshot array order inside
+    /// each workspace. `number` is a TUI slot, not a sort key.
+    public static func ordered(_ tabs: [TabInfo], workspaces: [WorkspaceInfo]) -> [TabInfo] {
+        let known = Set(workspaces.map(\.workspaceID))
+        var buckets: [String: [TabInfo]] = [:]
+        buckets.reserveCapacity(workspaces.count)
+        var unknown: [TabInfo] = []
+        unknown.reserveCapacity(4)
+        for tab in tabs {
+            if known.contains(tab.workspaceID) {
+                buckets[tab.workspaceID, default: []].append(tab)
+            } else {
+                unknown.append(tab)
+            }
+        }
+        var result: [TabInfo] = []
+        result.reserveCapacity(tabs.count)
+        for workspace in workspaces {
+            result.append(contentsOf: buckets[workspace.workspaceID] ?? [])
+        }
+        result.append(contentsOf: unknown)
+        return result
+    }
+
     public static func insertIndex(
         moving: String,
         onto: String,

--- a/Packages/HerdrKit/Tests/HerdrKitTests/AgentTitleTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/AgentTitleTests.swift
@@ -171,6 +171,12 @@ final class AgentTitleTests: XCTestCase {
             focused: true, paneCount: 1, agentStatusRaw: "idle"
         )
         XCTAssertNil(fresh.customLabel)
+        // tab.move updates position without rewriting the numeric label.
+        let desynced = TabInfo(
+            tabID: "w1:t1", workspaceID: "w1", number: 1, label: "2",
+            focused: true, paneCount: 1, agentStatusRaw: "idle"
+        )
+        XCTAssertNil(desynced.customLabel)
         let renamed = TabInfo(
             tabID: "w1:t2", workspaceID: "w1", number: 2, label: "制度图谱讨论",
             focused: false, paneCount: 1, agentStatusRaw: nil

--- a/Packages/HerdrKit/Tests/HerdrKitTests/TabReorderTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/TabReorderTests.swift
@@ -50,4 +50,28 @@ final class TabReorderTests: XCTestCase {
             0
         )
     }
+
+    func testSnapshotArrayOrderBeatsTabNumber() {
+        let workspaces = [
+            WorkspaceInfo(
+                workspaceID: "wD", number: 1, label: "herdrm",
+                focused: true, paneCount: 2, tabCount: 2,
+                activeTabID: "wD:t5", agentStatusRaw: nil
+            ),
+        ]
+        let tabs = [
+            TabInfo(
+                tabID: "wD:t5", workspaceID: "wD", number: 5, label: "5",
+                focused: true, paneCount: 1, agentStatusRaw: nil
+            ),
+            TabInfo(
+                tabID: "wD:t1", workspaceID: "wD", number: 1, label: "2",
+                focused: false, paneCount: 1, agentStatusRaw: nil
+            ),
+        ]
+        XCTAssertEqual(
+            TabReorder.ordered(tabs, workspaces: workspaces).map(\.tabID),
+            ["wD:t5", "wD:t1"]
+        )
+    }
 }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2161,6 +2161,54 @@
         }
       }
     },
+    "Rename Terminal" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename Terminal"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名终端"
+          }
+        }
+      }
+    },
+    "Rename Terminal…" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rename Terminal…"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "重命名终端…"
+          }
+        }
+      }
+    },
+    "Terminal name" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminal name"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "终端名称"
+          }
+        }
+      }
+    },
     "Agent name" : {
       "localizations" : {
         "en" : {

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -267,6 +267,7 @@ final class AppModel: ObservableObject {
 
         var id: String { "\(device.id.uuidString)-\(pane.paneID)" }
         var ref: PaneRef { PaneRef(deviceID: device.id, paneID: pane.paneID) }
+        var tabID: String? { pane.tabID ?? tab?.tabID }
 
         var title: String {
             // User tab labels must win or `tab.rename` is invisible behind OSC.
@@ -340,7 +341,7 @@ final class AppModel: ObservableObject {
     }
 
     /// Agents across the scope, filtered by selected space, in herdr tab order
-    /// (device → workspace → tab number) so sidebar drag matches the TUI.
+    /// (device → workspace → snapshot array) so sidebar drag matches the TUI.
     var visibleAgents: [AgentEntry] {
         var entries = devicesInScope.flatMap { device in
             session(device.id).agents.map { agentEntry(device: device, agent: $0) }
@@ -384,7 +385,17 @@ final class AppModel: ObservableObject {
                 $0.device.id == space.deviceID && $0.pane.workspaceID == space.workspaceID
             }
         }
-        return entries
+        let deviceRank = Dictionary(uniqueKeysWithValues: devicesInScope.enumerated().map { ($1.id, $0) })
+        return entries.sorted { lhs, rhs in
+            let d0 = deviceRank[lhs.device.id] ?? Int.max
+            let d1 = deviceRank[rhs.device.id] ?? Int.max
+            if d0 != d1 { return d0 < d1 }
+            let w0 = workspaceRank(deviceID: lhs.device.id, workspaceID: lhs.pane.workspaceID)
+            let w1 = workspaceRank(deviceID: rhs.device.id, workspaceID: rhs.pane.workspaceID)
+            if w0 != w1 { return w0 < w1 }
+            return tabRank(deviceID: lhs.device.id, tabID: lhs.tabID)
+                < tabRank(deviceID: rhs.device.id, tabID: rhs.tabID)
+        }
     }
 
     func isUnread(_ entry: AgentEntry) -> Bool {
@@ -422,8 +433,9 @@ final class AppModel: ObservableObject {
         session(deviceID).workspaces.firstIndex { $0.workspaceID == workspaceID } ?? Int.max
     }
 
-    private func tabRank(deviceID: UUID, tabID: String) -> Int {
-        session(deviceID).tabs.firstIndex { $0.tabID == tabID } ?? Int.max
+    private func tabRank(deviceID: UUID, tabID: String?) -> Int {
+        guard let tabID else { return Int.max }
+        return session(deviceID).tabs.firstIndex { $0.tabID == tabID } ?? Int.max
     }
 
     private func orderedTabIDs(deviceID: UUID, workspaceID: String) -> [String] {
@@ -807,7 +819,7 @@ final class AppModel: ObservableObject {
             sessions[deviceID]?.agents = snapshot.agents
             sessions[deviceID]?.workspaces = snapshot.workspaces
             sessions[deviceID]?.workspaces = snapshot.workspaces
-            sessions[deviceID]?.tabs = Self.orderedTabs(
+            sessions[deviceID]?.tabs = TabReorder.ordered(
                 snapshot.tabs ?? [],
                 workspaces: snapshot.workspaces
             )
@@ -996,7 +1008,7 @@ final class AppModel: ObservableObject {
     }
 
     func renameTerminal(_ entry: TerminalEntry, name: String) {
-        guard let tabID = entry.pane.tabID ?? entry.tab?.tabID else { return }
+        guard let tabID = entry.tabID else { return }
         renameTabLabel(device: entry.device, tabID: tabID, current: entry.title, name: name)
     }
 
@@ -1026,11 +1038,13 @@ final class AppModel: ObservableObject {
         ) else { return }
 
         if let current = sessions[source.device.id]?.workspaces {
-            sessions[source.device.id]?.workspaces = WorkspaceReorder.applying(
-                current,
-                id: \.workspaceID,
-                plan: plan
-            )
+            withAnimation(.easeInOut(duration: 0.2)) {
+                sessions[source.device.id]?.workspaces = WorkspaceReorder.applying(
+                    current,
+                    id: \.workspaceID,
+                    plan: plan
+                )
+            }
         }
 
         Task {
@@ -1053,56 +1067,72 @@ final class AppModel: ObservableObject {
         guard source.device.id == target.device.id,
               source.agent.workspaceID == target.agent.workspaceID
         else { return }
-        let orderedIDs = orderedTabIDs(
-            deviceID: source.device.id,
-            workspaceID: source.agent.workspaceID
-        )
-        guard let insertIndex = TabReorder.insertIndex(
+        moveTab(
+            device: source.device,
+            workspaceID: source.agent.workspaceID,
             moving: source.agent.tabID,
             onto: target.agent.tabID,
+            placeAfter: placeAfter
+        )
+    }
+
+    /// Same `tab.move` path as agents. Cross-space / cross-device drops are ignored.
+    func moveTerminal(_ source: TerminalEntry, onto target: TerminalEntry, placeAfter: Bool) {
+        guard source.device.id == target.device.id,
+              source.pane.workspaceID == target.pane.workspaceID,
+              let moving = source.tabID,
+              let onto = target.tabID
+        else { return }
+        moveTab(
+            device: source.device,
+            workspaceID: source.pane.workspaceID,
+            moving: moving,
+            onto: onto,
+            placeAfter: placeAfter
+        )
+    }
+
+    private func moveTab(
+        device: Device,
+        workspaceID: String,
+        moving: String,
+        onto: String,
+        placeAfter: Bool
+    ) {
+        let orderedIDs = orderedTabIDs(deviceID: device.id, workspaceID: workspaceID)
+        guard let insertIndex = TabReorder.insertIndex(
+            moving: moving,
+            onto: onto,
             placeAfter: placeAfter,
             orderedIDs: orderedIDs
         ) else { return }
         guard let plan = WorkspaceReorder.plan(
-            moving: source.agent.tabID,
-            onto: target.agent.tabID,
+            moving: moving,
+            onto: onto,
             placeAfter: placeAfter,
             orderedIDs: orderedIDs
         ) else { return }
 
-        if let current = sessions[source.device.id]?.tabs {
-            let scoped = current.filter { $0.workspaceID == source.agent.workspaceID }
+        if let current = sessions[device.id]?.tabs {
+            let scoped = current.filter { $0.workspaceID == workspaceID }
             let reordered = WorkspaceReorder.applying(scoped, id: \.tabID, plan: plan)
-            sessions[source.device.id]?.tabs = Self.replacingTabs(
-                current,
-                workspaceID: source.agent.workspaceID,
-                with: reordered
-            )
+            withAnimation(.easeInOut(duration: 0.2)) {
+                sessions[device.id]?.tabs = Self.replacingTabs(
+                    current,
+                    workspaceID: workspaceID,
+                    with: reordered
+                )
+            }
         }
 
         Task {
             do {
-                try await service(for: source.device).moveTab(
-                    tabID: source.agent.tabID,
-                    insertIndex: insertIndex
-                )
-                await refresh(source.device.id)
+                try await service(for: device).moveTab(tabID: moving, insertIndex: insertIndex)
+                await refresh(device.id)
             } catch {
-                await refresh(source.device.id)
-                actionError = actionErrorMessage(error, device: source.device)
+                await refresh(device.id)
+                actionError = actionErrorMessage(error, device: device)
             }
-        }
-    }
-
-    private static func orderedTabs(_ tabs: [TabInfo], workspaces: [WorkspaceInfo]) -> [TabInfo] {
-        let wsIndex = Dictionary(uniqueKeysWithValues: workspaces.enumerated().map {
-            ($1.workspaceID, $0)
-        })
-        return tabs.sorted {
-            let w0 = wsIndex[$0.workspaceID] ?? Int.max
-            let w1 = wsIndex[$1.workspaceID] ?? Int.max
-            if w0 != w1 { return w0 < w1 }
-            return ($0.number ?? Int.max) < ($1.number ?? Int.max)
         }
     }
 

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -165,6 +165,7 @@ final class AppModel: ObservableObject {
     @Published var sshAuthenticationRequest: SSHAuthenticationRequest?
     @Published var spaceToRename: SpaceEntry?
     @Published var agentToRename: AgentEntry?
+    @Published var terminalToRename: TerminalEntry?
     /// Transient action failures: shown as an alert, never by tearing down sessions.
     @Published var actionError: String?
 
@@ -268,12 +269,13 @@ final class AppModel: ObservableObject {
         var ref: PaneRef { PaneRef(deviceID: device.id, paneID: pane.paneID) }
 
         var title: String {
+            // User tab labels must win or `tab.rename` is invisible behind OSC.
+            if let label = tab?.customLabel {
+                return label
+            }
             if let terminalTitle = pane.terminalTitle?.trimmingCharacters(in: .whitespacesAndNewlines),
                !terminalTitle.isEmpty {
                 return terminalTitle
-            }
-            if let label = tab?.customLabel {
-                return label
             }
             if let cwd = pane.cwd, !cwd.isEmpty {
                 let basename = URL(fileURLWithPath: cwd).lastPathComponent
@@ -990,17 +992,23 @@ final class AppModel: ObservableObject {
     }
 
     func renameAgent(_ entry: AgentEntry, name: String) {
+        renameTabLabel(device: entry.device, tabID: entry.agent.tabID, current: entry.title, name: name)
+    }
+
+    func renameTerminal(_ entry: TerminalEntry, name: String) {
+        guard let tabID = entry.pane.tabID ?? entry.tab?.tabID else { return }
+        renameTabLabel(device: entry.device, tabID: tabID, current: entry.title, name: name)
+    }
+
+    private func renameTabLabel(device: Device, tabID: String, current: String, name: String) {
         let name = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !name.isEmpty, name != entry.title else { return }
+        guard !name.isEmpty, name != current else { return }
         Task {
             do {
-                try await service(for: entry.device).renameTab(
-                    tabID: entry.agent.tabID,
-                    label: name
-                )
-                await refresh(entry.device.id)
+                try await service(for: device).renameTab(tabID: tabID, label: name)
+                await refresh(device.id)
             } catch {
-                actionError = actionErrorMessage(error, device: entry.device)
+                actionError = actionErrorMessage(error, device: device)
             }
         }
     }

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -60,6 +60,7 @@ struct RootView: View {
         .sheet(isPresented: $model.showNewSpace) { NewSpaceSheet(model: model) }
         .sheet(item: $model.spaceToRename) { entry in RenameSpaceSheet(model: model, entry: entry) }
         .sheet(item: $model.agentToRename) { entry in RenameAgentSheet(model: model, entry: entry) }
+        .sheet(item: $model.terminalToRename) { entry in RenameTerminalSheet(model: model, entry: entry) }
         .sheet(item: $model.deviceToEdit) { device in EditDeviceSheet(model: model, device: device) }
         .sheet(item: $model.sshAuthenticationRequest) { request in
             SSHAuthenticationSheet(model: model, request: request)
@@ -1337,6 +1338,58 @@ struct RenameAgentSheet: View {
                     .keyboardShortcut(.cancelAction)
                 Button("Rename") {
                     model.renameAgent(entry, name: name)
+                    dismiss()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accent)
+                .keyboardShortcut(.defaultAction)
+                .disabled(trimmedName.isEmpty || trimmedName == entry.title)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .frame(width: 400)
+        .onAppear { name = entry.title }
+    }
+}
+
+struct RenameTerminalSheet: View {
+    @ObservedObject var model: AppModel
+    let entry: AppModel.TerminalEntry
+    @Environment(\.dismiss) private var dismiss
+    @State private var name = ""
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            SheetHeader(
+                systemImage: "pencil",
+                title: String(localized: "Rename Terminal"),
+                subtitle: String(localized: "Rename \(entry.title) on \(entry.device.name)")
+            )
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            VStack(alignment: .leading, spacing: 8) {
+                SheetSectionLabel("NAME")
+                TextField("Terminal name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                Text("Chinese, spaces, and punctuation are allowed.")
+                    .font(.system(size: 11.5))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            .padding(16)
+
+            Rectangle().fill(Theme.hairline).frame(height: 1)
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Rename") {
+                    model.renameTerminal(entry, name: name)
                     dismiss()
                 }
                 .buttonStyle(.borderedProminent)

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -326,6 +326,7 @@ struct SidebarView: View {
                 )
             }
             .accessibilityAddTraits(.isButton)
+            .accessibilityAction { model.selectAgent(entry.ref) }
             .accessibilityLabel(entry.title)
         }
     }
@@ -446,6 +447,7 @@ struct SidebarView: View {
             )
         }
         .accessibilityAddTraits(.isButton)
+        .accessibilityAction { model.selectAgent(entry.ref) }
         .accessibilityLabel(accessibilityLabel(unread: unread))
     }
 
@@ -849,6 +851,7 @@ private struct SpaceRowView: View {
             )
         }
         .accessibilityAddTraits(.isButton)
+        .accessibilityAction { model.selectSpace(entry.ref) }
         .accessibilityLabel(accessibilityLabel)
     }
 

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -26,6 +26,8 @@ struct SidebarView: View {
     @State private var spaceDrop: (id: String, after: Bool)?
     @State private var draggingAgentID: String?
     @State private var agentDrop: (id: String, after: Bool)?
+    @State private var draggingTerminalID: String?
+    @State private var terminalDrop: (id: String, after: Bool)?
     @State private var spacesExpanded = true
     @State private var agentsExpanded = true
     @State private var terminalsExpanded = true
@@ -122,7 +124,12 @@ struct SidebarView: View {
                         groupHeader("Terminals", expanded: $terminalsExpanded)
                         if terminalsExpanded {
                             ForEach(model.visibleTerminals) { entry in
-                                TerminalRowView(entry: entry, model: model)
+                                TerminalRowView(
+                                    entry: entry,
+                                    model: model,
+                                    draggingTerminalID: $draggingTerminalID,
+                                    terminalDrop: $terminalDrop
+                                )
                             }
                             ForEach(model.shellSessions) { session in
                                 shellRow(session)
@@ -243,6 +250,8 @@ struct SidebarView: View {
     private struct TerminalRowView: View {
         let entry: AppModel.TerminalEntry
         @ObservedObject var model: AppModel
+        @Binding var draggingTerminalID: String?
+        @Binding var terminalDrop: (id: String, after: Bool)?
         @State private var hovered = false
 
         var body: some View {
@@ -283,12 +292,37 @@ struct SidebarView: View {
                     .fill(selected || hovered ? AnyShapeStyle(Theme.itemWashSelected) : AnyShapeStyle(.clear))
             )
             .onHover { hovered = $0 }
+            .sidebarDragChrome(
+                isDragging: draggingTerminalID == entry.id,
+                dropAfter: terminalDrop?.after,
+                isTarget: terminalDrop?.id == entry.id
+            )
             .overlay {
                 TerminalRowDragHost(
                     entryID: entry.id,
                     onClick: { model.selectAgent(entry.ref) },
                     onRename: { model.terminalToRename = entry },
-                    onClose: { model.requestClosePane(entry.ref, name: entry.title) }
+                    onClose: { model.requestClosePane(entry.ref, name: entry.title) },
+                    onDragStart: { draggingTerminalID = $0 },
+                    onDragEnd: {
+                        draggingTerminalID = nil
+                        terminalDrop = nil
+                    },
+                    onDropHover: { after in
+                        terminalDrop = sidebarDropTarget(
+                            onto: entry.id, after: after, items: model.visibleTerminals
+                        )
+                    },
+                    onHoverExit: {
+                        if terminalDrop?.id == entry.id { terminalDrop = nil }
+                    },
+                    onDrop: { sourceID, after in
+                        draggingTerminalID = nil
+                        terminalDrop = nil
+                        guard let source = model.visibleTerminals.first(where: { $0.id == sourceID })
+                        else { return }
+                        model.moveTerminal(source, onto: entry, placeAfter: after)
+                    }
                 )
             }
             .accessibilityAddTraits(.isButton)
@@ -378,14 +412,11 @@ struct SidebarView: View {
                 .fill(selected || hovered ? AnyShapeStyle(Theme.itemWashSelected) : AnyShapeStyle(.clear))
         )
         .onHover { hovered = $0 }
-        .opacity(draggingAgentID == entry.id ? 0.4 : 1)
-        .overlay(alignment: (agentDrop?.after ?? false) ? .bottom : .top) {
-            if agentDrop?.id == entry.id {
-                Rectangle()
-                    .fill(Theme.accent)
-                    .frame(height: 2)
-            }
-        }
+        .sidebarDragChrome(
+            isDragging: draggingAgentID == entry.id,
+            dropAfter: agentDrop?.after,
+            isTarget: agentDrop?.id == entry.id
+        )
         .overlay {
             AgentRowDragHost(
                 entryID: entry.id,
@@ -397,7 +428,11 @@ struct SidebarView: View {
                     draggingAgentID = nil
                     agentDrop = nil
                 },
-                onDropHover: { after in agentDrop = (entry.id, after) },
+                    onDropHover: { after in
+                        agentDrop = sidebarDropTarget(
+                            onto: entry.id, after: after, items: model.visibleAgents
+                        )
+                    },
                 onHoverExit: {
                     if agentDrop?.id == entry.id { agentDrop = nil }
                 },
@@ -696,7 +731,32 @@ struct DevicePopoverRow: View {
     }
 }
 
+/// `after A` and `before B` are the same gap. Always draw that gap on B's
+/// top edge so the line does not jump when the pointer crosses the seam.
+private func sidebarDropTarget<T: Identifiable>(
+    onto id: T.ID, after: Bool, items: [T]
+) -> (id: T.ID, after: Bool) {
+    guard after,
+          let index = items.firstIndex(where: { $0.id == id }),
+          items.indices.contains(index + 1)
+    else { return (id, after) }
+    return (items[index + 1].id, false)
+}
+
 private extension View {
+    func sidebarDragChrome(isDragging: Bool, dropAfter: Bool?, isTarget: Bool) -> some View {
+        opacity(isDragging ? 0.4 : 1)
+            .animation(.easeOut(duration: 0.15), value: isDragging)
+            .overlay(alignment: (dropAfter ?? false) ? .bottom : .top) {
+                if isTarget {
+                    Rectangle()
+                        .fill(Theme.accent)
+                        .frame(height: 2)
+                        .transaction { $0.animation = nil }
+                }
+            }
+    }
+
     /// Button trait plus expanded/collapsed so VoiceOver matches the chevron.
     /// macOS SwiftUI has no `accessibilityExpanded`; VoiceOver reads the value.
     func disclosureAccessibility(expanded: Bool) -> some View {
@@ -754,14 +814,11 @@ private struct SpaceRowView: View {
                 .fill(selected || hovered ? AnyShapeStyle(Theme.itemWashSelected) : AnyShapeStyle(.clear))
         )
         .onHover { hovered = $0 }
-        .opacity(draggingSpaceID == entry.id ? 0.4 : 1)
-        .overlay(alignment: (spaceDrop?.after ?? false) ? .bottom : .top) {
-            if spaceDrop?.id == entry.id {
-                Rectangle()
-                    .fill(Theme.accent)
-                    .frame(height: 2)
-            }
-        }
+        .sidebarDragChrome(
+            isDragging: draggingSpaceID == entry.id,
+            dropAfter: spaceDrop?.after,
+            isTarget: spaceDrop?.id == entry.id
+        )
         .overlay {
             SpaceRowDragHost(
                 entryID: entry.id,
@@ -774,7 +831,11 @@ private struct SpaceRowView: View {
                     draggingSpaceID = nil
                     spaceDrop = nil
                 },
-                onDropHover: { after in spaceDrop = (entry.id, after) },
+                    onDropHover: { after in
+                        spaceDrop = sidebarDropTarget(
+                            onto: entry.id, after: after, items: model.visibleSpaces
+                        )
+                    },
                 onHoverExit: {
                     if spaceDrop?.id == entry.id { spaceDrop = nil }
                 },

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -122,12 +122,7 @@ struct SidebarView: View {
                         groupHeader("Terminals", expanded: $terminalsExpanded)
                         if terminalsExpanded {
                             ForEach(model.visibleTerminals) { entry in
-                                terminalRow(entry)
-                                    .contextMenu {
-                                        Button("Close Terminal…", role: .destructive) {
-                                            model.requestClosePane(entry.ref, name: entry.title)
-                                        }
-                                    }
+                                TerminalRowView(entry: entry, model: model)
                             }
                             ForEach(model.shellSessions) { session in
                                 shellRow(session)
@@ -245,13 +240,15 @@ struct SidebarView: View {
         .buttonStyle(SidebarRowButtonStyle(selected: selected))
     }
 
-    private func terminalRow(_ entry: AppModel.TerminalEntry) -> some View {
-        let selected = !model.isFileManagerActive
-            && model.selectedPane == entry.ref
-            && model.selectedShellID == nil
-        return Button {
-            model.selectAgent(entry.ref)
-        } label: {
+    private struct TerminalRowView: View {
+        let entry: AppModel.TerminalEntry
+        @ObservedObject var model: AppModel
+        @State private var hovered = false
+
+        var body: some View {
+            let selected = !model.isFileManagerActive
+                && model.selectedPane == entry.ref
+                && model.selectedShellID == nil
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 6) {
                     Image(systemName: "terminal")
@@ -273,7 +270,7 @@ struct SidebarView: View {
                         .lineLimit(1)
                     Spacer(minLength: 0)
                     if model.showsRowDeviceBadges {
-                        deviceBadge(entry.device)
+                        DeviceChip(device: entry.device)
                     }
                 }
             }
@@ -281,8 +278,22 @@ struct SidebarView: View {
             .padding(.vertical, 7)
             .frame(height: 51)
             .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 7)
+                    .fill(selected || hovered ? AnyShapeStyle(Theme.itemWashSelected) : AnyShapeStyle(.clear))
+            )
+            .onHover { hovered = $0 }
+            .overlay {
+                TerminalRowDragHost(
+                    entryID: entry.id,
+                    onClick: { model.selectAgent(entry.ref) },
+                    onRename: { model.terminalToRename = entry },
+                    onClose: { model.requestClosePane(entry.ref, name: entry.title) }
+                )
+            }
+            .accessibilityAddTraits(.isButton)
+            .accessibilityLabel(entry.title)
         }
-        .buttonStyle(SidebarRowButtonStyle(selected: selected))
     }
 
     /// App-owned standalone shell (local login shell or plain ssh), outside
@@ -311,10 +322,6 @@ struct SidebarView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(SidebarRowButtonStyle(selected: selected))
-    }
-
-    private func deviceBadge(_ device: Device) -> some View {
-        DeviceChip(device: device)
     }
 
     private struct AgentRowView: View {

--- a/Sources/HerdrM/SpaceRowDrag.swift
+++ b/Sources/HerdrM/SpaceRowDrag.swift
@@ -15,30 +15,35 @@ struct SidebarRowDragHost: NSViewRepresentable {
     let pasteboardType: NSPasteboard.PasteboardType
     let menuItems: [SidebarContextMenuItem]
     let onClick: () -> Void
-    let onDragStart: (String) -> Void
-    let onDragEnd: () -> Void
-    let onDropHover: (Bool) -> Void
-    let onHoverExit: () -> Void
-    let onDrop: (String, Bool) -> Void
+    var onDoubleClick: (() -> Void)?
+    var allowsDrag = true
+    var onDragStart: ((String) -> Void)?
+    var onDragEnd: (() -> Void)?
+    var onDropHover: ((Bool) -> Void)?
+    var onHoverExit: (() -> Void)?
+    var onDrop: ((String, Bool) -> Void)?
 
     func makeNSView(context: Context) -> SidebarRowDragNSView {
         // Non-zero seed frame: a SwiftUI overlay NSView that starts at .zero
         // can stay 0-size, so clicks and drags never arrive (#42).
         let view = SidebarRowDragNSView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
         view.pasteboardType = pasteboardType
-        view.registerForDraggedTypes([pasteboardType])
+        view.allowsDrag = allowsDrag
+        if allowsDrag { view.registerForDraggedTypes([pasteboardType]) }
         return view
     }
 
     func updateNSView(_ view: SidebarRowDragNSView, context: Context) {
-        if view.pasteboardType != pasteboardType {
+        if view.pasteboardType != pasteboardType || view.allowsDrag != allowsDrag {
             view.unregisterDraggedTypes()
             view.pasteboardType = pasteboardType
-            view.registerForDraggedTypes([pasteboardType])
+            if allowsDrag { view.registerForDraggedTypes([pasteboardType]) }
         }
         view.entryID = entryID
         view.menuItems = menuItems
+        view.allowsDrag = allowsDrag
         view.onClick = onClick
+        view.onDoubleClick = onDoubleClick
         view.onDragStart = onDragStart
         view.onDragEnd = onDragEnd
         view.onDropHover = onDropHover
@@ -69,6 +74,7 @@ struct SpaceRowDragHost: View {
                 .destructive(title: String(localized: "Close Space \"\(label)\"…"), action: onClose),
             ],
             onClick: onClick,
+            onDoubleClick: onRename,
             onDragStart: onDragStart,
             onDragEnd: onDragEnd,
             onDropHover: onDropHover,
@@ -99,6 +105,7 @@ struct AgentRowDragHost: View {
                 .destructive(title: String(localized: "Close Agent…"), action: onClose),
             ],
             onClick: onClick,
+            onDoubleClick: onRename,
             onDragStart: onDragStart,
             onDragEnd: onDragEnd,
             onDropHover: onDropHover,
@@ -108,14 +115,41 @@ struct AgentRowDragHost: View {
     }
 }
 
+/// Click / menu / double-click for herdr terminals. Drag stays off until
+/// `tab.move` is wired for this section.
+struct TerminalRowDragHost: View {
+    let entryID: String
+    let onClick: () -> Void
+    let onRename: () -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        SidebarRowDragHost(
+            entryID: entryID,
+            pasteboardType: SidebarRowDragNSView.terminalPasteboardType,
+            menuItems: [
+                .item(title: String(localized: "Rename Terminal…"), action: onRename),
+                .separator,
+                .destructive(title: String(localized: "Close Terminal…"), action: onClose),
+            ],
+            onClick: onClick,
+            onDoubleClick: onRename,
+            allowsDrag: false
+        )
+    }
+}
+
 final class SidebarRowDragNSView: NSView, NSDraggingSource {
     static let spacePasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.space-id")
     static let agentPasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.agent-id")
+    static let terminalPasteboardType = NSPasteboard.PasteboardType("dev.bybee.herdrm.terminal-id")
 
     var pasteboardType = SidebarRowDragNSView.spacePasteboardType
     var entryID = ""
     var menuItems: [SidebarContextMenuItem] = []
+    var allowsDrag = true
     var onClick: (() -> Void)?
+    var onDoubleClick: (() -> Void)?
     var onDragStart: ((String) -> Void)?
     var onDragEnd: (() -> Void)?
     var onDropHover: ((Bool) -> Void)?
@@ -148,7 +182,7 @@ final class SidebarRowDragNSView: NSView, NSDraggingSource {
     }
 
     override func mouseDragged(with event: NSEvent) {
-        guard let down = downEvent, !didDrag else { return }
+        guard allowsDrag, let down = downEvent, !didDrag else { return }
         let start = convert(down.locationInWindow, from: nil)
         let now = convert(event.locationInWindow, from: nil)
         guard hypot(now.x - start.x, now.y - start.y) >= 4 else { return }
@@ -162,7 +196,15 @@ final class SidebarRowDragNSView: NSView, NSDraggingSource {
     }
 
     override func mouseUp(with event: NSEvent) {
-        if !didDrag { onClick?() }
+        if !didDrag {
+            // Native clickCount on mouse-up (Apple NSEvent.clickCount), not a
+            // home-grown streak. First up is 1 (select); second is 2 (rename).
+            if event.clickCount >= 2, let onDoubleClick {
+                onDoubleClick()
+            } else {
+                onClick?()
+            }
+        }
         downEvent = nil
         didDrag = false
     }

--- a/Sources/HerdrM/SpaceRowDrag.swift
+++ b/Sources/HerdrM/SpaceRowDrag.swift
@@ -115,13 +115,16 @@ struct AgentRowDragHost: View {
     }
 }
 
-/// Click / menu / double-click for herdr terminals. Drag stays off until
-/// `tab.move` is wired for this section.
 struct TerminalRowDragHost: View {
     let entryID: String
     let onClick: () -> Void
     let onRename: () -> Void
     let onClose: () -> Void
+    let onDragStart: (String) -> Void
+    let onDragEnd: () -> Void
+    let onDropHover: (Bool) -> Void
+    let onHoverExit: () -> Void
+    let onDrop: (String, Bool) -> Void
 
     var body: some View {
         SidebarRowDragHost(
@@ -134,7 +137,11 @@ struct TerminalRowDragHost: View {
             ],
             onClick: onClick,
             onDoubleClick: onRename,
-            allowsDrag: false
+            onDragStart: onDragStart,
+            onDragEnd: onDragEnd,
+            onDropHover: onDropHover,
+            onHoverExit: onHoverExit,
+            onDrop: onDrop
         )
     }
 }
@@ -187,11 +194,12 @@ final class SidebarRowDragNSView: NSView, NSDraggingSource {
         let now = convert(event.locationInWindow, from: nil)
         guard hypot(now.x - start.x, now.y - start.y) >= 4 else { return }
         didDrag = true
+        let preview = dragPreviewImage()
         onDragStart?(entryID)
         let pbItem = NSPasteboardItem()
         pbItem.setString(entryID, forType: pasteboardType)
         let item = NSDraggingItem(pasteboardWriter: pbItem)
-        item.setDraggingFrame(bounds, contents: nil)
+        item.setDraggingFrame(bounds, contents: preview)
         beginDraggingSession(with: [item], event: down, source: self)
     }
 
@@ -272,6 +280,20 @@ final class SidebarRowDragNSView: NSView, NSDraggingSource {
         let after = placeAfter(sender)
         onDrop?(sourceID, after)
         return true
+    }
+
+    /// Snapshot the SwiftUI row under this transparent overlay. Taken before
+    /// `onDragStart` dims the source so the drag image stays opaque.
+    private func dragPreviewImage() -> NSImage? {
+        guard let content = window?.contentView else { return nil }
+        let rect = convert(bounds, to: content)
+        guard !rect.isEmpty, let rep = content.bitmapImageRepForCachingDisplay(in: rect) else {
+            return nil
+        }
+        content.cacheDisplay(in: rect, to: rep)
+        let image = NSImage(size: rect.size)
+        image.addRepresentation(rep)
+        return image
     }
 
     private func placeAfter(_ sender: NSDraggingInfo) -> Bool {


### PR DESCRIPTION
## Summary

- Adds drag-reorder for herdr **Terminals** in the sidebar via the same `tab.move` RPC path Agents already use; cross-space / cross-device drops are ignored and standalone shells stay put.
- Fixes sidebar tab order to follow **`session.snapshot` array order** (what herdr uses for `insert_index`), not tab `number`, so drags persist in both HerdrM and the TUI.
- After `tab.move`, stale all-digit tab labels (e.g. `number=1`, `label="2"`) are no longer treated as custom names, so Agent titles no longer flip to digits.
- Drag polish: row snapshot follows the pointer, rows slide on drop, and the orange insertion line is pinned to one edge between rows (no seam flicker).

**Depends on #71** (double-click rename). This branch includes that commit until #71 merges; please review the reorder commit (`d7d1a39`) or merge #71 first and ask me to rebase.


https://github.com/user-attachments/assets/f19de585-068a-459a-9375-895f6e5ce673



## Test plan

- [x] Drag Agents within a Space — order sticks after refresh and matches herdr TUI tab bar
- [x] Drag herdr Terminals within a Space — same
- [x] Cross-space drop — no-op
- [x] Agent titles stay conversation/kind names after reorder (no stray `"2"` labels)
- [x] Orange drop line stays stable when hovering between two rows
- [x] `make kit-test` — `TabReorderTests`, `AgentTitleTests` pass


Made with [Cursor](https://cursor.com)