### PR TITLE
fix: show Oh My Pi in the local agent picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Fixed
+- Installed Oh My Pi (`omp`) now appears in the local New Agent picker even
+  though its hook-based lifecycle integration has no screen-detection manifest.
+  Settings → Agents also provides an Oh My Pi binary override. Install the
+  lifecycle extension with `herdr integration install omp` before starting OMP.
+
 ## [0.5.3] - 2026-08-29
 
 ### Added

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -195,17 +195,24 @@ public actor HerdrService {
     /// callers omit it and share the process-wide capture.
     public func installedAgents(
         from kinds: [String],
+        includingIntegrationKinds integrationKinds: [String] = [],
         overrides: [String: String] = [:],
         snapshot: ShellEnvironment? = nil
     ) async -> [InstalledAgent] {
-        guard !kinds.isEmpty else { return [] }
+        // Hook-based agents may be startable without a screen-detection manifest.
+        // Still require a runnable local CLI, and preserve advertised ordering.
+        var candidates = kinds
+        for kind in integrationKinds where !candidates.contains(kind) {
+            candidates.append(kind)
+        }
+        guard !candidates.isEmpty else { return [] }
         let environment: ShellEnvironment
         if let snapshot {
             environment = snapshot
         } else {
             environment = await ShellEnvironment.ensure()
         }
-        return kinds.compactMap { kind in
+        return candidates.compactMap { kind in
             let query: String
             if let override = overrides[kind]?.trimmingCharacters(in: .whitespacesAndNewlines),
                !override.isEmpty {

--- a/Packages/HerdrKit/Tests/HerdrKitTests/ShellEnvironmentTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/ShellEnvironmentTests.swift
@@ -158,6 +158,41 @@ final class ShellEnvironmentTests: XCTestCase {
         XCTAssertEqual(redirected.first?.path, cursor.appendingPathComponent("cursor-agent").path)
     }
 
+    func testHookAgentIsDiscoveredWithoutManifestAlongsidePi() async throws {
+        let binaries = try bin("bin", command: "omp")
+        _ = try bin("bin", command: "pi")
+        let snapshot = ShellEnvironment(variables: [
+            "PATH": binaries.path,
+            "HOME": directory.path,
+        ])
+        let service = HerdrService(device: .local, localServer: nil)
+        let found = await service.installedAgents(
+            from: ["pi"],
+            includingIntegrationKinds: ["omp", "omp"],
+            snapshot: snapshot
+        )
+        XCTAssertEqual(found.map(\.kind), ["pi", "omp"])
+        XCTAssertEqual(found.map(\.path), [
+            binaries.appendingPathComponent("pi").path,
+            binaries.appendingPathComponent("omp").path,
+        ])
+
+        let advertised = await service.installedAgents(
+            from: ["omp", "pi"],
+            includingIntegrationKinds: ["omp"],
+            snapshot: snapshot
+        )
+        XCTAssertEqual(advertised.map(\.kind), ["omp", "pi"])
+
+        let missing = await service.installedAgents(
+            from: ["pi"],
+            includingIntegrationKinds: ["omp"],
+            overrides: ["omp": directory.appendingPathComponent("missing-omp").path],
+            snapshot: snapshot
+        )
+        XCTAssertEqual(missing.map(\.kind), ["pi"])
+    }
+
     // MARK: - Real zsh
 
     func testCaptureRunsLoginAndInteractiveStartupFilesAndIgnoresStdoutBanners() throws {

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -655,8 +655,11 @@ final class AppModel: ObservableObject {
                 AgentAttachmentCapabilityRegistry(manifests: manifests)
             let advertised = manifests.map(\.agent)
             if device(deviceID)?.isLocal == true {
+                // Herdr supports OMP through its lifecycle extension, so it has
+                // no screen-detection manifest in server.agent_manifests.
                 let found = await service.installedAgents(
                     from: advertised,
+                    includingIntegrationKinds: ["omp"],
                     overrides: AgentBinaryOverrides.load()
                 )
                 sessions[deviceID]?.agentCatalog = .loaded(

--- a/Sources/HerdrM/HerdrMApp.swift
+++ b/Sources/HerdrM/HerdrMApp.swift
@@ -275,6 +275,7 @@ struct AgentsSettingsView: View {
         ("kimi", "Kimi", "kimi"),
         ("opencode", "OpenCode", "opencode"),
         ("pi", "Pi", "pi"),
+        ("omp", "Oh My Pi", "omp"),
         ("copilot", "Copilot", "copilot"),
     ]
 


### PR DESCRIPTION
Installed Oh My Pi (`omp`) is missing from the local New Agent picker because herdrm uses `server.agent_manifests` as its candidate list. Herdr supports starting OMP, but OMP reports lifecycle state through an integration and has no screen-detection manifest.

This adds OMP as an extra local discovery candidate and exposes an Oh My Pi path field in Settings → Agents. The executable must still resolve, Pi remains a separate entry, advertised ordering is preserved, and an already-advertised OMP is not duplicated. SSH catalogs are unchanged.

OMP requires its existing Herdr lifecycle extension: `herdr integration install omp`. This PR does not install extensions automatically.

### Validation

- HerdrKit: 130 tests, 5 remote E2E tests skipped because no SSH test target was configured, 0 failures.
- macOS arm64 Debug build and bundle signature verification passed.
- Tested through the herdrm GUI with Herdr 0.8.2, OMP 18.1.8, and OMP integration v8: New Agent → omp launched into a dedicated temporary workspace, accepted a one-message smoke test, returned the expected marker, and reported working/completed state and an unread indicator. The temporary workspace was closed afterward.
- Regression coverage includes discovery without a manifest, separate Pi/OMP paths, deduplication, and an invalid OMP path override.
- The patch merges cleanly with current main (`20daf96`).

Build command (local ad-hoc signing, package versions pinned):
```sh
xcodegen generate
xcodebuild -project HerdrM.xcodeproj -scheme HerdrM -configuration Debug \
  -destination 'platform=macOS,arch=arm64' \
  -derivedDataPath /tmp/herdrm-omp-build-fresh \
  -clonedSourcePackagesDirPath /tmp/herdrm-omp-packages-fresh \
  -disableAutomaticPackageResolution -skipPackagePluginValidation \
  CODE_SIGN_IDENTITY=- DEVELOPMENT_TEAM= \
  MARKETING_VERSION=0.5.3 CURRENT_PROJECT_VERSION=28.1 build
swift test --package-path Packages/HerdrKit
```
