### PR TITLE
fix(status): compatibility fix for herdr 0.9.0 events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ the Sparkle update description — a release without a section here fails CI.
   reference implementation!)
 
 ### Fixed
+- Agent working / blocked / done indicators now update from herdr 0.9's
+  pane-scoped `pane.agent_status_changed` events instead of waiting for an
+  unrelated `pane.updated` event. Event names from both lifecycle and scoped
+  envelopes are normalized, subscriptions follow newly created/moved panes,
+  and continuous event bursts can no longer postpone snapshot refresh forever.
 - Mouse gestures in attached agent TUIs now have one owner from press through
   release. Plain drags reach mouse-aware TUIs in full, while Shift-drag stays
   in Ghostty for local selection. Command-C copies a local Ghostty selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Added
+- The custom titlebar now behaves like a native macOS titlebar: drag it to
+  move the window, and double-click it to follow the system Zoom, Minimize,
+  or Do Nothing preference.
+
+### Fixed
+- Copy now works through both terminal paths: Command-C writes a local Ghostty
+  selection directly to the macOS pasteboard, while agent TUI copy actions can
+  write through OSC 52.
+
 ## [0.6.3] - 2026-09-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,15 +61,16 @@ release notes and the Sparkle update description, and fails if it's missing —
 add the section before tagging. The cask in OwO-Network/homebrew-brew is
 auto-bumped after each release.
 
-## herdr protocol notes (0.8.0, protocol 19; verified against the live socket)
+## herdr protocol notes (0.9.0, private protocol 22; verified against the live socket)
 
 - Requests are NDJSON `{"id","method","params"}` on `~/.config/herdr/herdr.sock`;
   `params` must be present even when empty (`{}`), or the server rejects the request.
 - `tab.create` returns the new pane as `result.root_pane.pane_id`.
-- `events.subscribe` takes `{"subscriptions":[{"type":"pane.updated"},…]}`;
-  `pane.agent_status_changed` / `pane.scroll_changed` / `pane.output_matched` are
-  pane-scoped (require `pane_id`) and cannot be subscribed globally — status changes
-  arrive globally as `pane.updated`. Full global kind list: `HerdrEvent.allKinds`.
+- `events.subscribe` takes `{"subscriptions":[{"type":"pane.updated"},…]}`.
+  `pane.agent_status_changed` is pane-scoped and must be subscribed with `pane_id`;
+  status transitions do not emit `pane.updated`. HerdrM appends one scoped status
+  subscription for every known pane and re-subscribes when pane topology changes.
+  `pane.scroll_changed` / `pane.output_matched` are scoped too.
 - Terminal attach: agents use `herdr agent attach <pane_id> --takeover`; bare shells use
   `herdr terminal attach <terminal_id> --takeover` (takes the pane over from other attached
   clients). Remote devices run it through `ssh -tt` with PATH prepended

