### PR TITLE
fix(iOS): compile HerdrMobile under Swift 6 handshake isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/
 design/
 HerdrM.xcodeproj/
 Packages/HerdrKit/.build/
+Packages/HerdrSSH/.build/
 Sources/HerdrM/Info.plist
 *.xcuserstate
 .swiftpm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ the Sparkle update description — a release without a section here fails CI.
 
 ### Changed
 - Documented `make mobile-build` and `make ssh-test` (HerdrSSH Swift Testing on
-  Simulator). Dropped stale HerdrSSH README pointers to a Heeler-only CI script
-  that is not in this repo.
+  Simulator). Removed the HerdrSSH README “Direct-streamlocal / Jump Host
+  acceptance” block that documented Heeler’s `scripts/run-ci-ios-tests.sh`
+  workflow: that script and those suites were never checked into herdrm, so the
+  old text told people to run something that does not exist here.
 
 ## [0.6.3] - 2026-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ on [Keep a Changelog](https://keepachangelog.com); versions follow semver.
 Release automation extracts the matching section for GitHub release notes and
 the Sparkle update description — a release without a section here fails CI.
 
+## [Unreleased]
+
+### Fixed
+- HerdrSSH handshake compiles under Swift 6 region isolation: `performHandshake`
+  no longer captures a local `OpaquePointer` across `repeatUntilComplete`
+  awaits, so `HerdrMobile` / `make mobile-build` succeed again.
+
+### Changed
+- Documented `make mobile-build` and `make ssh-test` (HerdrSSH Swift Testing on
+  Simulator). Dropped stale HerdrSSH README pointers to a Heeler-only CI script
+  that is not in this repo.
+
 ## [0.6.3] - 2026-09-10
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,8 @@ make build      # xcodegen + xcodebuild → build/Build/Products/Debug/HerdrM.ap
 make run
 make kit-test   # HerdrKit integration tests (need a running local herdr)
 HERDRM_E2E_SSH_TARGET=vincent@10.10.10.87 make kit-test   # + remote SSH E2E
