### PR TITLE
fix(terminal): give each mouse gesture one owner, Shift always selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Fixed
+- Mouse gestures in attached agent TUIs now have one owner from press through
+  release. Plain drags reach mouse-aware TUIs in full, while Shift-drag stays
+  in Ghostty for local selection. Command-C copies a local Ghostty selection
+  when present and otherwise reaches TUIs using the Kitty keyboard protocol,
+  instead of a replayed press producing an oversized selection or leaving the
+  TUI button logically held down. Herdr terminal panes follow the same rule:
+  the wheel keeps scrolling herdr's own scrollback and Shift-drag selects
+  locally, because `herdr … attach` has no server-side mouse selection — it
+  forwards button events to the pane program and drops them when that program
+  did not ask for the mouse.
+
 ## [0.6.1] - 2026-09-10
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 .PHONY: gen build run test kit-test clean
 
+CODE_SIGN_IDENTITY ?= -
+
 gen:
 	xcodegen generate
 
 build: gen
-	xcodebuild -project HerdrM.xcodeproj -scheme HerdrM -configuration Debug -derivedDataPath build build -skipPackagePluginValidation | tail -5
+	xcodebuild -project HerdrM.xcodeproj -scheme HerdrM -configuration Debug -derivedDataPath build build CODE_SIGN_IDENTITY="$(CODE_SIGN_IDENTITY)" CODE_SIGN_STYLE=Manual -skipPackagePluginValidation | tail -5
 
 run: build
 	open build/Build/Products/Debug/herdrm.app

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -126,6 +126,13 @@ enum GhosttyRuntime {
             // Option-as-Meta: matches what the SwiftTerm embed did, and the
             // readline chords below (⌥⌫ → ESC DEL etc.) assume it.
             builder.withCustom("macos-option-as-alt", "true")
+            // HerdrM owns copy only while Ghostty has a local selection. With
+            // no local selection, Command-C must reach a mouse-aware pane app.
+            builder.withCustom("keybind", "super+c=unbind")
+            // Shift is HerdrM's unconditional local-selection escape hatch.
+            // Plain TUI gestures have Shift removed before reaching Ghostty,
+            // so disabling application shift capture cannot affect them.
+            builder.withCustom("mouse-shift-capture", "never")
             if !fontName.isEmpty {
                 builder.withFontFamily(fontName)
             } else {
@@ -313,10 +320,10 @@ private enum ClipboardFileError: LocalizedError {
 /// raw input path, bypassing key translation, and stay local while an IME
 /// composition is open.
 ///
-/// Mouse: dragging always selects text locally, like a native text view. When
-/// the TUI captured the mouse, a drag (or any click with Shift / multi-click)
-/// is replayed to Ghostty with Shift added — Ghostty's own "bypass mouse
-/// reporting" path — while plain clicks and the wheel still reach the TUI.
+/// Mouse: one side owns each complete gesture. Plain gestures follow Ghostty's
+/// negotiated mouse capture and reach the TUI; Shift gestures stay local for
+/// terminal selection. Turning Mouse Reporting off also keeps the complete
+/// gesture local.
 ///
 /// IME: Ghostty implements `NSTextInputClient` itself and renders the marked
 /// text in the grid; the only hook needed here is keeping ⌘/⌃ chords off the
@@ -331,14 +338,17 @@ final class LineBreakTerminalView: AppTerminalView {
     weak var attachedSurface: TerminalSurface?
     weak var processHost: TerminalProcessHost?
 
-    /// The plain click that was forwarded to the TUI and may still turn into a
-    /// drag; replayed with Shift if it does.
-    private var pendingPlainDown: NSEvent?
-    private var dragIsLocal = false
+    /// Fixed at mouse-down so press, motion and release cannot split between
+    /// the TUI and Ghostty's local selection.
+    private var gestureIsLocal = false
+    /// A locally handled Command-C must consume its matching release too;
+    /// kitty report-events applications otherwise receive a release-only key.
+    private var locallyConsumedCopyKeyCode: UInt16?
 
     // MARK: Keyboard
 
     override func keyDown(with event: NSEvent) {
+        locallyConsumedCopyKeyCode = nil
         if hasMarkedText() {
             // Command/Control chords must stay with the IME until composition
             // ends; other keys still reach Ghostty so preedit can update.
@@ -352,6 +362,14 @@ final class LineBreakTerminalView: AppTerminalView {
             return
         }
         super.keyDown(with: event)
+    }
+
+    override func keyUp(with event: NSEvent) {
+        if locallyConsumedCopyKeyCode == event.keyCode {
+            locallyConsumedCopyKeyCode = nil
+            return
+        }
+        super.keyUp(with: event)
     }
 
     /// Mac Delete is Backspace (keyCode 51). ⌥⌘ arrows move split focus and
@@ -393,71 +411,36 @@ final class LineBreakTerminalView: AppTerminalView {
 
     private func isSelectionGesture(_ event: NSEvent) -> Bool {
         event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.shift)
-            || event.clickCount > 1
     }
 
-    /// Ghostty treats Shift+click as local selection even while the program
-    /// owns the mouse — replaying the event with Shift added is the supported
-    /// way to keep a drag local.
-    private func forcingLocalSelection(_ event: NSEvent) -> NSEvent {
+    private func routedMouseEvent(_ event: NSEvent) -> NSEvent {
         guard isMouseCaptured else { return event }
-        return event.addingShiftModifier()
+        return gestureIsLocal
+            ? event.addingShiftModifier()
+            : event.removingShiftModifier()
     }
 
     override func mouseDown(with event: NSEvent) {
-        if mouseReportingEnabled, !isSelectionGesture(event), isMouseCaptured {
-            // Forward the click to the TUI, but keep it: if it becomes a drag,
-            // the drag switches to local selection in mouseDragged.
-            pendingPlainDown = event
-            super.mouseDown(with: event)
-            return
-        }
-        pendingPlainDown = nil
-        super.mouseDown(with: forcingLocalSelection(event))
+        gestureIsLocal = !mouseReportingEnabled
+            || isSelectionGesture(event)
+            || !isMouseCaptured
+        super.mouseDown(with: routedMouseEvent(event))
     }
 
     override func mouseDragged(with event: NSEvent) {
-        guard isMouseCaptured else {
-            super.mouseDragged(with: event)
-            return
-        }
-        // A drag always selects locally. Ghostty only starts a selection from a
-        // Shift+press, so a press that already went to the TUI is replayed with
-        // Shift before the drag stream switches over.
-        if let down = pendingPlainDown {
-            pendingPlainDown = nil
-            dragIsLocal = true
-            super.mouseDown(with: down.addingShiftModifier())
-        } else if !mouseReportingEnabled {
-            dragIsLocal = true
-        }
-        if dragIsLocal {
-            super.mouseDragged(with: event.addingShiftModifier())
-        } else {
-            super.mouseDragged(with: event)
-        }
+        super.mouseDragged(with: routedMouseEvent(event))
     }
 
     override func mouseUp(with event: NSEvent) {
-        if dragIsLocal {
-            dragIsLocal = false
-            pendingPlainDown = nil
-            super.mouseUp(with: event.addingShiftModifier())
-            return
-        }
-        pendingPlainDown = nil
-        if !isSelectionGesture(event), mouseReportingEnabled, isMouseCaptured {
-            super.mouseUp(with: event)
-        } else {
-            super.mouseUp(with: forcingLocalSelection(event))
-        }
+        defer { gestureIsLocal = false }
+        super.mouseUp(with: routedMouseEvent(event))
     }
 
     // MARK: Context menu
 
     // The right mouse button always opens the context menu and never reaches
-    // the TUI. The link items key off the selected text — a double-click
-    // selects a whole URL, which pairs naturally with right-click.
+    // the TUI. Link items key off the selected text; while mouse reporting is
+    // active, Shift-double-click selects a whole URL locally.
     override func rightMouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
     }
@@ -533,13 +516,28 @@ final class LineBreakTerminalView: AppTerminalView {
         uploadTask?.cancel()
     }
 
-    // ⌘V is intercepted here so the attachment flow below owns every paste,
-    // regardless of whether the app's menu has a Paste item.
+    // ⌘C/⌘V are intercepted here because the app has no Edit menu. Copy stays
+    // local only when Ghostty owns a selection; otherwise the physical key is
+    // sent to the TUI now that its global copy binding is unbound above.
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if event.type == .keyDown,
-           window?.firstResponder === self,
-           event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command,
-           event.charactersIgnoringModifiers == "v" {
+        guard event.type == .keyDown,
+              window?.firstResponder === self,
+              event.modifierFlags
+                  .intersection(.deviceIndependentFlagsMask)
+                  .subtracting([.capsLock, .numericPad]) == .command
+        else {
+            return super.performKeyEquivalent(with: event)
+        }
+        if event.charactersIgnoringModifiers?.lowercased() == "c" {
+            if attachedSurface?.hasSelection() == true {
+                locallyConsumedCopyKeyCode = event.keyCode
+                copy(self)
+            } else {
+                keyDown(with: event)
+            }
+            return true
+        }
+        if event.charactersIgnoringModifiers?.lowercased() == "v" {
             handlePaste()
             return true
         }
@@ -770,6 +768,20 @@ private extension NSEvent {
             with: type,
             location: locationInWindow,
             modifierFlags: modifierFlags.union(.shift),
+            timestamp: timestamp,
+            windowNumber: windowNumber,
+            context: nil,
+            eventNumber: eventNumber,
+            clickCount: clickCount,
+            pressure: pressure
+        ) ?? self
+    }
+
+    func removingShiftModifier() -> NSEvent {
+        NSEvent.mouseEvent(
+            with: type,
+            location: locationInWindow,
+            modifierFlags: modifierFlags.subtracting(.shift),
             timestamp: timestamp,
             windowNumber: windowNumber,
             context: nil,


### PR DESCRIPTION
## Problem

A mouse gesture in an attached pane could split between the pane program and Ghostty.

A plain press was forwarded to the program, and if it turned into a drag the press was **replayed** to Ghostty with Shift added so a local selection would start. That had two consequences:

- Ghostty read the replayed press as a **second click**, so the drag selected by word instead of by character — the "oversized selection".
- The program received a press whose release never arrived (the release went to Ghostty), so its button stayed **logically held down**.

## Change

The owner of a gesture is decided once, at mouse-down, and press, motion and release all take that route.

- Plain gestures reach the pane program, with Shift stripped.
- Shift gestures reach Ghostty, with Shift added. `mouse-shift-capture = never` keeps that escape hatch working even when the program claims Shift via `XTSHIFTESCAPE`.
- Multi-click is no longer a local gesture on its own — only Shift is — so a double-click can no longer begin in the program and end in Ghostty.
- Turning off **Settings → Terminal → Mouse reporting** still keeps the whole gesture local.

Command-C follows the same split: Ghostty's global copy binding is unbound, so the key copies a local Ghostty selection when there is one and otherwise reaches the program. Its key-up is consumed alongside the key-down, so a program speaking the Kitty keyboard protocol never sees a release without a press.

## Why herdr terminal panes behave the same way

A terminal pane (`herdr terminal attach`) has no agent TUI in it, so "always select locally" looks tempting. It is the wrong default. Verified against herdr 0.9.0 by attaching through a pty and injecting SGR mouse sequences:

| Gesture sent over `herdr … attach` | herdr's response |
| --- | --- |
| Wheel | scrolls herdr's own scrollback |
| Click / double-click / drag, bare shell in the pane | nothing — no bytes, no highlight, clipboard untouched |
| Click, after the pane program enabled mouse reporting | forwarded to the program |

The same drag sent to the **herdr client shell** (`herdr`, what a Mac terminal runs) returns a painted selection highlight. herdr's mouse selection lives in that client shell, which herdrm does not run — it embeds the raw attach stream and draws its own sidebar natively.

So over `attach` there is nothing to gain by keeping buttons local, and something to lose: `vim`, `lazygit` and `btop` in a terminal pane would stop receiving clicks. Selection in a terminal pane is Shift-drag over the visible viewport; the wheel keeps scrolling herdr's scrollback.

Note this also means `isMouseCaptured` cannot tell herdrm whether the *inner* program wants the mouse: `herdr … attach` sets modes 1000/1002/1003/1006 on the outer terminal unconditionally.

## Also

`make build` defaults `CODE_SIGN_IDENTITY` to ad-hoc, so it works on a machine without the Developer ID certificate. Override with `make build CODE_SIGN_IDENTITY="Developer ID Application: …"`.

## Testing

- `make build`
- `make kit-test` — 137 tests, 6 skipped, 0 failures
- Manual: agent panes (opencode, Copilot CLI) and herdr terminal panes, plain drag, Shift-drag, wheel, Command-C with and without a selection