--- a/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/HerdrService.swift
@@ -571,8 +571,8 @@ public actor HerdrService {
 
     // MARK: - Events
 
-    public func events() throws -> AsyncThrowingStream<HerdrEvent, Error> {
-        try client().events()
+    public func events(statusPaneIDs: [String] = []) throws -> AsyncThrowingStream<HerdrEvent, Error> {
+        try client().events(statusPaneIDs: statusPaneIDs)
     }
 
     // MARK: - Terminal attach

--- a/Packages/HerdrKit/Sources/HerdrKit/Models.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/Models.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Agent status buckets as reported by herdr (protocol 19).
+/// Agent status buckets reported by herdr snapshots and status events.
 public enum AgentStatus: String, Codable, Sendable, CaseIterable {
     case idle
     case working
@@ -47,6 +47,24 @@ public struct AgentInfo: Codable, Sendable, Identifiable, Equatable {
     public var agent: String { agentKindRaw ?? "agent" }
     /// Sidebar / titlebar label without a tab label. Prefer `title(tabLabel:)`.
     public var title: String { title(tabLabel: nil) }
+
+    public func updatingStatus(_ status: AgentStatus) -> AgentInfo {
+        AgentInfo(
+            terminalID: terminalID,
+            agentKindRaw: agentKindRaw,
+            name: name,
+            customTitle: customTitle,
+            terminalTitle: terminalTitle,
+            terminalTitleStripped: terminalTitleStripped,
+            agentStatusRaw: status.rawValue,
+            workspaceID: workspaceID,
+            tabID: tabID,
+            paneID: paneID,
+            focused: focused,
+            cwd: cwd,
+            revision: revision
+        )
+    }
 
     /// Sidebar / titlebar label.
     ///
@@ -254,6 +272,24 @@ public struct SessionSnapshot: Codable, Sendable, Equatable {
         }
     }
 
+    public func updatingAgentStatus(paneID: String, status: AgentStatus) -> SessionSnapshot? {
+        var agents = agents
+        guard let index = agents.firstIndex(where: { $0.paneID == paneID }) else {
+            return nil
+        }
+        agents[index] = agents[index].updatingStatus(status)
+        return SessionSnapshot(
+            agents: agents,
+            workspaces: workspaces,
+            tabs: tabs,
+            panes: panes,
+            focusedPaneID: focusedPaneID,
+            focusedWorkspaceID: focusedWorkspaceID,
+            version: version,
+            protocolVersion: protocolVersion
+        )
+    }
+
     enum CodingKeys: String, CodingKey {
         case agents
         case workspaces
@@ -285,10 +321,12 @@ public struct HerdrEvent: Sendable {
         self.payload = payload
     }
 
-    /// All parameterless (globally subscribable) kinds in herdr protocol 19.
-    /// pane.agent_status_changed / pane.scroll_changed / pane.output_matched are
-    /// pane-scoped (require pane_id) and are deliberately absent; status changes
-    /// surface globally via pane.updated.
+    public static let subscriptionStartedKind = "subscription.started"
+    public static let agentStatusChangedKind = "pane.agent_status_changed"
+
+    /// All parameterless (globally subscribable) lifecycle kinds.
+    /// `pane.agent_status_changed` is pane-scoped and appended separately for
+    /// each known pane by `SocketRPC.events`.
     public static let allKinds: [String] = [
         "workspace.created", "workspace.updated", "workspace.metadata_updated", "workspace.renamed",
         "workspace.moved", "workspace.reordered", "workspace.focused", "workspace.closed",
@@ -298,6 +336,23 @@ public struct HerdrEvent: Sendable {
         "pane.agent_detected",
         "layout.updated",
     ]
+
+    private static let scopedKinds = [
+        agentStatusChangedKind,
+        "pane.scroll_changed",
+        "pane.output_matched",
+    ]
+
+    private static let normalizedKinds = Dictionary(
+        (allKinds + scopedKinds).map {
+            ($0.replacingOccurrences(of: ".", with: "_"), $0)
+        },
+        uniquingKeysWith: { first, _ in first }
+    )
+
+    static func normalizedKind(_ wireKind: String) -> String {
+        normalizedKinds[wireKind] ?? wireKind
+    }
 }
 
 public enum HerdrError: Error, LocalizedError, Sendable {

--- a/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
+++ b/Packages/HerdrKit/Sources/HerdrKit/SocketRPC.swift
@@ -37,42 +37,136 @@ public struct SocketRPC: Sendable {
 
     /// Opens a persistent connection, sends events.subscribe, and yields each event line.
     /// The stream finishes when the connection drops; callers own reconnect policy.
-    public func events(kinds: [String] = HerdrEvent.allKinds) -> AsyncThrowingStream<HerdrEvent, Error> {
+    public func events(
+        kinds: [String] = HerdrEvent.allKinds,
+        statusPaneIDs: [String] = []
+    ) -> AsyncThrowingStream<HerdrEvent, Error> {
         let path = socketPath
         return AsyncThrowingStream { continuation in
+            let socketHandle = EventSocketHandle()
             let task = Task.detached(priority: .utility) {
-                var fd: Int32 = -1
+                var scopedPaneIDs = statusPaneIDs
                 do {
-                    fd = try Self.connect(path: path)
-                    let subs = JSONValue.object([
-                        "subscriptions": .array(kinds.map { .object(["type": .string($0)]) })
-                    ])
-                    try Self.writeLine(fd: fd, data: Self.encodeRequest(id: "events", method: "events.subscribe", params: subs))
-                    // A single read() can contain the acknowledgement and one or
-                    // more events. Keep the buffer used for the acknowledgement so
-                    // those already-received events are not discarded.
-                    var buffer = Data()
-                    let ack = try Self.readLine(fd: fd, timeoutSeconds: 15, buffer: &buffer)
-                    _ = try Self.decodeResponse(ack)
-                    while !Task.isCancelled {
-                        guard let line = try Self.readLine(fd: fd, timeoutSeconds: nil, buffer: &buffer) else { break }
-                        guard !line.isEmpty else { continue }
-                        if let value = try? JSONDecoder().decode(JSONValue.self, from: line) {
-                            let kind = value["event"]?["type"]?.stringValue
-                                ?? value["type"]?.stringValue
-                                ?? value["kind"]?.stringValue
-                                ?? "unknown"
-                            continuation.yield(HerdrEvent(kind: kind, payload: value))
+                    subscriptionAttempt: while !Task.isCancelled {
+                        var fd: Int32 = -1
+                        do {
+                            fd = try Self.connect(path: path)
+                            guard socketHandle.install(fd) else {
+                                close(fd)
+                                continuation.finish()
+                                return
+                            }
+                            let subs = Self.eventSubscriptionParams(
+                                kinds: kinds,
+                                statusPaneIDs: scopedPaneIDs
+                            )
+                            try Self.writeLine(
+                                fd: fd,
+                                data: Self.encodeRequest(
+                                    id: "events",
+                                    method: "events.subscribe",
+                                    params: subs
+                                )
+                            )
+                            // A single read() can contain the acknowledgement and one or
+                            // more events. Keep the buffer used for the acknowledgement so
+                            // those already-received events are not discarded.
+                            var buffer = Data()
+                            let ack = try Self.readLine(
+                                fd: fd,
+                                timeoutSeconds: 15,
+                                buffer: &buffer
+                            )
+                            do {
+                                _ = try Self.decodeResponse(ack)
+                            } catch where Self.shouldRetryStatusSubscription(
+                                after: error,
+                                statusPaneIDs: scopedPaneIDs
+                            ) {
+                                // A pane can close after the snapshot and before
+                                // subscribe. Keep lifecycle events alive for one
+                                // cycle; subscription.started makes the caller
+                                // re-snapshot and reopen with the corrected set.
+                                socketHandle.closeIfOwned(fd)
+                                fd = -1
+                                scopedPaneIDs = []
+                                continue subscriptionAttempt
+                            }
+                            continuation.yield(HerdrEvent(
+                                kind: HerdrEvent.subscriptionStartedKind,
+                                payload: .object([:])
+                            ))
+                            while !Task.isCancelled {
+                                guard let line = try Self.readLine(
+                                    fd: fd,
+                                    timeoutSeconds: nil,
+                                    buffer: &buffer
+                                ) else { break }
+                                guard !line.isEmpty else { continue }
+                                if let event = Self.decodeEvent(line) {
+                                    continuation.yield(event)
+                                }
+                            }
+                            if fd >= 0 {
+                                socketHandle.closeIfOwned(fd)
+                            }
+                            continuation.finish()
+                            return
+                        } catch {
+                            if fd >= 0 {
+                                socketHandle.closeIfOwned(fd)
+                            }
+                            throw error
                         }
                     }
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }
-                if fd >= 0 { close(fd) }
             }
-            continuation.onTermination = { _ in task.cancel() }
+            continuation.onTermination = { _ in
+                task.cancel()
+                socketHandle.terminate()
+            }
         }
+    }
+
+    public static func eventSubscriptionParams(
+        kinds: [String],
+        statusPaneIDs: [String]
+    ) -> JSONValue {
+        var subscriptions = kinds.map {
+            JSONValue.object(["type": .string($0)])
+        }
+        subscriptions.append(contentsOf: Set(statusPaneIDs).sorted().map {
+            JSONValue.object([
+                "type": .string(HerdrEvent.agentStatusChangedKind),
+                "pane_id": .string($0),
+            ])
+        })
+        return .object(["subscriptions": .array(subscriptions)])
+    }
+
+    public static func decodeEvent(_ line: Data) -> HerdrEvent? {
+        guard let value = try? JSONDecoder().decode(JSONValue.self, from: line) else {
+            return nil
+        }
+        let rawKind = value["event"]?.stringValue
+            ?? value["event"]?["type"]?.stringValue
+            ?? value["type"]?.stringValue
+            ?? value["kind"]?.stringValue
+            ?? "unknown"
+        return HerdrEvent(kind: HerdrEvent.normalizedKind(rawKind), payload: value)
+    }
+
+    public static func shouldRetryStatusSubscription(
+        after error: Error,
+        statusPaneIDs: [String]
+    ) -> Bool {
+        guard !statusPaneIDs.isEmpty,
+              case HerdrError.rpc(let code, _) = error
+        else { return false }
+        return code == "pane_not_found"
     }
 
     // MARK: - Wire helpers
@@ -138,6 +232,7 @@ public struct SocketRPC: Sendable {
                 Darwin.connect(fd, sa, len)
             }
         }
+
         guard rc == 0 else {
             let reason = String(cString: strerror(errno))
             close(fd)
@@ -154,6 +249,43 @@ public struct SocketRPC: Sendable {
             }
             guard written > 0 else { throw HerdrError.connectionFailed("write(): \(String(cString: strerror(errno)))") }
             remaining = remaining.dropFirst(written)
+        }
+    }
+
+    private final class EventSocketHandle: @unchecked Sendable {
+        private let lock = NSLock()
+        private var fd: Int32 = -1
+        private var terminated = false
+
+        func install(_ fd: Int32) -> Bool {
+            lock.lock()
+            guard !terminated else {
+                lock.unlock()
+                return false
+            }
+            self.fd = fd
+            lock.unlock()
+            return true
+        }
+
+        func closeIfOwned(_ expected: Int32) {
+            lock.lock()
+            let owned = fd == expected ? fd : -1
+            if owned >= 0 { fd = -1 }
+            lock.unlock()
+            if owned >= 0 { close(owned) }
+        }
+
+        func terminate() {
+            lock.lock()
+            terminated = true
+            let current = fd
+            fd = -1
+            lock.unlock()
+            if current >= 0 {
+                Darwin.shutdown(current, SHUT_RDWR)
+                close(current)
+            }
         }
     }
 

--- a/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/LocalSocketTests.swift
@@ -117,6 +117,7 @@ final class LocalSocketTests: XCTestCase {
         let collector = Task { () -> [String] in
             var kinds: [String] = []
             for try await event in stream {
+                if event.kind == HerdrEvent.subscriptionStartedKind { continue }
                 kinds.append(event.kind)
                 if kinds.count >= 2 { break }
             }
@@ -129,6 +130,37 @@ final class LocalSocketTests: XCTestCase {
 
         let result = try await withTimeout(seconds: 10) { try await collector.value }
         XCTAssertFalse(result.isEmpty, "no events received for tab lifecycle")
+    }
+
+    func testEventStreamFallsBackWhenAStatusPaneClosedBeforeSubscribe() async throws {
+        try requireLocalHerdr()
+        let service = HerdrService(device: .local, autoStartLocalServer: false)
+        _ = try await service.connect()
+        let stream = try await service.events(statusPaneIDs: ["pane-that-does-not-exist"])
+
+        let collector = Task { () -> [String] in
+            var kinds: [String] = []
+            for try await event in stream {
+                kinds.append(event.kind)
+                if event.kind == "pane.created" { break }
+            }
+            return kinds
+        }
+        try await Task.sleep(nanoseconds: 300_000_000)
+        let paneID = try await service.createTab(
+            workspaceID: nil,
+            cwd: nil,
+            label: "herdrm-stale-subscription-test"
+        )
+        do {
+            let result = try await withTimeout(seconds: 10) { try await collector.value }
+            try await service.closePane(paneID: paneID)
+            XCTAssertEqual(result.first, HerdrEvent.subscriptionStartedKind)
+            XCTAssertTrue(result.contains("pane.created"))
+        } catch {
+            try? await service.closePane(paneID: paneID)
+            throw error
+        }
     }
 
     func testMoveWorkspaceBlockReordersTemporarySpaces() async throws {

--- a/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
+++ b/Packages/HerdrKit/Tests/HerdrKitTests/SocketRPCTests.swift
@@ -4,6 +4,61 @@ import XCTest
 @testable import HerdrKit
 
 final class SocketRPCTests: XCTestCase {
+    func testEventSubscriptionsIncludeScopedStatusPanesOnce() throws {
+        let params = SocketRPC.eventSubscriptionParams(
+            kinds: ["pane.updated"],
+            statusPaneIDs: ["w1:p2", "w1:p1", "w1:p2"]
+        )
+        XCTAssertEqual(
+            params,
+            .object([
+                "subscriptions": .array([
+                    .object(["type": .string("pane.updated")]),
+                    .object([
+                        "type": .string("pane.agent_status_changed"),
+                        "pane_id": .string("w1:p1"),
+                    ]),
+                    .object([
+                        "type": .string("pane.agent_status_changed"),
+                        "pane_id": .string("w1:p2"),
+                    ]),
+                ])
+            ])
+        )
+    }
+
+    func testDecodeEventNormalizesLifecycleAndScopedEventNames() throws {
+        let lifecycle = try XCTUnwrap(SocketRPC.decodeEvent(
+            Data(#"{"event":"pane_updated","data":{"pane":{"pane_id":"w1:p1"}}}"#.utf8)
+        ))
+        XCTAssertEqual(lifecycle.kind, "pane.updated")
+
+        let status = try XCTUnwrap(SocketRPC.decodeEvent(
+            Data(#"{"event":"pane.agent_status_changed","data":{"pane_id":"w1:p1","agent_status":"working"}}"#.utf8)
+        ))
+        XCTAssertEqual(status.kind, HerdrEvent.agentStatusChangedKind)
+
+        let snakeStatus = try XCTUnwrap(SocketRPC.decodeEvent(
+            Data(#"{"event":"pane_agent_status_changed","data":{"pane_id":"w1:p1","agent_status":"working"}}"#.utf8)
+        ))
+        XCTAssertEqual(snakeStatus.kind, HerdrEvent.agentStatusChangedKind)
+    }
+
+    func testStaleStatusPaneRetriesWithoutScopedSubscriptions() {
+        XCTAssertTrue(SocketRPC.shouldRetryStatusSubscription(
+            after: HerdrError.rpc(code: "pane_not_found", message: "gone"),
+            statusPaneIDs: ["w1:p1"]
+        ))
+        XCTAssertFalse(SocketRPC.shouldRetryStatusSubscription(
+            after: HerdrError.rpc(code: "pane_not_found", message: "gone"),
+            statusPaneIDs: []
+        ))
+        XCTAssertFalse(SocketRPC.shouldRetryStatusSubscription(
+            after: HerdrError.rpc(code: "invalid_params", message: "bad"),
+            statusPaneIDs: ["w1:p1"]
+        ))
+    }
+
     func testReadLineKeepsNDJSONRecordsFollowingTheFirstLine() throws {
         var fds: [Int32] = [0, 0]
         let result = fds.withUnsafeMutableBufferPointer { buffer in

--- a/Sources/HerdrM/AppModel.swift
+++ b/Sources/HerdrM/AppModel.swift
@@ -201,6 +201,12 @@ final class AppModel: ObservableObject {
     private var services: [UUID: HerdrService] = [:]
     private var sessionTasks: [UUID: Task<Void, Never>] = [:]
     private var refreshDebounces: [UUID: Task<Void, Never>] = [:]
+    private var refreshDebounceTokens: [UUID: UUID] = [:]
+    private var refreshDebouncePending: Set<UUID> = []
+    private var snapshotRefreshTasks: [UUID: Task<Bool, Never>] = [:]
+    private var snapshotRefreshTokens: [UUID: UUID] = [:]
+    private var refreshRequested: Set<UUID> = []
+    private var statusGenerations: [UUID: UInt64] = [:]
     private var previousStatuses: [UUID: [String: AgentStatus]] = [:]
 
     init() {
@@ -656,9 +662,45 @@ final class AppModel: ObservableObject {
                     }
                     await self.refresh(device.id)
                     await self.loadAgentCatalog(deviceID: device.id, using: service)
-                    let stream = try await service.events()
-                    for try await _ in stream {
-                        self.scheduleRefresh(device.id)
+                    eventSubscriptions: while !Task.isCancelled {
+                        let subscribedPaneIDs = self.statusSubscriptionPaneIDs(device.id)
+                        let stream = try await service.events(statusPaneIDs: subscribedPaneIDs)
+                        var needsResubscribe = false
+                        var resubscribeDelay: UInt64 = 100_000_000
+                        for try await event in stream {
+                            guard !Task.isCancelled else { return }
+                            if event.kind == HerdrEvent.agentStatusChangedKind {
+                                if self.applyAgentStatusEvent(event, deviceID: device.id) {
+                                    self.scheduleRefresh(device.id)
+                                } else {
+                                    _ = await self.refreshImmediately(device.id)
+                                }
+                            } else if event.kind == HerdrEvent.subscriptionStartedKind
+                                || Self.paneTopologyEventKinds.contains(event.kind) {
+                                if !(await self.refreshImmediately(device.id)) {
+                                    needsResubscribe = true
+                                    resubscribeDelay = 500_000_000
+                                    break
+                                }
+                            } else {
+                                self.scheduleRefresh(device.id)
+                            }
+
+                            if event.kind == HerdrEvent.subscriptionStartedKind
+                                || Self.paneTopologyEventKinds.contains(event.kind) {
+                                let currentPaneIDs = self.statusSubscriptionPaneIDs(device.id)
+                                if currentPaneIDs != subscribedPaneIDs {
+                                    needsResubscribe = true
+                                    break
+                                }
+                            }
+                        }
+                        if needsResubscribe {
+                            try? await Task.sleep(nanoseconds: resubscribeDelay)
+                            continue eventSubscriptions
+                        }
+                        guard !Task.isCancelled else { return }
+                        throw HerdrError.connectionFailed("event stream ended")
                     }
                 } catch {
                     self.sessions[device.id]?.connection = .failed(error.localizedDescription)
@@ -740,6 +782,13 @@ final class AppModel: ObservableObject {
         sessionTasks[id] = nil
         refreshDebounces[id]?.cancel()
         refreshDebounces[id] = nil
+        refreshDebounceTokens[id] = nil
+        refreshDebouncePending.remove(id)
+        snapshotRefreshTasks[id]?.cancel()
+        snapshotRefreshTasks[id] = nil
+        snapshotRefreshTokens[id] = nil
+        refreshRequested.remove(id)
+        statusGenerations[id] = nil
         previousStatuses[id] = nil
         let service = services[id]
         services[id] = nil
@@ -846,10 +895,47 @@ final class AppModel: ObservableObject {
 
     // MARK: - Refresh
 
-    func refresh(_ deviceID: UUID) async {
-        guard let device = device(deviceID), let service = services[deviceID] else { return }
+    @discardableResult
+    func refresh(_ deviceID: UUID) async -> Bool {
+        refreshRequested.insert(deviceID)
+        if let task = snapshotRefreshTasks[deviceID] {
+            return await task.value
+        }
+        let token = UUID()
+        snapshotRefreshTokens[deviceID] = token
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return false }
+            var latestSucceeded = false
+            while !Task.isCancelled, self.refreshRequested.remove(deviceID) != nil {
+                latestSucceeded = await self.performRefresh(deviceID)
+            }
+            if self.snapshotRefreshTokens[deviceID] == token {
+                self.snapshotRefreshTokens[deviceID] = nil
+                self.snapshotRefreshTasks[deviceID] = nil
+            }
+            return latestSucceeded
+        }
+        snapshotRefreshTasks[deviceID] = task
+        return await task.value
+    }
+
+    private func performRefresh(_ deviceID: UUID) async -> Bool {
+        guard let device = device(deviceID), let service = services[deviceID] else {
+            return false
+        }
+        let statusGeneration = statusGenerations[deviceID, default: 0]
         do {
             let snapshot = try await service.snapshot()
+            guard services[deviceID] === service, sessions[deviceID] != nil else {
+                return false
+            }
+            guard statusGenerations[deviceID, default: 0] == statusGeneration else {
+                // A direct status event overtook this request on the separate
+                // event connection. Discard the older snapshot and let the
+                // refresh drain fetch one after that event.
+                refreshRequested.insert(deviceID)
+                return true
+            }
             unreadAgents = AgentUnread.applying(
                 previous: previousStatuses[deviceID] ?? [:],
                 agents: snapshot.agents,
@@ -903,19 +989,97 @@ final class AppModel: ObservableObject {
                     selectedPane = preferredVisibleAgent()?.ref ?? firstVisiblePaneRef
                 }
             }
+            return true
         } catch {
-            sessions[deviceID]?.connection = .failed(error.localizedDescription)
+            // A snapshot is one request on an otherwise live session. The
+            // event/connect loop owns connection health and will mark the
+            // device failed if the transport itself is gone.
+            return false
         }
     }
 
     private func scheduleRefresh(_ deviceID: UUID) {
-        refreshDebounces[deviceID]?.cancel()
-        refreshDebounces[deviceID] = Task {
+        // Coalesce from the leading edge instead of resetting the timer for
+        // every event. A busy pane can emit continuously; a trailing debounce
+        // would never fire until output stopped, hiding the working state.
+        guard refreshDebounces[deviceID] == nil else {
+            refreshDebouncePending.insert(deviceID)
+            return
+        }
+        let token = UUID()
+        refreshDebounceTokens[deviceID] = token
+        refreshDebounces[deviceID] = Task { [weak self] in
             try? await Task.sleep(nanoseconds: 200_000_000)
-            guard !Task.isCancelled else { return }
+            guard let self, !Task.isCancelled,
+                  self.refreshDebounceTokens[deviceID] == token
+            else { return }
             await self.refresh(deviceID)
+            if self.refreshDebounceTokens[deviceID] == token {
+                let needsTrailing = self.refreshDebouncePending.remove(deviceID) != nil
+                self.refreshDebounceTokens[deviceID] = nil
+                self.refreshDebounces[deviceID] = nil
+                if needsTrailing {
+                    self.scheduleRefresh(deviceID)
+                }
+            }
         }
     }
+
+    private func refreshImmediately(_ deviceID: UUID) async -> Bool {
+        refreshDebounces[deviceID]?.cancel()
+        refreshDebounces[deviceID] = nil
+        refreshDebounceTokens[deviceID] = nil
+        refreshDebouncePending.remove(deviceID)
+        return await refresh(deviceID)
+    }
+
+    @discardableResult
+    private func applyAgentStatusEvent(_ event: HerdrEvent, deviceID: UUID) -> Bool {
+        guard let paneID = event.payload["data"]?["pane_id"]?.stringValue,
+              let statusRaw = event.payload["data"]?["agent_status"]?.stringValue,
+              let device = device(deviceID),
+              var state = sessions[deviceID],
+              let index = state.agents.firstIndex(where: { $0.paneID == paneID })
+        else { return false }
+
+        let status = AgentStatus(wire: statusRaw)
+        guard state.agents[index].status != status else { return true }
+        let previous = previousStatuses[deviceID] ?? [:]
+        state.agents[index] = state.agents[index].updatingStatus(status)
+        unreadAgents = AgentUnread.applying(
+            previous: previous,
+            agents: state.agents,
+            unread: unreadAgents,
+            deviceID: deviceID
+        )
+        notifyTransitions(
+            device: device,
+            from: previous,
+            to: state.agents,
+            workspaces: state.workspaces,
+            tabs: state.tabs
+        )
+        var nextStatuses = previous
+        nextStatuses[paneID] = status
+        previousStatuses[deviceID] = nextStatuses
+        statusGenerations[deviceID, default: 0] &+= 1
+        sessions[deviceID] = state
+        return true
+    }
+
+    private func statusSubscriptionPaneIDs(_ deviceID: UUID) -> [String] {
+        Array(Set(
+            session(deviceID).agents.map(\.paneID)
+                + session(deviceID).panes.map(\.paneID)
+        )).sorted()
+    }
+
+    private static let paneTopologyEventKinds: Set<String> = [
+        "pane.created",
+        "pane.closed",
+        "pane.moved",
+        "pane.agent_detected",
+    ]
 
     /// Notifies when an agent newly becomes blocked (needs input) or done (finished
     /// while unwatched). Initial snapshots don't notify — only real transitions do.

--- a/Sources/HerdrM/ContentView.swift
+++ b/Sources/HerdrM/ContentView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import HerdrKit
 import SwiftUI
 
@@ -100,6 +101,160 @@ enum TitlebarMetrics {
     static let trafficLightClearance: CGFloat = 78
 }
 
+private struct WindowTitlebarInteraction: NSViewRepresentable {
+    func makeNSView(context _: Context) -> NSView {
+        WindowTitlebarInteractionView()
+    }
+
+    func updateNSView(_: NSView, context _: Context) {}
+}
+
+private final class WindowTitlebarInteractionView: NSView {
+    private static let fillRestoreFrames =
+        NSMapTable<NSWindow, NSValue>(keyOptions: .weakMemory, valueOptions: .strongMemory)
+    private var rememberFrameWorkItem: DispatchWorkItem?
+
+    override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+        true
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        rememberFrameWorkItem?.cancel()
+        NotificationCenter.default.removeObserver(self)
+        guard let window else { return }
+        Self.rememberNonFilledFrame(of: window)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowFrameDidChange(_:)),
+            name: NSWindow.didMoveNotification,
+            object: window
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowFrameDidChange(_:)),
+            name: NSWindow.didResizeNotification,
+            object: window
+        )
+    }
+
+    deinit {
+        rememberFrameWorkItem?.cancel()
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func windowFrameDidChange(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow else { return }
+        rememberFrameWorkItem?.cancel()
+        let item = DispatchWorkItem { [weak window] in
+            guard let window else { return }
+            Self.rememberNonFilledFrame(of: window)
+        }
+        rememberFrameWorkItem = item
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: item)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let window else { return }
+        guard event.clickCount == 2 else {
+            window.performDrag(with: event)
+            return
+        }
+        guard !window.styleMask.contains(.fullScreen) else { return }
+
+        let action = UserDefaults.standard
+            .string(forKey: "AppleActionOnDoubleClick")?
+            .lowercased()
+        switch action {
+        case "fill":
+            Self.toggleFill(window)
+        case nil:
+            if #available(macOS 15.0, *) {
+                Self.toggleFill(window)
+            } else {
+                Self.fillRestoreFrames.removeObject(forKey: window)
+                window.performZoom(nil)
+            }
+        case "minimize":
+            Self.fillRestoreFrames.removeObject(forKey: window)
+            window.performMiniaturize(nil)
+        case "none":
+            break
+        default:
+            Self.fillRestoreFrames.removeObject(forKey: window)
+            window.performZoom(nil)
+        }
+    }
+
+    private static func toggleFill(_ window: NSWindow) {
+        guard let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame else {
+            return
+        }
+        if framesApproximatelyEqual(window.frame, visibleFrame) {
+            let previous = fillRestoreFrames.object(forKey: window)?.rectValue
+                ?? fallbackRestoreFrame(in: visibleFrame)
+            fillRestoreFrames.removeObject(forKey: window)
+            let restored = constrainedRestoreFrame(previous, for: window)
+            window.setFrame(restored, display: true, animate: true)
+        } else {
+            fillRestoreFrames.setObject(NSValue(rect: window.frame), forKey: window)
+            window.setFrame(visibleFrame, display: true, animate: true)
+        }
+    }
+
+    private static func rememberNonFilledFrame(of window: NSWindow) {
+        guard !window.styleMask.contains(.fullScreen),
+              let visibleFrame = (window.screen ?? NSScreen.main)?.visibleFrame,
+              !framesApproximatelyEqual(window.frame, visibleFrame)
+        else { return }
+        fillRestoreFrames.setObject(NSValue(rect: window.frame), forKey: window)
+    }
+
+    private static func fallbackRestoreFrame(in visibleFrame: NSRect) -> NSRect {
+        visibleFrame.insetBy(
+            dx: visibleFrame.width * 0.1,
+            dy: visibleFrame.height * 0.1
+        )
+    }
+
+    private static func framesApproximatelyEqual(_ lhs: NSRect, _ rhs: NSRect) -> Bool {
+        abs(lhs.minX - rhs.minX) < 1
+            && abs(lhs.minY - rhs.minY) < 1
+            && abs(lhs.width - rhs.width) < 1
+            && abs(lhs.height - rhs.height) < 1
+    }
+
+    private static func constrainedRestoreFrame(_ frame: NSRect, for window: NSWindow) -> NSRect {
+        let intersectingScreen = NSScreen.screens
+            .map { screen in
+                let intersection = frame.intersection(screen.visibleFrame)
+                let area = intersection.isNull ? 0 : intersection.width * intersection.height
+                return (screen, area)
+            }
+            .max { $0.1 < $1.1 }
+        let screen = if let intersectingScreen, intersectingScreen.1 > 0 {
+            intersectingScreen.0
+        } else {
+            window.screen ?? NSScreen.main
+        }
+        guard let screen else { return frame }
+        return window.constrainFrameRect(frame, to: screen)
+    }
+}
+
+private struct WindowTitlebarInteractionModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .background(WindowTitlebarInteraction())
+    }
+}
+
+extension View {
+    func windowTitlebarInteraction() -> some View {
+        modifier(WindowTitlebarInteractionModifier())
+    }
+}
+
 struct DetailView: View {
     @ObservedObject var model: AppModel
     @Binding var sidebarCollapsed: Bool
@@ -167,78 +322,82 @@ struct DetailView: View {
                     sidebarCollapsed = false
                 }
             }
-            if model.isFileManagerActive {
-                Image(systemName: "folder")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Theme.textTertiary)
-                Text("Files")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(Theme.text)
-                Spacer()
-            } else if let shell = model.selectedShell {
-                Image(systemName: "terminal")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Theme.textTertiary)
-                Text(shell.title)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(Theme.text)
-                Text(shell.device.name)
-                    .font(.system(size: 11.5))
-                    .foregroundStyle(Theme.textTertiary)
-                Spacer()
-            } else if let attached = model.selectedAttachedEntry {
-                switch attached {
-                case .agent(let entry):
-                    let agent = entry.agent
-                    statusGlyph(agent.status)
-                    Text(entry.title)
+            Group {
+                if model.isFileManagerActive {
+                    Image(systemName: "folder")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Theme.textTertiary)
+                    Text("Files")
                         .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(Theme.text)
-                        .lineLimit(1)
-                        .layoutPriority(1)
-                        .help((agent.cwd as NSString?)?.abbreviatingWithTildeInPath ?? "")
-                    Spacer(minLength: 12)
-                    AgentKindBadge(kind: agent.agent)
-                    Text("\u{b7}")
-                        .font(.system(size: 11.5))
-                        .foregroundStyle(Theme.textGhost)
-                    Text(model.spaceName(deviceID: entry.device.id, workspaceID: agent.workspaceID))
-                        .font(.system(size: 11.5))
-                        .foregroundStyle(Theme.textTertiary)
-                        .lineLimit(1)
-                    if model.showsRowDeviceBadges {
-                        DeviceChip(device: entry.device)
-                    }
-                    statusPill(agent.status)
-                case .terminal(let entry):
+                    Spacer()
+                } else if let shell = model.selectedShell {
                     Image(systemName: "terminal")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundStyle(Theme.textTertiary)
-                    Text(entry.title)
+                    Text(shell.title)
                         .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(Theme.text)
-                        .lineLimit(1)
-                        .layoutPriority(1)
-                        .help((entry.pane.cwd as NSString?)?.abbreviatingWithTildeInPath ?? "")
-                    Spacer(minLength: 12)
-                    Text(model.spaceName(deviceID: entry.device.id, workspaceID: entry.pane.workspaceID))
+                    Text(shell.device.name)
                         .font(.system(size: 11.5))
                         .foregroundStyle(Theme.textTertiary)
-                        .lineLimit(1)
-                    if model.showsRowDeviceBadges {
-                        DeviceChip(device: entry.device)
+                    Spacer()
+                } else if let attached = model.selectedAttachedEntry {
+                    switch attached {
+                    case .agent(let entry):
+                        let agent = entry.agent
+                        statusGlyph(agent.status)
+                        Text(entry.title)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(Theme.text)
+                            .lineLimit(1)
+                            .layoutPriority(1)
+                            .help((agent.cwd as NSString?)?.abbreviatingWithTildeInPath ?? "")
+                        Spacer(minLength: 12)
+                        AgentKindBadge(kind: agent.agent)
+                        Text("\u{b7}")
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(Theme.textGhost)
+                        Text(model.spaceName(deviceID: entry.device.id, workspaceID: agent.workspaceID))
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(Theme.textTertiary)
+                            .lineLimit(1)
+                        if model.showsRowDeviceBadges {
+                            DeviceChip(device: entry.device)
+                        }
+                        statusPill(agent.status)
+                    case .terminal(let entry):
+                        Image(systemName: "terminal")
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(Theme.textTertiary)
+                        Text(entry.title)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(Theme.text)
+                            .lineLimit(1)
+                            .layoutPriority(1)
+                            .help((entry.pane.cwd as NSString?)?.abbreviatingWithTildeInPath ?? "")
+                        Spacer(minLength: 12)
+                        Text(model.spaceName(deviceID: entry.device.id, workspaceID: entry.pane.workspaceID))
+                            .font(.system(size: 11.5))
+                            .foregroundStyle(Theme.textTertiary)
+                            .lineLimit(1)
+                        if model.showsRowDeviceBadges {
+                            DeviceChip(device: entry.device)
+                        }
                     }
+                } else {
+                    Text("No terminal selected")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(Theme.textTertiary)
+                    Spacer()
                 }
-            } else {
-                Text("No terminal selected")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(Theme.textTertiary)
-                Spacer()
             }
+            .allowsHitTesting(false)
         }
         .padding(.leading, sidebarCollapsed ? 10 : 14)
         .padding(.trailing, 12)
         .frame(height: TitlebarMetrics.height)
+        .windowTitlebarInteraction()
     }
 
     @ViewBuilder

--- a/Sources/HerdrM/SidebarView.swift
+++ b/Sources/HerdrM/SidebarView.swift
@@ -43,6 +43,7 @@ struct SidebarView: View {
             }
             .padding(.horizontal, 10)
             .frame(height: TitlebarMetrics.height)
+            .windowTitlebarInteraction()
 
             Spacer().frame(height: 8)
 

--- a/Sources/HerdrM/TerminalView.swift
+++ b/Sources/HerdrM/TerminalView.swift
@@ -129,6 +129,9 @@ enum GhosttyRuntime {
             // HerdrM owns copy only while Ghostty has a local selection. With
             // no local selection, Command-C must reach a mouse-aware pane app.
             builder.withCustom("keybind", "super+c=unbind")
+            // Agent TUI copy actions use OSC 52. Keep writes enabled explicitly
+            // rather than depending on Ghostty's default clipboard policy.
+            builder.withCustom("clipboard-write", "allow")
             // Shift is HerdrM's unconditional local-selection escape hatch.
             // Plain TUI gestures have Shift removed before reaching Ghostty,
             // so disabling application shift capture cannot affect them.
@@ -458,7 +461,7 @@ final class LineBreakTerminalView: AppTerminalView {
         if attachedSurface?.hasSelection() == true,
            let selection = attachedSurface?.readSelection(),
            !selection.isEmpty {
-            menu.addItem(makeItem(String(localized: "Copy"), #selector(copy(_:))))
+            menu.addItem(makeItem(String(localized: "Copy"), #selector(copySelectionFromMenu(_:))))
             if let url = Self.firstURL(in: selection) {
                 menu.addItem(.separator())
                 let open = makeItem(String(localized: "Open Link"), #selector(openLinkFromMenu(_:)))
@@ -490,6 +493,20 @@ final class LineBreakTerminalView: AppTerminalView {
         guard let url = sender.representedObject as? URL else { return }
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(url.absoluteString, forType: .string)
+    }
+
+    @objc private func copySelectionFromMenu(_: Any?) {
+        copyLocalSelection()
+    }
+
+    @discardableResult
+    private func copyLocalSelection() -> Bool {
+        guard let selection = attachedSurface?.readSelection(), !selection.isEmpty else {
+            return false
+        }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        return pasteboard.setString(selection, forType: .string)
     }
 
     static func firstURL(in text: String) -> URL? {
@@ -531,7 +548,7 @@ final class LineBreakTerminalView: AppTerminalView {
         if modifiers == .command, event.charactersIgnoringModifiers?.lowercased() == "c" {
             if attachedSurface?.hasSelection() == true {
                 locallyConsumedCopyKeyCode = event.keyCode
-                copy(self)
+                copyLocalSelection()
             } else {
                 keyDown(with: event)
             }

--- a/Sources/HerdrMobile/MobileAppModel.swift
+++ b/Sources/HerdrMobile/MobileAppModel.swift
@@ -18,7 +18,12 @@ final class MobileDeviceSession {
     var snapshot: SessionSnapshot?
     private(set) var transport: MobileTransport?
     private var eventTask: Task<Void, Never>?
-    private var refreshPending = false
+    private var refreshDebounceTask: Task<Void, Never>?
+    private var refreshDebouncePending = false
+    private var snapshotRefreshTask: Task<Bool, Never>?
+    private var snapshotRefreshToken: UUID?
+    private var refreshRequested = false
+    private var statusGeneration: UInt64 = 0
 
     var onChange: (() -> Void)?
 
@@ -60,6 +65,13 @@ final class MobileDeviceSession {
     func disconnect() async {
         eventTask?.cancel()
         eventTask = nil
+        refreshDebounceTask?.cancel()
+        refreshDebounceTask = nil
+        refreshDebouncePending = false
+        snapshotRefreshTask?.cancel()
+        snapshotRefreshTask = nil
+        snapshotRefreshToken = nil
+        refreshRequested = false
         if let transport {
             await transport.close()
         }
@@ -68,17 +80,53 @@ final class MobileDeviceSession {
         onChange?()
     }
 
-    func refresh() async {
-        guard let transport else { return }
+    @discardableResult
+    func refresh() async -> Bool {
+        refreshRequested = true
+        if let task = snapshotRefreshTask {
+            return await task.value
+        }
+        let token = UUID()
+        snapshotRefreshToken = token
+        let task = Task { @MainActor [weak self] in
+            guard let self else { return false }
+            var latestSucceeded = false
+            while !Task.isCancelled, self.refreshRequested {
+                self.refreshRequested = false
+                latestSucceeded = await self.performRefresh()
+            }
+            if self.snapshotRefreshToken == token {
+                self.snapshotRefreshToken = nil
+                self.snapshotRefreshTask = nil
+            }
+            return latestSucceeded
+        }
+        snapshotRefreshTask = task
+        return await task.value
+    }
+
+    private func performRefresh() async -> Bool {
+        guard let transport else { return false }
+        let generation = statusGeneration
         struct Envelope: Codable { let snapshot: SessionSnapshot }
         do {
-            snapshot = try await transport.request(
+            let fetched = try await transport.request(
                 method: "session.snapshot", as: Envelope.self
             ).snapshot
+            guard !Task.isCancelled, self.transport === transport else {
+                return false
+            }
+            guard statusGeneration == generation else {
+                refreshRequested = true
+                return true
+            }
+            snapshot = fetched
             onChange?()
+            return true
         } catch {
             // A failed refresh keeps the last snapshot; the event pump's own
             // failure handling decides when the connection is actually gone.
+            return false
         }
     }
 
@@ -87,8 +135,45 @@ final class MobileDeviceSession {
         eventTask?.cancel()
         eventTask = Task { [weak self] in
             do {
-                for try await _ in transport.events(kinds: HerdrEvent.allKinds) {
-                    await self?.scheduleRefresh()
+                eventSubscriptions: while !Task.isCancelled {
+                    guard let self else { return }
+                    let subscribedPaneIDs = self.statusSubscriptionPaneIDs
+                    let stream = transport.events(
+                        kinds: HerdrEvent.allKinds,
+                        statusPaneIDs: subscribedPaneIDs
+                    )
+                    var needsResubscribe = false
+                    var resubscribeDelay = Duration.milliseconds(100)
+                    for try await event in stream {
+                        guard !Task.isCancelled else { return }
+                        if event.kind == HerdrEvent.agentStatusChangedKind,
+                           self.applyAgentStatusEvent(event) {
+                            self.scheduleRefresh()
+                        } else if event.kind == HerdrEvent.subscriptionStartedKind
+                            || event.kind == HerdrEvent.agentStatusChangedKind
+                            || Self.paneTopologyEventKinds.contains(event.kind) {
+                            if !(await self.refresh()) {
+                                needsResubscribe = true
+                                resubscribeDelay = .milliseconds(500)
+                                break
+                            }
+                        } else {
+                            self.scheduleRefresh()
+                        }
+
+                        if event.kind == HerdrEvent.subscriptionStartedKind
+                            || Self.paneTopologyEventKinds.contains(event.kind),
+                           self.statusSubscriptionPaneIDs != subscribedPaneIDs {
+                            needsResubscribe = true
+                            break
+                        }
+                    }
+                    if needsResubscribe {
+                        try? await Task.sleep(for: resubscribeDelay)
+                        continue eventSubscriptions
+                    }
+                    guard !Task.isCancelled else { return }
+                    throw HerdrError.connectionFailed("event stream ended")
                 }
             } catch {}
             // Stream ended: the connection is likely gone. Reflect it so the
@@ -102,13 +187,51 @@ final class MobileDeviceSession {
     }
 
     /// Coalesces event bursts into one snapshot fetch per 300 ms.
-    private func scheduleRefresh() async {
-        guard !refreshPending else { return }
-        refreshPending = true
-        try? await Task.sleep(for: .milliseconds(300))
-        refreshPending = false
-        await refresh()
+    private func scheduleRefresh() {
+        guard refreshDebounceTask == nil else {
+            refreshDebouncePending = true
+            return
+        }
+        refreshDebounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard let self, !Task.isCancelled else { return }
+            await self.refresh()
+            self.refreshDebounceTask = nil
+            if self.refreshDebouncePending {
+                self.refreshDebouncePending = false
+                self.scheduleRefresh()
+            }
+        }
     }
+
+    private var statusSubscriptionPaneIDs: [String] {
+        guard let snapshot else { return [] }
+        return Array(Set(
+            snapshot.agents.map(\.paneID)
+                + snapshot.ordinaryTerminalPanes.map(\.paneID)
+        )).sorted()
+    }
+
+    private func applyAgentStatusEvent(_ event: HerdrEvent) -> Bool {
+        guard let paneID = event.payload["data"]?["pane_id"]?.stringValue,
+              let statusRaw = event.payload["data"]?["agent_status"]?.stringValue,
+              let updated = snapshot?.updatingAgentStatus(
+                  paneID: paneID,
+                  status: AgentStatus(wire: statusRaw)
+              )
+        else { return false }
+        snapshot = updated
+        statusGeneration &+= 1
+        onChange?()
+        return true
+    }
+
+    private static let paneTopologyEventKinds: Set<String> = [
+        "pane.created",
+        "pane.closed",
+        "pane.moved",
+        "pane.agent_detected",
+    ]
 }
 
 @MainActor

--- a/Sources/HerdrMobile/MobileTransport.swift
+++ b/Sources/HerdrMobile/MobileTransport.swift
@@ -7,9 +7,9 @@ import HerdrSSH
 /// `direct-streamlocal` channel per RPC (herdr is one-request-per-connection),
 /// or the tailcat tunnel re-served on a local Unix socket by the embedded
 /// bridge (same NDJSON API, no shell).
-protocol MobileTransport: Sendable {
+protocol MobileTransport: AnyObject, Sendable {
     func request(method: String, params: JSONValue) async throws -> JSONValue
-    func events(kinds: [String]) -> AsyncThrowingStream<HerdrEvent, Error>
+    func events(kinds: [String], statusPaneIDs: [String]) -> AsyncThrowingStream<HerdrEvent, Error>
     func openTerminal(command: String, columns: Int, rows: Int) async throws -> SSHPTYChannel
     func close() async
 }
@@ -157,47 +157,89 @@ final class SSHDirectTransport: MobileTransport {
         return try SocketRPC.decodeResponse(line)
     }
 
-    func events(kinds: [String]) -> AsyncThrowingStream<HerdrEvent, Error> {
+    func events(
+        kinds: [String],
+        statusPaneIDs: [String]
+    ) -> AsyncThrowingStream<HerdrEvent, Error> {
         let connection = connection
         let socketPath = socketPath
         return AsyncThrowingStream { continuation in
             let task = Task {
                 do {
-                    let channel = try await connection.openStreamLocal(
-                        socketPath: socketPath, timeout: .seconds(10)
-                    )
-                    defer { Task { try? await channel.close(timeout: .seconds(2)) } }
-                    let subscribe = JSONValue.object([
-                        "subscriptions": .array(kinds.map { .object(["type": .string($0)]) })
-                    ])
-                    try await channel.write(
-                        SocketRPC.encodeRequest(id: "events", method: "events.subscribe", params: subscribe),
-                        timeout: .seconds(10)
-                    )
-                    var buffer = Data()
-                    var sawAck = false
-                    while !Task.isCancelled {
-                        // Long timeout: herdr only writes when something happens.
-                        guard let chunk = try await channel.read(timeout: .seconds(3600)) else { break }
-                        buffer.append(chunk)
-                        while let index = buffer.firstIndex(of: 0x0A) {
-                            let line = buffer.prefix(upTo: index)
-                            buffer.removeSubrange(...index)
-                            guard !line.isEmpty else { continue }
-                            guard sawAck else {
-                                sawAck = true  // first line is the subscribe ack
-                                continue
+                    var scopedPaneIDs = statusPaneIDs
+                    subscriptionAttempt: while !Task.isCancelled {
+                        let channel = try await connection.openStreamLocal(
+                            socketPath: socketPath, timeout: .seconds(10)
+                        )
+                        var retryWithoutScopedStatus = false
+                        do {
+                            let subscribe = SocketRPC.eventSubscriptionParams(
+                                kinds: kinds,
+                                statusPaneIDs: scopedPaneIDs
+                            )
+                            try await channel.write(
+                                SocketRPC.encodeRequest(
+                                    id: "events",
+                                    method: "events.subscribe",
+                                    params: subscribe
+                                ),
+                                timeout: .seconds(10)
+                            )
+                            var buffer = Data()
+                            var sawAck = false
+                            eventRead: while !Task.isCancelled {
+                                // Long timeout: herdr only writes when something happens.
+                                guard let chunk = try await channel.read(timeout: .seconds(3600)) else { break }
+                                buffer.append(chunk)
+                                while let index = buffer.firstIndex(of: 0x0A) {
+                                    let line = buffer.prefix(upTo: index)
+                                    buffer.removeSubrange(...index)
+                                    guard !line.isEmpty else { continue }
+                                    guard sawAck else {
+                                        do {
+                                            _ = try SocketRPC.decodeResponse(Data(line))
+                                        } catch where SocketRPC.shouldRetryStatusSubscription(
+                                            after: error,
+                                            statusPaneIDs: scopedPaneIDs
+                                        ) {
+                                            retryWithoutScopedStatus = true
+                                            break eventRead
+                                        }
+                                        sawAck = true
+                                        continuation.yield(HerdrEvent(
+                                            kind: HerdrEvent.subscriptionStartedKind,
+                                            payload: .object([:])
+                                        ))
+                                        continue
+                                    }
+                                    if let event = SocketRPC.decodeEvent(Data(line)) {
+                                        continuation.yield(event)
+                                    }
+                                }
                             }
-                            if let value = try? JSONDecoder().decode(JSONValue.self, from: line) {
-                                let kind = value["event"]?["type"]?.stringValue
-                                    ?? value["type"]?.stringValue
-                                    ?? value["kind"]?.stringValue
-                                    ?? "unknown"
-                                continuation.yield(HerdrEvent(kind: kind, payload: value))
-                            }
+                        } catch {
+                            try? await channel.close(timeout: .seconds(2))
+                            throw error
                         }
+                        try? await channel.close(timeout: .seconds(2))
+                        if retryWithoutScopedStatus {
+                            scopedPaneIDs = []
+                            continue subscriptionAttempt
+                        }
+                        if Task.isCancelled {
+                            continuation.finish()
+                        } else {
+                            continuation.finish(throwing: HerdrError.connectionFailed(
+                                "event stream ended"
+                            ))
+                        }
+                        return
                     }
-                    continuation.finish()
+                    if !Task.isCancelled {
+                        continuation.finish()
+                    } else {
+                        continuation.finish()
+                    }
                 } catch {
                     continuation.finish(throwing: error)
                 }
@@ -261,8 +303,11 @@ final class TailcatMobileTransport: MobileTransport {
         }
     }
 
-    func events(kinds: [String]) -> AsyncThrowingStream<HerdrEvent, Error> {
-        rpc.events(kinds: kinds)
+    func events(
+        kinds: [String],
+        statusPaneIDs: [String]
+    ) -> AsyncThrowingStream<HerdrEvent, Error> {
+        rpc.events(kinds: kinds, statusPaneIDs: statusPaneIDs)
     }
 
     func openTerminal(command _: String, columns _: Int, rows _: Int) async throws -> SSHPTYChannel {

--- a/Tests/TerminalColorFilterTests.swift
+++ b/Tests/TerminalColorFilterTests.swift
@@ -25,6 +25,19 @@ struct TerminalColorFilterTests {
             "split escape sequences should be transformed without corruption"
         )
 
+        // Agent TUI copy actions arrive through the PTY as OSC 52. The light
+        // color adapter must preserve them, including when ESC ends one read.
+        var clipboardAdapter = LightTerminalANSIAdapter()
+        let clipboardSequence = "\u{1B}]52;c;Y29waWVkIHRleHQ=\u{07}"
+        let clipboardFirst = Array(clipboardSequence.utf8.prefix(1))
+        let clipboardSecond = Array(clipboardSequence.utf8.dropFirst())
+        let clipboardResult = clipboardAdapter.transform(clipboardFirst[...])
+            + clipboardAdapter.transform(clipboardSecond[...])
+        expect(
+            String(decoding: clipboardResult, as: UTF8.self) == clipboardSequence,
+            "split OSC 52 clipboard writes should pass through unchanged"
+        )
+
         // herdr passes 256-indexed SGR through verbatim (48;5;22 etc.), which is
         // what Claude Code's diff backgrounds arrive as — they must be resolved
         // through the xterm palette and adapted like truecolor.


### PR DESCRIPTION
## Summary

- subscribe to herdr 0.9's pane-scoped `pane.agent_status_changed` events for every known pane
- apply status transitions immediately, then reconcile with serialized snapshots
- keep subscriptions synchronized as panes are created, moved, detected, and closed
- make event decoding handle both global snake-case envelopes and scoped dotted envelopes
- recover from panes disappearing between snapshot and subscription without dropping the lifecycle stream
- mirror the status/event behavior in the iOS SSH and tailcat transports

## Problem

HerdrM still relied on the older assumption that agent status changes would cause a globally subscribable `pane.updated` event. In herdr 0.9, status changes are emitted as `pane.agent_status_changed`, which requires a `pane_id`. `pane.updated` is reserved for other pane metadata such as names, titles, and tokens.

That left the sidebar status stale until some unrelated lifecycle event triggered another full snapshot. The existing trailing 200 ms debounce could make this worse by canceling and restarting the refresh indefinitely during an event burst.

## Implementation

The event stream now appends one scoped status subscription for each known agent or ordinary pane. A subscription acknowledgement triggers a fresh snapshot to close the bootstrap gap, and pane topology changes rebuild the scoped subscription set.

Status payloads update the matching agent immediately. Snapshot reconciliation is serialized per device; status generations prevent an older response from overwriting a newer event. Ordinary events use a leading-and-trailing coalescer rather than an indefinitely postponable trailing debounce.

If a pane closes between snapshot and subscription, the client retries once with lifecycle subscriptions only, refreshes its pane set, and opens the corrected scoped stream. Unix socket cancellation now atomically shuts down the active descriptor so resubscription does not leak blocked readers.

## Validation

- `swift test --package-path Packages/HerdrKit`: 141 tests passed, 6 opt-in tests skipped
- `make build`: macOS Debug build succeeded
- live herdr 0.9 test: a temporary pane emitted `working` and `done` through `pane.agent_status_changed`; `done` had no accompanying `pane.updated`
- live stale-pane integration test confirms lifecycle events survive a rejected scoped subscription
- mobile event files pass Swift parser validation; a full iOS build was unavailable because the iOS platform is not installed on the test machine