+make mobile-build  # HerdrMobile + HerdrSSH compile (arm64 Simulator)
+make ssh-test      # HerdrSSH Swift Testing on iOS Simulator
 ```
 
 xcodebuild needs `-skipPackagePluginValidation`; the Makefile passes it. Building

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,21 @@
-.PHONY: gen build run test kit-test clean
+.PHONY: gen build run test kit-test ssh-test mobile-build clean
+
+# HerdrMobile / HerdrSSH are arm64-only (libssh2 + OpenSSL xcframeworks).
+# Keep code signing on so Simulator Keychain (device SSH key) works; unsigned
+# builds log errSecMissingEntitlement (-34018) on every launch.
+MOBILE_BUILD = xcodebuild -project HerdrM.xcodeproj -scheme HerdrMobile \
+	-configuration Debug \
+	-destination 'platform=iOS Simulator,name=iPhone 17,arch=arm64' \
+	-derivedDataPath build-ios build \
+	-skipPackagePluginValidation \
+	ARCHS=arm64 ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS=x86_64
+
+SSH_TEST = cd Packages/HerdrSSH && xcodebuild test \
+	-scheme HerdrSSH \
+	-destination 'platform=iOS Simulator,name=iPhone 17,arch=arm64' \
+	-derivedDataPath ../../build/HerdrSSHDerivedData \
+	-collect-test-diagnostics never \
+	-parallel-testing-enabled NO
 
 CODE_SIGN_IDENTITY ?= -
 
@@ -14,7 +31,16 @@ run: build
 kit-test:
 	cd Packages/HerdrKit && swift test
 
+# HerdrSSH Swift Testing on iOS Simulator (Session-driver e2e skips without a live sshd fixture).
+ssh-test:
+	$(SSH_TEST)
+
+# Compile gate for HerdrMobile + HerdrSSH.
+mobile-build: gen
+	$(MOBILE_BUILD)
+
 test: kit-test
 
 clean:
-	rm -rf build HerdrM.xcodeproj Packages/HerdrKit/.build
+	rm -rf build build-ios build/HerdrSSHDerivedData HerdrM.xcodeproj \
+		Packages/HerdrKit/.build Packages/HerdrSSH/.build

--- a/Packages/HerdrSSH/README.md
+++ b/Packages/HerdrSSH/README.md
@@ -41,55 +41,25 @@ and signature switches disabled; the small reviewed patch in `Patches/`
 removes SHA-1 key exchange and MAC methods that libssh2 1.11.1 otherwise has no
 build switch for.
 
-## Direct-streamlocal acceptance
+## Tests
 
-`scripts/run-ci-ios-tests.sh` provisions disposable OpenSSH endpoints and a
-temporary Unix-socket fake herdr server, then runs the mandatory
-`HerdrSSHDirectStreamLocalE2ETests` suite.
+Swift Testing under `Tests/HerdrSSHTests`. From the repo root:
 
-Every sshd instance runs unprivileged, as the invoking account, so the whole
-gate runs on a developer machine with no `sudo` and leaves nothing behind. Each
-session is forced through POSIX `sh` with an isolated `HOME` and a fixed `PATH`
-that contains a `herdr` stub and no `socat`, so the fixture means the same thing
-on every machine and can never reach a real herdr server. The single exception
-is real password authentication: macOS cannot verify an account password
-without root, and an unprivileged sshd can only authenticate the account it
-already runs as. Those two tests need a disposable account and one root-owned
-sshd, so they skip without passwordless `sudo` and are mandatory in merge CI
-(`HEELER_CI_MANDATORY=1`).
+```sh
+make ssh-test
+```
 
-The suite includes a repeatable 25-exchange loopback measurement. Its printed
-output is telemetry for local channel open, exchange, and close cost — not a
-merge gate, not a machine-speed promise, and not a WAN latency promise.
-Absolute loopback timing varies with the CI scheduler; accidental remote-process
-fallback is a hard functional failure under the socat-free Host PATH the
-fixture already enforces (see `scripts/run-ci-ios-tests.sh`).
+That runs `xcodebuild test -scheme HerdrSSH` against an iOS Simulator. Unit
+tests always run. Session-driver e2e tests enable only when a disposable sshd
+fixture exports `HEELER_SSH_E2E_*` into the Simulator (`simctl … launchctl
+setenv`); without that fixture they skip. herdrm does not currently ship the
+OpenSSH fixture runner — keep unit coverage green via `make ssh-test` /
+`make mobile-build`.
 
-### Recorded exec-plus-socat baseline
-
-The transport spike measured both transports on loopback over the same
-authenticated session (spec #110, ADR 0011). Kept as historical context for
-telemetry comparison only:
-
-| Transport | Mean per exchange |
-| --- | --- |
-| `exec` + `socat` | 22.368 ms |
-| `direct-streamlocal` | 0.514 ms |
-
-The socat backend was deleted with the Citadel cutover, so that number cannot be
-re-measured. Architecture regression (reintroducing per-request remote process
-startup) is caught by the socat-free fixture and the suite's functional
-direct-streamlocal coverage, not by an absolute timing ceiling.
-
-## Jump Host acceptance
+## Jump Host
 
 `SSHConnection.connectThrough(to:timeout:)` opens a `direct-tcpip` channel on
 an authenticated Jump Host and runs a second, independent SSH session over its
 byte stream. The target performs its own Host Key verification and
 authentication. Closing the target connection tears down the target session,
 forwarding channel, and Jump Host session in that order.
-
-The same CI fixture also runs `HerdrSSHJumpHostGateE2ETests` against two
-disposable sshd instances with independent Host Keys. The suite is a hard gate
-for protocol-17 direct-streamlocal traffic, failure taxonomy, cancellation,
-deadlines, cleanup, and sequential and concurrent stress.

--- a/Packages/HerdrSSH/Sources/HerdrSSH/SessionDriver.swift
+++ b/Packages/HerdrSSH/Sources/HerdrSSH/SessionDriver.swift
@@ -1518,12 +1518,14 @@ actor SessionDriver {
         try configureAlgorithms(createdSession)
 
         let handshakeResult = try await repeatUntilComplete(deadline: deadline) {
-            libssh2_session_handshake(createdSession, descriptor)
+            guard let session else { return LIBSSH2_ERROR_SOCKET_DISCONNECT }
+            return libssh2_session_handshake(session, descriptor)
         }
         guard handshakeResult == 0 else {
             throw mapSessionError(handshakeResult)
         }
-        return try extractHostKey(createdSession)
+        guard let session else { throw SSHError.connectionInvalidated }
+        return try extractHostKey(session)
     }
 
     func openDirectTCPIP(


### PR DESCRIPTION
## Summary
- Fix HerdrSSH `performHandshake` so it compiles under Swift 6 region isolation (no local `OpaquePointer` across `repeatUntilComplete` awaits).
- Add `make mobile-build` and `make ssh-test` so HerdrMobile / HerdrSSH can be verified from the repo root.
- Correct the HerdrSSH README: drop the copied Heeler CI acceptance section and document what this repo actually runs.

## Why the HerdrSSH README deleted the “Direct-streamlocal / Jump Host acceptance” block
That section described Heeler’s merge harness (`scripts/run-ci-ios-tests.sh`, disposable sshd matrix, Jump Host gate suites, socat timing table). **In herdrm that script and those suites were never checked in.** So the README was telling people to run a workflow that does not exist here. Following it fails or misleads (“where is `run-ci-ios-tests.sh`?”). Replaced with `make ssh-test` / `make mobile-build`, and a note that Session-driver e2e still skips until a fixture exists.

## Screenshot
HerdrMobile on iPhone Simulator after `make mobile-build` — empty state, no devices configured:

<img src="https://raw.githubusercontent.com/jt-wang/herdrm/pr-85-assets/herdrmobile-empty-390.png" alt="HerdrMobile empty state" width="390" />

## Test plan
- [x] `make mobile-build` — BUILD SUCCEEDED
- [x] Install + launch on iOS Simulator — app stays up, empty “No Devices” UI
- [x] No app Keychain / device-key errors on signed Simulator build
- [x] `make ssh-test` — TEST SUCCEEDED (Session-driver e2e skips without sshd fixture)
- [x] `make kit-test` — 0 failures